### PR TITLE
Add filename to BPF output

### DIFF
--- a/vendors/dell/vllm-lmcache-hipfile/scripts/hipfile.bt
+++ b/vendors/dell/vllm-lmcache-hipfile/scripts/hipfile.bt
@@ -1,32 +1,171 @@
 // SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
+// hipFileDescr_t layout constant
+// Validated against: hipFile 0.2.0, x86_64 Linux
+//
+//   struct hipFileDescr_t {
+//       hipFileHandleType type;   // offset 0, 4 bytes (enum)
+//       union {                   // offset 8 (aligned to 8 for the int/void* union)
+//           int            fd;    // hipFileHandleTypeOpaqueFd
+//           void          *win32; // hipFileHandleTypeOpaqueFd (Windows, not used here)
+//       } handle;
+//   };
+//
+// If the hipFileDescr_t layout changes across hipFile versions or architectures,
+// update this offset accordingly.
+#define HIPFILE_DESCR_FD_OFFSET 8
+#define HIPFILE_HANDLE_TYPE_OPAQUE_FD 1
+
 BEGIN {
-    printf("start_ns,type,size_bytes,file_offset,dev_offset,duration_us,return_code\n");
+    printf("start_ns, type, filename, size_bytes, file_offset, dev_offset, duration_us, return_code\n");
 }
 
-uprobe:$1:hipFileRead,
-uprobe:$1:hipFileWrite
+// Track POSIX open() to map fd -> filename
+// filename is only available on sys_enter; the fd (return value) is only on sys_exit.
+// We stash the filename per-thread on enter, then pair it with the fd on exit.
+tracepoint:syscalls:sys_enter_openat
 {
-    /* elapsed is ns since bpftrace started; nsecs is ns since boot */
+    @pending_filename[tid] = str(args->filename);
+}
+
+tracepoint:syscalls:sys_exit_openat
+/args->ret >= 0/
+{
+    @fd_to_filename[pid, args->ret] = @pending_filename[tid];
+    delete(@pending_filename[tid]);
+}
+
+tracepoint:syscalls:sys_exit_openat
+/args->ret < 0/
+{
+    delete(@pending_filename[tid]);
+}
+
+// Track hipFileHandleRegister to map hipFileHandle_t -> fd -> filename
+// hipFileError_t hipFileHandleRegister(hipFileHandle_t *fh, hipFileDescr_t *descr);
+// descr->handle.fd is at HIPFILE_DESCR_FD_OFFSET (see layout constant at top of file)
+uprobe:$1:hipFileHandleRegister
+{
+    // arg0 = hipFileHandle_t *fh (output)
+    // arg1 = hipFileDescr_t *descr (input)
+    $descr_type = *(int32*)(arg1 + 0);  // hipFileHandleType_t at offset 0
+
+    // hipFileHandleTypeOpaqueFD == 1; only this type carries a file descriptor.
+    // Skip other handle types to avoid reading garbage into the fd slot.
+    if ($descr_type == HIPFILE_HANDLE_TYPE_OPAQUE_FD) {
+        $fd = *(int32*)(arg1 + HIPFILE_DESCR_FD_OFFSET);
+        @pending_reg_fd[tid] = $fd;
+        @pending_reg_fh_ptr[tid] = arg0;
+    }
+}
+
+uretprobe:$1:hipFileHandleRegister
+// hipFileError_t is a struct { hipFileOpError err; hipResult_t hip_err; } (8 bytes).
+// On x86_64 Linux ABI, structs <= 16 bytes are returned in rax:rdx.
+// bpftrace's retval captures rax, which packs both 4-byte fields.
+// Mask to the low 32 bits to isolate the .err field (hipFileOpError).
+/@pending_reg_fh_ptr[tid] && (retval & 0xFFFFFFFF) == 0/
+{
+    $fd = @pending_reg_fd[tid];
+    $fh_ptr = @pending_reg_fh_ptr[tid];
+
+    // Read the hipFileHandle_t value that was written to *fh
+    $fh = *(uint64*)$fh_ptr;
+
+    // Map hipFileHandle_t -> filename via fd
+    $filename = @fd_to_filename[pid, $fd];
+    if ($filename != "") {
+        @handle_to_filename[pid, $fh] = $filename;
+    }
+
+    delete(@pending_reg_fd[tid]);
+    delete(@pending_reg_fh_ptr[tid]);
+}
+
+uretprobe:$1:hipFileHandleRegister
+/@pending_reg_fh_ptr[tid] && (retval & 0xFFFFFFFF) != 0/
+{
+    delete(@pending_reg_fd[tid]);
+    delete(@pending_reg_fh_ptr[tid]);
+}
+
+// Track hipFileHandleDeregister to clean up the mapping
+uprobe:$1:hipFileHandleDeregister
+{
+    delete(@handle_to_filename[pid, arg0]);
+}
+
+// Track POSIX close() to clean up fd -> filename mapping
+// Only delete on successful close to avoid dropping the mapping if close() fails.
+tracepoint:syscalls:sys_enter_close
+{
+    @pending_close_fd[tid] = args->fd;
+}
+
+tracepoint:syscalls:sys_exit_close
+/args->ret == 0/
+{
+    delete(@fd_to_filename[pid, @pending_close_fd[tid]]);
+    delete(@pending_close_fd[tid]);
+}
+
+tracepoint:syscalls:sys_exit_close
+/args->ret != 0/
+{
+    delete(@pending_close_fd[tid]);
+}
+
+// Clean up per-process and per-thread state when a thread/process exits
+tracepoint:sched:sched_process_exit
+{
+    // Note: @fd_to_filename[pid, fd] and @handle_to_filename[pid, fh] entries
+    // for this pid may leak here — bpftrace does not support partial-key
+    // deletion on multi-key maps.  Individual entries are cleaned up by the
+    // close() and hipFileHandleDeregister handlers during normal operation;
+    // the END block's clear() catches anything left over at script exit.
+
+    // Remove any per-thread pending state for this tid
+    delete(@pending_filename[tid]);
+    delete(@pending_close_fd[tid]);
+    delete(@start_ts[tid]);
+    delete(@info[tid]);
+}
+
+// Track hipFileRead - ssize_t hipFileRead(hipFileHandle_t fh, void *buffer_base, size_t size, hoff_t file_offset, hoff_t buffer_offset)
+uprobe:$1:hipFileRead
+{
     @start_ts[tid] = elapsed;
-    @info[tid]     = (arg2, arg3, arg4);
+    @info[tid] = (arg0, arg2, arg3, arg4);  // fh, size, file_offset, buffer_offset
 }
 
 uretprobe:$1:hipFileRead
-/@start_ts[tid]/ 
+/@start_ts[tid]/
 {
     $now = elapsed;
     $duration_us = ($now - @start_ts[tid]) / 1000;
-    $sz = @info[tid].0; 
-    $fo = @info[tid].1; 
-    $do = @info[tid].2;
+    $fh = @info[tid].0;
+    $sz = @info[tid].1;
+    $fo = @info[tid].2;
+    $bo = @info[tid].3;
 
-    printf("%llu,READ,%lu,%lld,%lld,%lu,%ld\n", 
-           @start_ts[tid], $sz, $fo, $do, $duration_us, retval);
-    
+    $filename = @handle_to_filename[pid, $fh];
+    if ($filename == "") {
+        $filename = "unknown";
+    }
+
+    printf("%llu,READ,\"%s\",%lu,%lld,%lld,%lu,%ld\n",
+           @start_ts[tid], $filename, $sz, $fo, $bo, $duration_us, retval);
+
     delete(@start_ts[tid]);
     delete(@info[tid]);
+}
+
+// Track hipFileWrite - ssize_t hipFileWrite(hipFileHandle_t fh, const void *buffer_base, size_t size, hoff_t file_offset, hoff_t buffer_offset)
+uprobe:$1:hipFileWrite
+{
+    @start_ts[tid] = elapsed;
+    @info[tid] = (arg0, arg2, arg3, arg4);  // fh, size, file_offset, buffer_offset
 }
 
 uretprobe:$1:hipFileWrite
@@ -34,13 +173,19 @@ uretprobe:$1:hipFileWrite
 {
     $now = elapsed;
     $duration_us = ($now - @start_ts[tid]) / 1000;
-    $sz = @info[tid].0; 
-    $fo = @info[tid].1; 
-    $do = @info[tid].2;
+    $fh = @info[tid].0;
+    $sz = @info[tid].1;
+    $fo = @info[tid].2;
+    $bo = @info[tid].3;
 
-    printf("%llu,WRITE,%lu,%lld,%lld,%lu,%ld\n", 
-           @start_ts[tid], $sz, $fo, $do, $duration_us, retval);
-    
+    $filename = @handle_to_filename[pid, $fh];
+    if ($filename == "") {
+        $filename = "unknown";
+    }
+
+    printf("%llu,WRITE,\"%s\",%lu,%lld,%lld,%lu,%ld\n",
+           @start_ts[tid], $filename, $sz, $fo, $bo, $duration_us, retval);
+
     delete(@start_ts[tid]);
     delete(@info[tid]);
 }
@@ -48,4 +193,10 @@ uretprobe:$1:hipFileWrite
 END {
     clear(@start_ts);
     clear(@info);
+    clear(@handle_to_filename);
+    clear(@fd_to_filename);
+    clear(@pending_reg_fd);
+    clear(@pending_reg_fh_ptr);
+    clear(@pending_close_fd);
+    clear(@pending_filename);
 }


### PR DESCRIPTION
Track filenames through the openat/close syscalls and hipFileHandleRegister/ hipFileHandleDeregister API to map hipFileHandle_t to the original filename, then log it in hipFileRead/hipFileWrite output.

## Motivation

Filename data would allow identification of re-read of evicted blocks.

## Technical Details

Track filenames through the openat/close syscalls and hipFileHandleRegister/ hipFileHandleDeregister API to map hipFileHandle_t to the original filename, then log it in hipFileRead/hipFileWrite output.

## Test Plan

Manual testing on a MI325X system.

## Test Result

BPF program output including the first 64 characters of the filenames being read/written:

```
start_ns,type,filename,size_bytes,file_offset,dev_offset,duration_us,return_code
25986080563,WRITE,/data/lmcache/16/08/openai_gpt-oss-120b@1@0@1653cd1ac6d66c6c@bf..,18874368,4096,0,6357,18874368
25993894742,WRITE,/data/lmcache/27/42/openai_gpt-oss-120b@1@0@2610bc9acf92bb30@bf..,18874368,4096,113246208,12540,18874368
25991744924,WRITE,/data/lmcache/-5/28/openai_gpt-oss-120b@1@0@-4948929e83df3c33@b..,18874368,4096,37748736,14693,18874368
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
