### PR TITLE
ansible: add host discovery playbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ ttft-llamacpp-*.log
 # Debian package files
 *.deb
 
+# Ansible discovery reports
+ansible/reports/
+
 #Codespell disctionary cache
 dictionary.dic
 

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -130,5 +130,15 @@ subcommand
 ttft
 warmup
 Dockerized
+dpkg
+fqdn
+ibstat
+InfiniBand
+iproute
 lmcache
+NICs
+lsblk
+lspci
+playbook
 README
+vCPUs

--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ The llama.cpp benchmark includes a `--cache-disk` patch
 for automatic disk-tier prompt caching (see
 [patches/0001-cache-disk.patch][patch]).
 
+## Host Discovery
+
+The [`ansible/`][ansible-dir] directory contains an Ansible
+playbook that inventories GPU cluster nodes and produces a
+per-host JSON report covering GPUs, NVMe drives, RDMA
+NICs, Linux kernel version, ROCm version, and DKMS module
+status. A second play compares all hosts and flags any
+differences. See the [discover playbook][discover-yml]
+for details.
+
 ## References
 
 [b-lmc]: benchmarks/ttft-lmcache/
@@ -29,6 +39,8 @@ for automatic disk-tier prompt caching (see
 [r-lmc]: benchmarks/ttft-lmcache/README.md
 [r-lcp]: benchmarks/ttft-llamacpp/README.md
 [patch]: benchmarks/ttft-llamacpp/patches/0001-cache-disk.patch
+[ansible-dir]: ansible/
+[discover-yml]: ansible/discover.yml
 
 - [NVIDIA ICMS technical blog][icms]
 - [WEKA blog on BlueField-4 and ICMS][weka]

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,0 +1,12 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+[defaults]
+inventory = inventory/hosts.yml
+host_key_checking = False
+gathering = smart
+interpreter_python = auto_silent
+
+[ssh_connection]
+pipelining = True

--- a/ansible/discover.yml
+++ b/ansible/discover.yml
@@ -1,0 +1,28 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+---
+- name: Discover host hardware and software configuration
+  hosts: discovery
+  gather_facts: true
+  become: true
+  pre_tasks:
+    - name: Record play start timestamp
+      ansible.builtin.set_fact:
+        play_timestamp: >-
+          {{ ansible_date_time.iso8601_basic_short }}
+      run_once: true
+  roles:
+    - host_discovery
+
+- name: Compare hosts and report differences
+  hosts: discovery
+  gather_facts: false
+  become: false
+  tasks:
+    - name: Load cross-host comparison role
+      ansible.builtin.include_role:
+        name: host_discovery
+        tasks_from: diff.yml
+      run_once: true

--- a/ansible/inventory/hosts.yml
+++ b/ansible/inventory/hosts.yml
@@ -1,0 +1,18 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+---
+all:
+  children:
+    discovery:
+      vars:
+        ansible_user: "{{ lookup('env', 'ANSIBLE_REMOTE_USER')
+          | default('stebates', true) }}"
+      hosts:
+        g04u07:
+          ansible_host: 10.245.130.131
+        g04u13:
+          ansible_host: 10.245.130.133
+        g04u19:
+          ansible_host: 10.245.130.135

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,0 +1,12 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+---
+collections:
+  - name: sbates130272.batesste
+    version: ">=1.2.0"
+  - name: ansible.posix
+    version: ">=1.6.2"
+  - name: community.general
+    version: ">=10.0.1"

--- a/ansible/roles/host_discovery/tasks/diff.yml
+++ b/ansible/roles/host_discovery/tasks/diff.yml
@@ -1,0 +1,100 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+---
+- name: Build per-host comparable summary
+  ansible.builtin.set_fact:
+    _comparable: >-
+      {{ dict(ansible_play_hosts | map('extract', hostvars)
+         | map(attribute='inventory_hostname')
+         | zip(ansible_play_hosts | map('extract', hostvars)
+               | map(attribute='host_report'))) }}
+
+- name: Identify fields that differ across hosts
+  ansible.builtin.set_fact:
+    host_diffs: >-
+      {% set ns = namespace(result={}) -%}
+      {% set fields = ['kernel', 'distro', 'architecture',
+                       'cpu_model', 'cpu_count', 'memory_gb',
+                       'rocm_version'] -%}
+      {% for field in fields -%}
+        {% set vals = _comparable.values()
+                      | map(attribute=field)
+                      | list -%}
+        {% if vals | unique | list | length > 1 -%}
+          {% set per_host = {} -%}
+          {% for h in _comparable -%}
+            {% set _ = per_host.update(
+                 {h: _comparable[h][field]}) -%}
+          {% endfor -%}
+          {% set _ = ns.result.update(
+               {field: per_host}) -%}
+        {% endif -%}
+      {% endfor -%}
+      {% set gpu_counts = {} -%}
+      {% for h in _comparable -%}
+        {% set _ = gpu_counts.update(
+             {h: _comparable[h].gpus.pci_devices
+                 | length}) -%}
+      {% endfor -%}
+      {% if gpu_counts.values() | unique | list
+            | length > 1 -%}
+        {% set _ = ns.result.update(
+             {'gpu_count': gpu_counts}) -%}
+      {% endif -%}
+      {% set nvme_counts = {} -%}
+      {% for h in _comparable -%}
+        {% set _ = nvme_counts.update(
+             {h: _comparable[h].nvme.drives
+                 | length}) -%}
+      {% endfor -%}
+      {% if nvme_counts.values() | unique | list
+            | length > 1 -%}
+        {% set _ = ns.result.update(
+             {'nvme_count': nvme_counts}) -%}
+      {% endif -%}
+      {% set dkms_sets = {} -%}
+      {% for h in _comparable -%}
+        {% set _ = dkms_sets.update(
+             {h: _comparable[h].dkms | sort
+                 | join(' | ')}) -%}
+      {% endfor -%}
+      {% if dkms_sets.values() | unique | list
+            | length > 1 -%}
+        {% set _ = ns.result.update(
+             {'dkms': dkms_sets}) -%}
+      {% endif -%}
+      {{ ns.result }}
+
+- name: Print cross-host diff to stdout
+  ansible.builtin.debug:
+    msg: |
+
+      ========== CROSS-HOST DIFFERENCES ==========
+      {% if host_diffs | length == 0 %}
+      All hosts are identical across checked fields.
+      {% else %}
+      {% for field, per_host in host_diffs.items() %}
+      {{ field }}:
+      {% for h, val in per_host.items() %}
+        {{ h }}: {{ val }}
+      {% endfor %}
+      {% endfor %}
+      {% endif %}
+      ===============================================
+
+- name: Print all-identical confirmation
+  ansible.builtin.debug:
+    msg: "All hosts match on kernel, distro, arch, CPU, \
+      memory, ROCm, GPU count, NVMe count, and DKMS."
+  when: host_diffs | length == 0
+
+- name: Write cross-host diff JSON report
+  ansible.builtin.copy:
+    content: "{{ host_diffs | to_nice_json }}\n"
+    dest: >-
+      {{ hostvars[ansible_play_hosts[0]].report_dir
+      }}/diff.json
+    mode: "0644"
+  delegate_to: localhost

--- a/ansible/roles/host_discovery/tasks/dkms.yml
+++ b/ansible/roles/host_discovery/tasks/dkms.yml
@@ -1,0 +1,24 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+---
+- name: Check for dkms command
+  ansible.builtin.command:
+    cmd: which dkms
+  register: dkms_cmd_check
+  changed_when: false
+  failed_when: false
+
+- name: Query DKMS module status
+  ansible.builtin.command:
+    cmd: dkms status
+  register: dkms_status_raw
+  changed_when: false
+  failed_when: false
+  when: dkms_cmd_check.rc == 0
+
+- name: Build DKMS facts
+  ansible.builtin.set_fact:
+    dkms_modules: >-
+      {{ dkms_status_raw.stdout_lines | default([]) }}

--- a/ansible/roles/host_discovery/tasks/gpus.yml
+++ b/ansible/roles/host_discovery/tasks/gpus.yml
@@ -1,0 +1,32 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+---
+- name: List GPU PCI devices
+  ansible.builtin.shell:
+    cmd: "lspci -nn 2>/dev/null | grep -iE 'VGA|Display|3D controller'"
+  register: gpu_pci_raw
+  changed_when: false
+  failed_when: false
+
+- name: Check for rocm-smi
+  ansible.builtin.stat:
+    path: /opt/rocm/bin/rocm-smi
+  register: rocm_smi_bin
+
+- name: Query rocm-smi for GPU details
+  ansible.builtin.command:
+    cmd: /opt/rocm/bin/rocm-smi --showproductname --showmeminfo vram --json
+  register: rocm_smi_raw
+  changed_when: false
+  failed_when: false
+  when: rocm_smi_bin.stat.exists
+
+- name: Build GPU facts
+  ansible.builtin.set_fact:
+    gpu_pci_devices: >-
+      {{ gpu_pci_raw.stdout_lines | default([]) }}
+    gpu_smi_detail: >-
+      {{ (rocm_smi_raw.stdout | default('{}')) if rocm_smi_bin.stat.exists
+         else '{}' }}

--- a/ansible/roles/host_discovery/tasks/main.yml
+++ b/ansible/roles/host_discovery/tasks/main.yml
@@ -1,0 +1,117 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+---
+- name: Detect GPUs
+  ansible.builtin.include_tasks: gpus.yml
+
+- name: Detect NVMe drives
+  ansible.builtin.include_tasks: nvme.yml
+
+- name: Detect RDMA NICs
+  ansible.builtin.include_tasks: rdma.yml
+
+- name: Detect ROCm version
+  ansible.builtin.include_tasks: rocm.yml
+
+- name: Detect DKMS module status
+  ansible.builtin.include_tasks: dkms.yml
+
+- name: Assemble host discovery report
+  ansible.builtin.set_fact:
+    host_report:
+      hostname: "{{ ansible_hostname }}"
+      fqdn: "{{ ansible_fqdn }}"
+      kernel: "{{ ansible_kernel }}"
+      distro: "{{ ansible_distribution }} {{ ansible_distribution_version }}"
+      architecture: "{{ ansible_architecture }}"
+      cpu_model: "{{ ansible_processor[2] | default('unknown') }}"
+      cpu_count: "{{ ansible_processor_vcpus }}"
+      memory_gb: "{{ (ansible_memtotal_mb / 1024) | round(1) }}"
+      rocm_version: "{{ rocm_version | trim }}"
+      gpus:
+        pci_devices: "{{ gpu_pci_devices }}"
+        rocm_smi: "{{ gpu_smi_detail }}"
+      nvme:
+        drives: "{{ nvme_drives }}"
+        nvme_cli: "{{ nvme_detail }}"
+      rdma:
+        links: "{{ rdma_links }}"
+        ib_devices: "{{ rdma_ib_devices }}"
+        ibstat: "{{ rdma_ibstat }}"
+      dkms: "{{ dkms_modules }}"
+
+- name: Print discovery summary to stdout
+  ansible.builtin.debug:
+    msg: |
+
+      ========== HOST DISCOVERY: {{ ansible_hostname }} ==========
+
+      Hostname .... {{ host_report.hostname }}
+      FQDN ........ {{ host_report.fqdn }}
+      Kernel ...... {{ host_report.kernel }}
+      Distro ...... {{ host_report.distro }}
+      Arch ........ {{ host_report.architecture }}
+      CPU ......... {{ host_report.cpu_model }}
+                     ({{ host_report.cpu_count }} vCPUs)
+      Memory ...... {{ host_report.memory_gb }} GiB
+      ROCm ........ {{ host_report.rocm_version }}
+
+      --- GPUs (PCI) ---
+      {% for line in host_report.gpus.pci_devices %}
+      {{ line }}
+      {% endfor %}
+
+      --- NVMe Drives ---
+      {% for d in host_report.nvme.drives %}
+      {{ d.name | default("?") }}  {{ d.size | default("?") }}
+        {{ d.model | default("?") }}
+      {% endfor %}
+      {% if host_report.nvme.drives | length == 0 %}
+      (none detected)
+      {% endif %}
+
+      --- RDMA ---
+      {% if host_report.rdma.links | length > 0 %}
+      {% for line in host_report.rdma.links %}
+      {{ line }}
+      {% endfor %}
+      {% elif host_report.rdma.ib_devices | length > 0 %}
+      IB devices: {{ host_report.rdma.ib_devices | join(', ') }}
+      {% else %}
+      (none detected)
+      {% endif %}
+
+      --- DKMS Modules ---
+      {% for line in host_report.dkms %}
+      {{ line }}
+      {% endfor %}
+      {% if host_report.dkms | length == 0 %}
+      (none detected)
+      {% endif %}
+
+      ===========================================================
+
+- name: Set report output directory
+  ansible.builtin.set_fact:
+    report_dir: >-
+      {{ playbook_dir }}/reports/{{ play_timestamp }}
+  run_once: true
+
+- name: Ensure timestamped reports directory exists
+  ansible.builtin.file:
+    path: "{{ report_dir }}"
+    state: directory
+    mode: "0755"
+  delegate_to: localhost
+  become: false
+  run_once: true
+
+- name: Write per-host JSON report
+  ansible.builtin.template:
+    src: report.json.j2
+    dest: "{{ report_dir }}/{{ inventory_hostname }}.json"
+    mode: "0644"
+  delegate_to: localhost
+  become: false

--- a/ansible/roles/host_discovery/tasks/nvme.yml
+++ b/ansible/roles/host_discovery/tasks/nvme.yml
@@ -1,0 +1,49 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+---
+- name: List block devices (JSON)
+  ansible.builtin.command:
+    cmd: lsblk -Jd -o NAME,SIZE,MODEL,TRAN
+  register: lsblk_raw
+  changed_when: false
+  failed_when: false
+
+- name: Filter NVMe drives from lsblk
+  ansible.builtin.set_fact:
+    nvme_lsblk: >-
+      {{ (lsblk_raw.stdout | from_json).blockdevices
+         | default([])
+         | selectattr('tran', 'defined')
+         | selectattr('tran', 'equalto', 'nvme')
+         | list }}
+  when: lsblk_raw.rc == 0
+
+- name: Set empty NVMe list on lsblk failure
+  ansible.builtin.set_fact:
+    nvme_lsblk: []
+  when: lsblk_raw.rc != 0
+
+- name: Check for nvme CLI
+  ansible.builtin.command:
+    cmd: which nvme
+  register: nvme_cli_check
+  changed_when: false
+  failed_when: false
+
+- name: Query nvme list (rich detail)
+  ansible.builtin.command:
+    cmd: nvme list -o json
+  register: nvme_list_raw
+  changed_when: false
+  failed_when: false
+  when: nvme_cli_check.rc == 0
+
+- name: Build NVMe facts
+  ansible.builtin.set_fact:
+    nvme_drives: >-
+      {{ nvme_lsblk }}
+    nvme_detail: >-
+      {{ (nvme_list_raw.stdout | default('{}'))
+         if (nvme_cli_check.rc == 0) else '{}' }}

--- a/ansible/roles/host_discovery/tasks/rdma.yml
+++ b/ansible/roles/host_discovery/tasks/rdma.yml
@@ -1,0 +1,51 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+---
+- name: Check for rdma command
+  ansible.builtin.command:
+    cmd: which rdma
+  register: rdma_cmd_check
+  changed_when: false
+  failed_when: false
+
+- name: List RDMA links
+  ansible.builtin.command:
+    cmd: rdma link show
+  register: rdma_link_raw
+  changed_when: false
+  failed_when: false
+  when: rdma_cmd_check.rc == 0
+
+- name: Fallback — list InfiniBand devices via sysfs
+  ansible.builtin.command:
+    cmd: ls /sys/class/infiniband/
+  register: ib_sysfs_raw
+  changed_when: false
+  failed_when: false
+  when: rdma_cmd_check.rc != 0
+
+- name: Check for ibstat command
+  ansible.builtin.command:
+    cmd: which ibstat
+  register: ibstat_cmd_check
+  changed_when: false
+  failed_when: false
+
+- name: Query ibstat for port details
+  ansible.builtin.command:
+    cmd: ibstat
+  register: ibstat_raw
+  changed_when: false
+  failed_when: false
+  when: ibstat_cmd_check.rc == 0
+
+- name: Build RDMA facts
+  ansible.builtin.set_fact:
+    rdma_links: >-
+      {{ rdma_link_raw.stdout_lines | default([]) }}
+    rdma_ib_devices: >-
+      {{ ib_sysfs_raw.stdout_lines | default([]) }}
+    rdma_ibstat: >-
+      {{ ibstat_raw.stdout_lines | default([]) }}

--- a/ansible/roles/host_discovery/tasks/rocm.yml
+++ b/ansible/roles/host_discovery/tasks/rocm.yml
@@ -1,0 +1,46 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+---
+- name: Check for ROCm version file
+  ansible.builtin.stat:
+    path: /opt/rocm/.info/version
+  register: rocm_version_file
+
+- name: Read ROCm version from file
+  ansible.builtin.slurp:
+    src: /opt/rocm/.info/version
+  register: rocm_version_slurp
+  when: rocm_version_file.stat.exists
+
+- name: Fallback — query rocm-core package (deb)
+  ansible.builtin.shell:
+    cmd: "dpkg-query -W -f='${Version}' rocm-core 2>/dev/null"
+  register: rocm_deb_raw
+  changed_when: false
+  failed_when: false
+  when: not rocm_version_file.stat.exists and ansible_os_family == "Debian"
+
+- name: Fallback — query rocm-core package (rpm)
+  ansible.builtin.command:
+    cmd: rpm -q --queryformat '%{VERSION}' rocm-core
+  register: rocm_rpm_raw
+  changed_when: false
+  failed_when: false
+  when: not rocm_version_file.stat.exists and ansible_os_family == "RedHat"
+
+- name: Build ROCm version fact
+  ansible.builtin.set_fact:
+    rocm_version: >-
+      {% if rocm_version_file.stat.exists -%}
+        {{ rocm_version_slurp.content | b64decode | trim }}
+      {%- elif ansible_os_family == "Debian"
+              and rocm_deb_raw.rc | default(1) == 0 -%}
+        {{ rocm_deb_raw.stdout | trim }}
+      {%- elif ansible_os_family == "RedHat"
+              and rocm_rpm_raw.rc | default(1) == 0 -%}
+        {{ rocm_rpm_raw.stdout | trim }}
+      {%- else -%}
+        not installed
+      {%- endif %}

--- a/ansible/roles/host_discovery/templates/report.json.j2
+++ b/ansible/roles/host_discovery/templates/report.json.j2
@@ -1,0 +1,1 @@
+{{ host_report | to_nice_json }}


### PR DESCRIPTION
Add an Ansible playbook that inventories GPU cluster nodes and reports on GPUs (lspci + rocm-smi), NVMe drives (lsblk + nvme CLI), RDMA NICs (rdma link + ibstat), Linux kernel version, ROCm version, and DKMS module status. A second play compares all hosts and flags any configuration differences.

Output is both stdout (formatted summary per host) and per-host JSON files written to a timestamped reports/ subdirectory. The sbates130272.batesste Galaxy collection and its dependencies are listed in requirements.yml.
