### PR TITLE
Minor fixes to Dell vLLM/LMCache/hipFile KV-cache benchmark kit

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -2,6 +2,7 @@ AIS
 AMD
 Ansible
 BlueField
+BPF
 CMX
 DPUs
 Dockerfile
@@ -36,6 +37,7 @@ cli
 configs
 contenteditable
 cpu
+csv
 debian
 dkms
 disaggregated

--- a/vendors/dell/vllm-lmcache-hipfile/Dockerfile
+++ b/vendors/dell/vllm-lmcache-hipfile/Dockerfile
@@ -9,13 +9,22 @@ WORKDIR /app
 
 # Setup prerequisites
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        cmake libmount-dev libboost-all-dev vim && \
-    rm -rf /var/lib/apt/lists/*
+	apt-get install -y --no-install-recommends \
+	cmake bpftrace libmount-dev libboost-all-dev vim && \
+	rm -rf /var/lib/apt/lists/*
+
+# Pinned SHAs for deterministic builds
+ARG HIPFILE_BASE_SHA=5a7d275
+ARG HIPFILE_PATCH_SHA=0d07c19
+ARG LMCACHE_SHA=542bb9b
+ARG VLLM_SHA=a913b612d
 
 # Build & install hipFile libs, headers, and python bindings
-RUN git clone https://github.com/glimchb/hipFile.git && \
-    	cd hipFile && git checkout origin/python && \
+RUN git clone https://github.com/ROCm/hipFile.git && \
+	cd hipFile && \
+	git config user.email "noone@example.com" && git config user.name "No User" && \
+	git remote add dell https://github.com/glimchb/hipFile.git && git fetch dell && git fetch origin && \
+	git checkout "${HIPFILE_BASE_SHA}" && git cherry-pick "${HIPFILE_PATCH_SHA}" && \
 	mkdir build && cd build && \
 	cmake .. && cmake --build . -j && cpack -G DEB && \
 	dpkg -i hipfile*deb && \
@@ -25,7 +34,7 @@ RUN git clone https://github.com/glimchb/hipFile.git && \
 
 # Build & install LMCache
 RUN git clone https://github.com/glimchb/LMCache.git && \
-    	cd LMCache && git checkout origin/hipFile && \
+	cd LMCache && git checkout "${LMCACHE_SHA}" && \
 	pip install --no-cache-dir \
 	    -r requirements/build.txt && \
 	PYTORCH_ROCM_ARCH=$(rocm_agent_enumerator | head -n 1) \
@@ -57,7 +66,8 @@ RUN git clone https://github.com/glimchb/LMCache.git && \
 
 # Build vLLM
 RUN git clone https://github.com/vllm-project/vllm.git && \
-    	cd vllm && \
+	cd vllm && \
+	git checkout "${VLLM_SHA}" && \
 	pip install --no-cache-dir /opt/rocm/share/amd_smi && \
 	pip install --no-cache-dir --upgrade numba \
 	    scipy \

--- a/vendors/dell/vllm-lmcache-hipfile/README.md
+++ b/vendors/dell/vllm-lmcache-hipfile/README.md
@@ -56,12 +56,25 @@ docker run -it --rm \
     --ulimit memlock=-1 \
     --ulimit stack=67108864 \
     --cap-add IPC_LOCK \
-    --cap-add CAP_SYS_PTRACE \
+    --cap-add SYS_PTRACE \
+    --cap-add SYS_ADMIN \
+    --cap-add BPF \
+    --cap-add PERFMON \
     -v "$HOME:$HOME" \
     -v /data:/data \
     --env-file ~/docker.env \
+    -v /lib/modules:/lib/modules:ro \
+    -v /usr/src:/usr/src:ro \
+    -v /etc/localtime:/etc/localtime:ro \
+    -v /sys/kernel/debug/:/sys/kernel/debug/ \
+    -v /sys/kernel/btf:/sys/kernel/btf:ro \
     "$(whoami)-hipfile"
 ```
+
+If your Docker/kernel setup does not support the fine-grained
+`BPF`/`PERFMON` capabilities and you still encounter permission
+errors when collecting BPF traces, you can temporarily add
+`--privileged` to the `docker run` command as a last resort.
 
 ### 4. Serve the model
 
@@ -90,6 +103,13 @@ In a second shell inside the same container:
 ./scripts/bench_multi_turn_long.sh
 ```
 
+### 6. Collect hipFile traces with BPF
+
+```bash
+# Trace hipFile IO with BPF
+./scripts/trace_hipfile.sh [<custom libhipfile.so location>] > data.csv
+```
+
 ## Directory layout
 
 ```
@@ -101,6 +121,8 @@ scripts/
   serve_ais_cache.sh           LMCache -> hipFile/AIS
   bench_multi_turn_short.sh    short benchmark
   bench_multi_turn_long.sh     long benchmark
+  trace_hipfile.sh             BPF tracing script
+  hipfile.bt                   BPF tracing recipe
   configs/
     lmcache-cpu.yaml           CPU cache config
     lmcache-ais.yaml           AIS cache config

--- a/vendors/dell/vllm-lmcache-hipfile/scripts/bench_multi_turn_long.sh
+++ b/vendors/dell/vllm-lmcache-hipfile/scripts/bench_multi_turn_long.sh
@@ -2,8 +2,10 @@
 
 # Uses vLLM's default short multi-turn example config
 
+SCRIPT_DIR=$(realpath "$(dirname "$0")")
+
 python vllm/benchmarks/multi_turn/benchmark_serving_multi_turn.py \
     --model openai/gpt-oss-120b \
-    --input-file configs/generate_multi_turn_long.json \
+    --input-file "${SCRIPT_DIR}/configs/generate_multi_turn_long.json" \
     --num-clients 6 \
     --max-active-conversations 18

--- a/vendors/dell/vllm-lmcache-hipfile/scripts/bench_multi_turn_short.sh
+++ b/vendors/dell/vllm-lmcache-hipfile/scripts/bench_multi_turn_short.sh
@@ -2,8 +2,10 @@
 
 # Uses vLLM's default short multi-turn example config
 
+SCRIPT_DIR=$(realpath "$(dirname "$0")")
+
 python vllm/benchmarks/multi_turn/benchmark_serving_multi_turn.py \
     --model openai/gpt-oss-120b \
-    --input-file configs/generate_multi_turn_short.json \
+    --input-file "${SCRIPT_DIR}/configs/generate_multi_turn_short.json" \
     --num-clients 2 \
     --max-active-conversations 6

--- a/vendors/dell/vllm-lmcache-hipfile/scripts/configs/generate_multi_turn_long.json
+++ b/vendors/dell/vllm-lmcache-hipfile/scripts/configs/generate_multi_turn_long.json
@@ -1,7 +1,7 @@
 {
     "filetype": "generate_conversations",
     "num_conversations": 240,
-    "text_files": ["configs/books.txt"],
+    "text_files": ["scripts/configs/books.txt"],
     "print_stats": false,
     "prompt_input": {
         "num_turns": {

--- a/vendors/dell/vllm-lmcache-hipfile/scripts/configs/generate_multi_turn_short.json
+++ b/vendors/dell/vllm-lmcache-hipfile/scripts/configs/generate_multi_turn_short.json
@@ -1,7 +1,7 @@
 {
     "filetype": "generate_conversations",
     "num_conversations": 24,
-    "text_files": ["configs/books.txt"],
+    "text_files": ["scripts/configs/books.txt"],
     "print_stats": false,
     "prompt_input": {
         "num_turns": {

--- a/vendors/dell/vllm-lmcache-hipfile/scripts/hipfile.bt
+++ b/vendors/dell/vllm-lmcache-hipfile/scripts/hipfile.bt
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+BEGIN {
+    printf("start_ns,type,size_bytes,file_offset,dev_offset,duration_us,return_code\n");
+}
+
+uprobe:$1:hipFileRead,
+uprobe:$1:hipFileWrite
+{
+    /* elapsed is ns since bpftrace started; nsecs is ns since boot */
+    @start_ts[tid] = elapsed;
+    @info[tid]     = (arg2, arg3, arg4);
+}
+
+uretprobe:$1:hipFileRead
+/@start_ts[tid]/ 
+{
+    $now = elapsed;
+    $duration_us = ($now - @start_ts[tid]) / 1000;
+    $sz = @info[tid].0; 
+    $fo = @info[tid].1; 
+    $do = @info[tid].2;
+
+    printf("%llu,READ,%lu,%lld,%lld,%lu,%ld\n", 
+           @start_ts[tid], $sz, $fo, $do, $duration_us, retval);
+    
+    delete(@start_ts[tid]);
+    delete(@info[tid]);
+}
+
+uretprobe:$1:hipFileWrite
+/@start_ts[tid]/
+{
+    $now = elapsed;
+    $duration_us = ($now - @start_ts[tid]) / 1000;
+    $sz = @info[tid].0; 
+    $fo = @info[tid].1; 
+    $do = @info[tid].2;
+
+    printf("%llu,WRITE,%lu,%lld,%lld,%lu,%ld\n", 
+           @start_ts[tid], $sz, $fo, $do, $duration_us, retval);
+    
+    delete(@start_ts[tid]);
+    delete(@info[tid]);
+}
+
+END {
+    clear(@start_ts);
+    clear(@info);
+}

--- a/vendors/dell/vllm-lmcache-hipfile/scripts/serve_ais_cache.sh
+++ b/vendors/dell/vllm-lmcache-hipfile/scripts/serve_ais_cache.sh
@@ -6,9 +6,11 @@
 #  GPU KV cache size: 157,200 tokens
 #
 
-export LMCACHE_LOG_LEVEL=ERROR
+SCRIPT_DIR=$(realpath "$(dirname "$0")")
+
+export LMCACHE_LOG_LEVEL=WARNING
 export PYTHONHASHSEED=42
-export LMCACHE_CONFIG_FILE=configs/lmcache-ais.yaml
+export LMCACHE_CONFIG_FILE="${SCRIPT_DIR}/configs/lmcache-ais.yaml"
 
 vllm serve openai/gpt-oss-120b --gpu-memory-utilization 0.32 \
      --kv-transfer-config '{"kv_connector":"LMCacheConnectorV1", "kv_role":"kv_both"}'

--- a/vendors/dell/vllm-lmcache-hipfile/scripts/serve_cpu_cache.sh
+++ b/vendors/dell/vllm-lmcache-hipfile/scripts/serve_cpu_cache.sh
@@ -6,9 +6,11 @@
 #  GPU KV cache size: 157,200 tokens
 #
 
-export LMCACHE_LOG_LEVEL=ERROR
+SCRIPT_DIR=$(realpath "$(dirname "$0")")
+
+export LMCACHE_LOG_LEVEL=WARNING
 export PYTHONHASHSEED=42
-export LMCACHE_CONFIG_FILE=configs/lmcache-cpu.yaml
+export LMCACHE_CONFIG_FILE="${SCRIPT_DIR}/configs/lmcache-cpu.yaml"
 
 vllm serve openai/gpt-oss-120b --gpu-memory-utilization 0.32 \
      --kv-transfer-config '{"kv_connector":"LMCacheConnectorV1", "kv_role":"kv_both"}'

--- a/vendors/dell/vllm-lmcache-hipfile/scripts/trace_hipfile.sh
+++ b/vendors/dell/vllm-lmcache-hipfile/scripts/trace_hipfile.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+#
+# Launch trace recipe with default libhipfile.so location
+#
+
+stdbuf -oL bpftrace -q scripts/hipfile.bt "${1:-/opt/rocm/lib/libhipfile.so.0}"


### PR DESCRIPTION
Fetch hipFile from ROCm and Dell upstreams and rebase specific branches to combine python bindings with NULL deref fix. Also update several paths in the KV-cache benchmark scripts.

## Motivation

Resolves docker build and scripting issues.

## Technical Details

Updated hipFile build that combines two specific branches from ROCm and Dell repos.

Fixed paths in scripts to serve & benchmark inference.

## Test Plan

Build & exercise as usual.

## Test Result

Build success. Inference & benchmark success.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
