### PR TITLE
Weka Ansible: explicit core allocation, container naming, and tarball…

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -30,6 +30,7 @@ UID
 VPN
 VRAM
 WEKA
+Weka
 amdgpu
 ais
 buildx
@@ -42,6 +43,8 @@ debian
 dkms
 disaggregated
 env
+filesystem
+frontend
 gfx
 gid
 gitignored
@@ -66,4 +69,5 @@ shm
 uid
 vLLM
 venv
+weka
 whoami

--- a/vendors/weka/README.md
+++ b/vendors/weka/README.md
@@ -1,5 +1,30 @@
 # AMD WEKA-FS Proof of Concept
 
+## Stephen - Notes from Weka Call (March 18 2026)
+
+Stephen to add more compute containers to the cluster. Use the same steps as
+per the drive based container 
+
+```
+$ creation --cores 2 --flag 
+$ weka local setup container --name default6 --net $NIC --cores 2 \
+  --cores-ids 12,13 --drives-dedicated-cores 1 \
+  --compute-dedicated-cores 1 --no-frontends --base-port 17000 \
+  --memory 16GB --failure-domain fd7
+```
+Only the first container needs a frontend to access the filesystem. Add to the
+existing containers. Add a frontend to the first container. Be sure to update
+the --core-ids.
+
+weka cluster process
+CPU is the core id.
+
+weka status
+weka cloud enable (this will send heuristics to Weka)
+
+
+
+
 ## Introduction
 
 ## Useful Commands

--- a/vendors/weka/ansible/inventory/group_vars/weka_servers.yml
+++ b/vendors/weka/ansible/inventory/group_vars/weka_servers.yml
@@ -4,5 +4,11 @@
 # inventory file under host_vars.
 weka_cluster_nic: "udp"
 weka_cluster_num_containers: 6
+weka_cluster_container_prefix: "stebates-weka-poc"
+weka_cluster_primary_drive_cores: 1
+weka_cluster_primary_frontend_cores: 1
+weka_cluster_primary_compute_cores: 0
+weka_cluster_secondary_drive_cores: 1
+weka_cluster_secondary_compute_cores: 1
 weka_cluster_primary_mem: "4GB"
-weka_cluster_secondary_mem: "1536MB"
+weka_cluster_secondary_mem: "2GB"

--- a/vendors/weka/ansible/inventory/hosts.amd-weka.yml
+++ b/vendors/weka/ansible/inventory/hosts.amd-weka.yml
@@ -10,8 +10,11 @@ all:
     weka_servers:
       hosts:
         weka-server-vm-1:
-          ansible_host: useocpm2m-097-114
-          ansible_port: 2030
+          ansible_host: snoc-think
+          ansible_port: 2230
+        weka-server-vm-2:
+          ansible_host: snoc-think
+          ansible_port: 2231
     weka_clients:
       hosts:
         weka-client-1:
@@ -23,9 +26,13 @@ all:
     ansible_ssh_common_args: >-
       -o RequestTTY=no
       -o RemoteCommand=none
-    weka_cluster_fs_group: amd-weka-test-cluster
+      -o StrictHostKeyChecking=no
+      -o UserKnownHostsFile=/dev/null
     weka_cluster_tar_path: >-
-      /home/stebates/Projects/amd-weka-fs/weka-drops/weka-5.1.0.547.tar
-    weka_cluster_use_loop_devices: true
-    weka_cluster_force_install: true
+      /tmp/weka-5.1.0.547.tar
+    weka_cluster_use_loop_devices: false
+    weka_cluster_force_install: false
     weka_cluster_wipe_drives: true
+    weka_cluster_container_prefix: stebates-weka-poc
+    weka_cluster_fs_group: "stebates-weka-poc-fs"
+    weka_cluster_fs_name: "stebates-weka-poc-fs"

--- a/vendors/weka/ansible/roles/weka_cluster/defaults/main.yml
+++ b/vendors/weka/ansible/roles/weka_cluster/defaults/main.yml
@@ -14,6 +14,25 @@ weka_cluster_version: "5.1.0.547"
 # re-install or upgrade.
 weka_cluster_force_install: false
 
+# ── Tarball download ─────────────────────────
+# URL to fetch the Weka install tar when it is
+# not already present at weka_cluster_tar_path.
+# The version is templated so bumping
+# weka_cluster_version updates the URL too.
+# Credentials are kept in a separate variable
+# so they can be vault-encrypted independently.
+weka_cluster_tar_url: >-
+  https://get.weka.io/dist/v1/pkg/weka-{{
+  weka_cluster_version }}.tar
+
+# Auth token for the Weka download endpoint.
+# Override via vault-encrypted var for safety.
+weka_cluster_download_token: "o4mwdKIJCVOwthRc"
+
+# When true, automatically download the tarball
+# from weka_cluster_tar_url if it is missing.
+weka_cluster_auto_download: true
+
 # ── Networking ────────────────────────────────────
 # "udp"            – kernel UDP networking (default)
 # "<iface>"        – DPDK via resolved PCI address
@@ -25,9 +44,25 @@ weka_cluster_nic: "udp"
 # container.  Each core needs its own queue.
 weka_cluster_nic_queues: 1
 
+# ── Core allocation ──────────────────────────────
+# Cores dedicated to each role, per container.
+# Total cores per container = drive + frontend +
+# compute.  The primary container is the first one
+# on each host; secondaries are the rest.
+weka_cluster_primary_drive_cores: 1
+weka_cluster_primary_frontend_cores: 1
+weka_cluster_primary_compute_cores: 0
+weka_cluster_secondary_drive_cores: 1
+weka_cluster_secondary_frontend_cores: 0
+weka_cluster_secondary_compute_cores: 1
+
 # ── Container layout ─────────────────────────────
 # Containers per server host (primary + secondaries).
 weka_cluster_num_containers: 6
+
+# Prefix for local and cluster container names.
+# Containers are named <prefix>-1, <prefix>-2, etc.
+weka_cluster_container_prefix: "weka"
 
 # Memory allocated to the primary (has frontends)
 # and each secondary container.

--- a/vendors/weka/ansible/roles/weka_cluster/tasks/cluster.yml
+++ b/vendors/weka/ansible/roles/weka_cluster/tasks/cluster.yml
@@ -6,8 +6,9 @@
 - name: Identify all server hosts
   ansible.builtin.set_fact:
     weka_cluster_server_hosts: >-
-      {{ (groups['weka_servers'] | default([]))
-         + (groups['weka_both'] | default([])) }}
+      {{ ((groups['weka_servers'] | default([]))
+         + (groups['weka_both'] | default([])))
+         | intersect(ansible_play_hosts) }}
   run_once: true
 
 - name: Set delegate host
@@ -56,7 +57,8 @@
             weka_cluster_total_containers
             | int) -%}
         {%- set _ = names.append(
-              'weka' ~ (i + 1)) -%}
+              weka_cluster_container_prefix
+              ~ '-' ~ (i + 1)) -%}
       {%- endfor -%}
       {{ names | join(' ') }}
   run_once: true

--- a/vendors/weka/ansible/roles/weka_cluster/tasks/containers.yml
+++ b/vendors/weka/ansible/roles/weka_cluster/tasks/containers.yml
@@ -69,61 +69,45 @@
     weka_cluster_net_arg: >-
       {{ weka_cluster_net_arg_raw.stdout | trim }}
 
-# ── Compute core/role splits ─────────────────────
+# ── Core totals ──────────────────────────────────
 
-- name: Compute role allocation per container
+- name: Compute total cores per container type
   ansible.builtin.set_fact:
-    weka_cluster_p_drive: 1
-    weka_cluster_p_remaining: >-
-      {{ (weka_cluster_nic_queues | int) - 1 }}
-
-- name: Compute primary frontend and compute cores
-  ansible.builtin.set_fact:
-    weka_cluster_p_frontend: >-
-      {%- if (weka_cluster_p_remaining | int)
-            >= 2 -%}
-        {{ (weka_cluster_p_remaining | int)
-           // 2 }}
-      {%- elif (weka_cluster_p_remaining | int)
-            == 1 -%}
-        1
-      {%- else -%}
-        0
-      {%- endif -%}
-    weka_cluster_p_compute: >-
-      {%- if (weka_cluster_p_remaining | int)
-            >= 2 -%}
-        {{ (weka_cluster_p_remaining | int)
-           - ((weka_cluster_p_remaining | int)
-              // 2) }}
-      {%- else -%}
-        0
-      {%- endif -%}
-
-- name: Compute secondary role allocation
-  ansible.builtin.set_fact:
-    weka_cluster_s_drive: 1
-    weka_cluster_s_compute: >-
-      {{ (weka_cluster_nic_queues | int) - 1 }}
+    weka_cluster_primary_total_cores: >-
+      {{ (weka_cluster_primary_drive_cores | int)
+         + (weka_cluster_primary_frontend_cores
+            | int)
+         + (weka_cluster_primary_compute_cores
+            | int) }}
+    weka_cluster_secondary_total_cores: >-
+      {{ (weka_cluster_secondary_drive_cores
+          | int)
+         + (weka_cluster_secondary_frontend_cores
+            | int)
+         + (weka_cluster_secondary_compute_cores
+            | int) }}
 
 - name: Log container layout
   ansible.builtin.debug:
     msg: |
       Host       : {{ inventory_hostname }}
       Net        : {{ weka_cluster_net_arg }}
-      Queues     : {{ weka_cluster_nic_queues }}
-      Primary    : {{ weka_cluster_nic_queues }}
-                   cores
-                   ({{ weka_cluster_p_drive }} drv,
-                    {{ weka_cluster_p_compute
-                       | trim }} cmp,
-                    {{ weka_cluster_p_frontend
-                       | trim }} fe)
-      Secondary  : {{ weka_cluster_nic_queues }}
-                   cores
-                   ({{ weka_cluster_s_drive }} drv,
-                    {{ weka_cluster_s_compute
-                       | trim }} cmp)
+      Primary    : {{
+        weka_cluster_primary_total_cores
+        | trim }} cores
+        ({{ weka_cluster_primary_drive_cores
+         }} drv,
+         {{ weka_cluster_primary_compute_cores
+         }} cmp,
+         {{ weka_cluster_primary_frontend_cores
+         }} fe)
+      Secondary  : {{
+        weka_cluster_secondary_total_cores
+        | trim }} cores
+        ({{ weka_cluster_secondary_drive_cores
+         }} drv,
+         {{ weka_cluster_secondary_compute_cores
+         }} cmp)
 
 # ── Create primary container ─────────────────────
 
@@ -131,33 +115,36 @@
   ansible.builtin.set_fact:
     weka_cluster_primary_core_ids: >-
       {{ range(1,
-         (weka_cluster_nic_queues | int) + 1)
+         (weka_cluster_primary_total_cores
+          | int) + 1)
          | join(',') }}
 
 - name: Determine primary frontend flags
   ansible.builtin.set_fact:
     weka_cluster_fe_flags: >-
-      {%- if (weka_cluster_p_frontend | int)
-            > 0 -%}
-        --frontend-dedicated-cores
-        {{ weka_cluster_p_frontend | trim }}
-      {%- else -%}
-        --no-frontends
-      {%- endif -%}
+      {%- if (weka_cluster_primary_frontend_cores
+      | int) > 0 -%}
+      --frontend-dedicated-cores
+      {{ weka_cluster_primary_frontend_cores
+      }}{%- else -%}
+      --no-frontends{%- endif -%}
 
 - name: Create primary container
   ansible.builtin.shell: |
     set -eo pipefail
     weka local setup container \
-      --name default \
+      --name "{{ weka_cluster_container_prefix }}-1" \
       --net "{{ weka_cluster_net_arg }}" \
-      --cores {{ weka_cluster_nic_queues }} \
+      --cores {{
+        weka_cluster_primary_total_cores
+        | trim }} \
       --cores-ids \
         "{{ weka_cluster_primary_core_ids }}" \
       --drives-dedicated-cores \
-        {{ weka_cluster_p_drive }} \
+        {{ weka_cluster_primary_drive_cores }} \
       --compute-dedicated-cores \
-        {{ weka_cluster_p_compute | trim }} \
+        {{ weka_cluster_primary_compute_cores
+        }} \
       {{ weka_cluster_fe_flags | trim }} \
       --memory "{{ weka_cluster_primary_mem }}" \
       --failure-domain \
@@ -171,22 +158,29 @@
 
 - name: Create secondary containers
   ansible.builtin.shell: |
-    {% set q = weka_cluster_nic_queues | int %}
-    {% set start = 1 + (item | int) * q %}
-    {% set ids = range(start, start + q)
+    {% set tc = weka_cluster_secondary_total_cores
+                | int %}
+    {% set pc = weka_cluster_primary_total_cores
+                | int %}
+    {% set start = 1 + pc
+                   + ((item | int) - 1) * tc %}
+    {% set ids = range(start, start + tc)
                  | join(',') %}
     {% set port = 14000 + (item | int) * 1000 %}
     {% set fd = (weka_cluster_fd_base | int)
                 + (item | int) + 1 %}
-    {% set cmp = weka_cluster_s_compute | int %}
+    {% set cmp =
+       weka_cluster_secondary_compute_cores
+       | int %}
     set -eo pipefail
     weka local setup container \
-      --name "default{{ item }}" \
+      --name "{{ weka_cluster_container_prefix }}-{{ item + 1 }}" \
       --net "{{ weka_cluster_net_arg }}" \
-      --cores {{ q }} \
+      --cores {{ tc }} \
       --cores-ids "{{ ids }}" \
       --drives-dedicated-cores \
-        {{ weka_cluster_s_drive }} \
+        {{ weka_cluster_secondary_drive_cores
+        }} \
       {% if cmp > 0 %}
       --compute-dedicated-cores {{ cmp }} \
       {% endif %}

--- a/vendors/weka/ansible/roles/weka_cluster/tasks/filesystem.yml
+++ b/vendors/weka/ansible/roles/weka_cluster/tasks/filesystem.yml
@@ -6,8 +6,9 @@
   ansible.builtin.set_fact:
     weka_cluster_delegate: >-
       {{ ((groups['weka_servers'] | default([]))
-          + (groups['weka_both']
-             | default([])))[0] }}
+          + (groups['weka_both'] | default([])))
+         | intersect(ansible_play_hosts)
+         | first }}
   run_once: true
 
 # ── Start IO ─────────────────────────────────────

--- a/vendors/weka/ansible/roles/weka_cluster/tasks/main.yml
+++ b/vendors/weka/ansible/roles/weka_cluster/tasks/main.yml
@@ -14,6 +14,13 @@
   ansible.builtin.import_tasks: install.yml
   tags: [install]
 
+- name: Validate core allocation
+  ansible.builtin.import_tasks: validate_cores.yml
+  tags: [validate, containers]
+  when: >-
+    'weka_servers' in group_names
+    or 'weka_both' in group_names
+
 - name: Set up Weka containers
   ansible.builtin.import_tasks: containers.yml
   tags: [containers]

--- a/vendors/weka/ansible/roles/weka_cluster/tasks/preflight.yml
+++ b/vendors/weka/ansible/roles/weka_cluster/tasks/preflight.yml
@@ -20,13 +20,38 @@
     path: "{{ weka_cluster_tar_path }}"
   register: weka_cluster_tar_stat
 
+- name: Ensure tar directory exists
+  ansible.builtin.file:
+    path: >-
+      {{ weka_cluster_tar_path | dirname }}
+    state: directory
+    mode: "0755"
+  when:
+    - not weka_cluster_tar_stat.stat.exists
+    - weka_cluster_auto_download | bool
+
+- name: Download Weka tarball
+  ansible.builtin.get_url:
+    url: "{{ weka_cluster_tar_url }}"
+    dest: "{{ weka_cluster_tar_path }}"
+    mode: "0644"
+    url_username: "{{ weka_cluster_download_token }}"
+    url_password: ""
+    force_basic_auth: true
+  when:
+    - not weka_cluster_tar_stat.stat.exists
+    - weka_cluster_auto_download | bool
+
 - name: Fail if install tar is missing
   ansible.builtin.fail:
     msg: >-
       {{ weka_cluster_tar_path }} is not accessible
       on {{ inventory_hostname }}.  Ensure the NFS
-      share is mounted.
-  when: not weka_cluster_tar_stat.stat.exists
+      share is mounted or set
+      weka_cluster_auto_download: true.
+  when:
+    - not weka_cluster_tar_stat.stat.exists
+    - not (weka_cluster_auto_download | bool)
 
 - name: Check jq is installed
   ansible.builtin.command: jq --version

--- a/vendors/weka/ansible/roles/weka_cluster/tasks/validate_cores.yml
+++ b/vendors/weka/ansible/roles/weka_cluster/tasks/validate_cores.yml
@@ -1,0 +1,102 @@
+---
+# Validate core-allocation variables before
+# creating containers.  Catches misconfigurations
+# early with clear error messages.
+
+- name: Compute total cores per container type
+  ansible.builtin.set_fact:
+    weka_cluster_primary_total_cores: >-
+      {{ (weka_cluster_primary_drive_cores | int)
+         + (weka_cluster_primary_frontend_cores
+            | int)
+         + (weka_cluster_primary_compute_cores
+            | int) }}
+    weka_cluster_secondary_total_cores: >-
+      {{ (weka_cluster_secondary_drive_cores
+          | int)
+         + (weka_cluster_secondary_frontend_cores
+            | int)
+         + (weka_cluster_secondary_compute_cores
+            | int) }}
+
+- name: Assert drive cores >= 1
+  ansible.builtin.assert:
+    that:
+      - >-
+        (weka_cluster_primary_drive_cores | int)
+        >= 1
+      - >-
+        (weka_cluster_secondary_drive_cores | int)
+        >= 1
+    fail_msg: >-
+      Every container must have at least 1 drive
+      core.  Got primary_drive_cores={{
+      weka_cluster_primary_drive_cores }},
+      secondary_drive_cores={{
+      weka_cluster_secondary_drive_cores }}.
+
+- name: Assert primary has at least 1 frontend core
+  ansible.builtin.assert:
+    that:
+      - >-
+        (weka_cluster_primary_frontend_cores
+         | int) >= 1
+    fail_msg: >-
+      The primary container must have at least 1
+      frontend core to access the filesystem.
+      Got primary_frontend_cores={{
+      weka_cluster_primary_frontend_cores }}.
+
+- name: Assert secondaries have no frontend cores
+  ansible.builtin.assert:
+    that:
+      - >-
+        (weka_cluster_secondary_frontend_cores
+         | int) == 0
+    fail_msg: >-
+      Only the primary container should have
+      frontend cores.  Got
+      secondary_frontend_cores={{
+      weka_cluster_secondary_frontend_cores }}.
+      Set to 0 for secondary containers.
+
+- name: Assert total cores per container >= 2
+  ansible.builtin.assert:
+    that:
+      - >-
+        (weka_cluster_primary_total_cores | int)
+        >= 2
+      - >-
+        (weka_cluster_secondary_total_cores | int)
+        >= 2
+    fail_msg: >-
+      Each container needs at least 2 cores (1
+      drive + 1 other role).  Got
+      primary_total={{
+      weka_cluster_primary_total_cores }},
+      secondary_total={{
+      weka_cluster_secondary_total_cores }}.
+
+- name: Compute total cores needed on host
+  ansible.builtin.set_fact:
+    weka_cluster_total_host_cores: >-
+      {{ (weka_cluster_primary_total_cores | int)
+         + ((weka_cluster_num_containers | int)
+            - 1)
+           * (weka_cluster_secondary_total_cores
+              | int) }}
+
+- name: Assert total cores fit within vCPU budget
+  ansible.builtin.assert:
+    that:
+      - >-
+        (weka_cluster_total_host_cores | int)
+        < (ansible_processor_vcpus | int)
+    fail_msg: >-
+      Weka containers need {{
+      weka_cluster_total_host_cores }} cores but
+      {{ inventory_hostname }} has only {{
+      ansible_processor_vcpus }} vCPUs (at least
+      1 must remain for the OS).  Reduce
+      cores-per-container or
+      weka_cluster_num_containers.


### PR DESCRIPTION
Replace the opaque core-derivation logic (driven by a single weka_cluster_nic_queues value) with six explicit per-role variables that set drive, frontend, and compute cores independently for primary and secondary containers.

Add validate_cores.yml preflight assertions that catch misconfiguration early: drive cores >= 1, primary frontend
>= 1, secondary frontend == 0, total cores >= 2 per
container, and total cores fit within the host vCPU budget.

Introduce weka_cluster_container_prefix so container names are configurable (local and cluster-level). The AMD-Oracle inventory overrides it to "stebates-weka-poc", producing stebates-weka-poc-1 through stebates-weka-poc-N.

Add automatic tarball download support via
weka_cluster_tar_url and weka_cluster_auto_download so the installer tar is fetched when not already present.

Update the AMD-Oracle inventory to point both server VMs at snoc-think (ports 2230/2231), use the new explicit core counts, and set deployment-specific filesystem names.

