### PR TITLE
ansible: add ais-check, rocminfo, provisioning, and cluster summary

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -129,6 +129,7 @@ stdout
 subcommand
 ttft
 warmup
+batesste
 Dockerized
 dpkg
 fqdn
@@ -141,4 +142,7 @@ lsblk
 lspci
 playbook
 README
+rocminfo
+sbates
 vCPUs
+yml

--- a/README.md
+++ b/README.md
@@ -22,15 +22,22 @@ The llama.cpp benchmark includes a `--cache-disk` patch
 for automatic disk-tier prompt caching (see
 [patches/0001-cache-disk.patch][patch]).
 
-## Host Discovery
+## Host Discovery and Provisioning
 
-The [`ansible/`][ansible-dir] directory contains an Ansible
-playbook that inventories GPU cluster nodes and produces a
-per-host JSON report covering GPUs, NVMe drives, RDMA
-NICs, Linux kernel version, ROCm version, and DKMS module
-status. A second play compares all hosts and flags any
-differences. See the [discover playbook][discover-yml]
-for details.
+The [`ansible/`][ansible-dir] directory contains Ansible
+playbooks for managing GPU cluster nodes.
+
+- **[discover.yml][discover-yml]** -- inventories each
+  node and produces a per-host JSON report covering GPUs,
+  NVMe drives, RDMA NICs, AIS status, Linux kernel
+  version, ROCm version, and DKMS module status. A second
+  play compares all hosts and flags differences.
+- **[provision.yml][provision-yml]** -- installs a base
+  set of developer packages via the
+  [sbates130272.batesste][galaxy] Galaxy collection's
+  `fave_packages` role, then layers on project-specific
+  packages defined in
+  [`group_vars/gpu_nodes.yml`][group-vars].
 
 ## References
 
@@ -41,6 +48,9 @@ for details.
 [patch]: benchmarks/ttft-llamacpp/patches/0001-cache-disk.patch
 [ansible-dir]: ansible/
 [discover-yml]: ansible/discover.yml
+[provision-yml]: ansible/provision.yml
+[galaxy]: https://galaxy.ansible.com/ui/repo/published/sbates130272/batesste/
+[group-vars]: ansible/inventory/group_vars/gpu_nodes.yml
 
 - [NVIDIA ICMS technical blog][icms]
 - [WEKA blog on BlueField-4 and ICMS][weka]

--- a/ansible/discover.yml
+++ b/ansible/discover.yml
@@ -4,7 +4,7 @@
 
 ---
 - name: Discover host hardware and software configuration
-  hosts: discovery
+  hosts: gpu_nodes
   gather_facts: true
   become: true
   pre_tasks:
@@ -17,7 +17,7 @@
     - host_discovery
 
 - name: Compare hosts and report differences
-  hosts: discovery
+  hosts: gpu_nodes
   gather_facts: false
   become: false
   tasks:

--- a/ansible/inventory/group_vars/gpu_nodes.yml
+++ b/ansible/inventory/group_vars/gpu_nodes.yml
@@ -1,0 +1,39 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+---
+# Extra packages installed by provision.yml on top of the
+# sbates130272.batesste.fave_packages base set.  Edit this
+# list to add or remove project-specific packages.
+extra_packages:
+  # GPU monitoring and tools
+  - nvtop
+  - numactl
+  - pciutils
+  # NVMe and storage
+  - nvme-cli
+  - gdisk
+  # RDMA and networking
+  - ibverbs-utils
+  - rdma-core
+  - rdmacm-utils
+  - infiniband-diags
+  - perftest
+  - iperf3
+  - ethtool
+  - lldpd
+  - net-tools
+  # Debugging and profiling
+  - htop
+  - lshw
+  - strace
+  - gdb
+  - valgrind
+  - dwarves
+  - trace-cmd
+  - hwloc
+  # Infrastructure
+  - ipmitool
+  - socat
+  - jq

--- a/ansible/inventory/hosts.yml
+++ b/ansible/inventory/hosts.yml
@@ -5,7 +5,7 @@
 ---
 all:
   children:
-    discovery:
+    gpu_nodes:
       vars:
         ansible_user: "{{ lookup('env', 'ANSIBLE_REMOTE_USER')
           | default('stebates', true) }}"

--- a/ansible/provision.yml
+++ b/ansible/provision.yml
@@ -1,0 +1,21 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+---
+- name: Provision target nodes with packages
+  hosts: gpu_nodes
+  gather_facts: true
+  become: true
+  vars:
+    extra_packages: []
+  tasks:
+    - name: Install base developer packages
+      ansible.builtin.include_role:
+        name: sbates130272.batesste.fave_packages
+
+    - name: Install project-specific extra packages
+      ansible.builtin.package:
+        name: "{{ extra_packages }}"
+        state: present
+      when: extra_packages | length > 0

--- a/ansible/roles/host_discovery/tasks/ais.yml
+++ b/ansible/roles/host_discovery/tasks/ais.yml
@@ -1,0 +1,41 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+---
+- name: Check for ais-check tool
+  ansible.builtin.stat:
+    path: /opt/rocm/bin/ais-check
+  register: ais_check_bin
+
+- name: Run ais-check
+  ansible.builtin.command:
+    cmd: /opt/rocm/bin/ais-check
+  register: ais_check_raw
+  changed_when: false
+  failed_when: false
+  when: ais_check_bin.stat.exists
+
+- name: Parse ais-check results
+  ansible.builtin.set_fact:
+    ais_results: >-
+      {% if not ais_check_bin.stat.exists -%}
+        {{ {'available': false} }}
+      {%- elif ais_check_raw.rc != 0 -%}
+        {{ {'available': true,
+            'error': ais_check_raw.stderr | trim} }}
+      {%- else -%}
+        {% set ns = namespace(d={'available': true}) -%}
+        {% for line in ais_check_raw.stdout_lines -%}
+          {% if ':' in line
+                and 'AIS support' not in line -%}
+            {% set k = line.split(':')[0]
+                   | trim | lower
+                   | replace(' ', '_') -%}
+            {% set v = line.split(':')[1]
+                   | trim -%}
+            {% set _ = ns.d.update({k: v}) -%}
+          {% endif -%}
+        {% endfor -%}
+        {{ ns.d }}
+      {%- endif %}

--- a/ansible/roles/host_discovery/tasks/diff.yml
+++ b/ansible/roles/host_discovery/tasks/diff.yml
@@ -65,6 +65,46 @@
         {% set _ = ns.result.update(
              {'dkms': dkms_sets}) -%}
       {% endif -%}
+      {% set ais_vals = {} -%}
+      {% for h in _comparable -%}
+        {% set _ = ais_vals.update(
+             {h: _comparable[h].ais
+                 | to_json}) -%}
+      {% endfor -%}
+      {% if ais_vals.values() | unique | list
+            | length > 1 -%}
+        {% set _ = ns.result.update(
+             {'ais': ais_vals}) -%}
+      {% endif -%}
+      {% set ri_gpu_counts = {} -%}
+      {% for h in _comparable -%}
+        {% set ri = _comparable[h].rocminfo -%}
+        {% set _ = ri_gpu_counts.update(
+             {h: ri.gpu_count
+                 | default(0)}) -%}
+      {% endfor -%}
+      {% if ri_gpu_counts.values() | unique | list
+            | length > 1 -%}
+        {% set _ = ns.result.update(
+             {'rocminfo_gpu_count':
+              ri_gpu_counts}) -%}
+      {% endif -%}
+      {% set ri_gpu_names = {} -%}
+      {% for h in _comparable -%}
+        {% set ri = _comparable[h].rocminfo -%}
+        {% set names = ri.gpus | default([])
+               | map(attribute='marketing_name',
+                     default='unknown')
+               | sort | join(', ') -%}
+        {% set _ = ri_gpu_names.update(
+             {h: names}) -%}
+      {% endfor -%}
+      {% if ri_gpu_names.values() | unique | list
+            | length > 1 -%}
+        {% set _ = ns.result.update(
+             {'rocminfo_gpu_models':
+              ri_gpu_names}) -%}
+      {% endif -%}
       {{ ns.result }}
 
 - name: Print cross-host diff to stdout
@@ -87,7 +127,8 @@
 - name: Print all-identical confirmation
   ansible.builtin.debug:
     msg: "All hosts match on kernel, distro, arch, CPU, \
-      memory, ROCm, GPU count, NVMe count, and DKMS."
+      memory, ROCm, GPU count, NVMe count, DKMS, \
+      AIS, and rocminfo."
   when: host_diffs | length == 0
 
 - name: Write cross-host diff JSON report
@@ -96,5 +137,84 @@
     dest: >-
       {{ hostvars[ansible_play_hosts[0]].report_dir
       }}/diff.json
+    mode: "0644"
+  delegate_to: localhost
+
+- name: Build cluster summary
+  ansible.builtin.set_fact:
+    cluster_summary: >-
+      {% set ns = namespace(hosts={}) -%}
+      {% for h in _comparable -%}
+        {% set r = _comparable[h] -%}
+        {% set ri = r.rocminfo | default({}) -%}
+        {% set gpu_names = ri.gpus | default([])
+               | map(attribute='marketing_name',
+                     default='unknown')
+               | list -%}
+        {% set gpu_gfx = ri.gpus | default([])
+               | map(attribute='name',
+                     default='unknown')
+               | list -%}
+        {% set nvme_list = [] -%}
+        {% for d in r.nvme.drives -%}
+          {% set _ = nvme_list.append(
+               {'device': d.name | default('?'),
+                'size': d.size | default('?'),
+                'model': d.model
+                         | default('?')}) -%}
+        {% endfor -%}
+        {% set rdma_active = r.rdma.links
+               | default([])
+               | select('search', 'ACTIVE')
+               | list | length -%}
+        {% set rdma_total = r.rdma.links
+               | default([])
+               | length -%}
+        {% set entry = {
+             'kernel': r.kernel,
+             'rocm_version': r.rocm_version,
+             'dkms': r.dkms,
+             'gpus': {
+               'count': ri.gpu_count | default(0),
+               'gfx_targets': gpu_gfx,
+               'models': gpu_names},
+             'nvme': {
+               'count': r.nvme.drives | length,
+               'drives': nvme_list},
+             'rdma': {
+               'total_links': rdma_total,
+               'active_links': rdma_active}
+           } -%}
+        {% set _ = ns.hosts.update(
+             {h: entry}) -%}
+      {% endfor -%}
+      {{ ns.hosts }}
+
+- name: Print cluster summary to stdout
+  ansible.builtin.debug:
+    msg: |
+
+      ========== CLUSTER SUMMARY ==========
+      {% for h, s in cluster_summary.items() %}
+      {{ h }}:
+        Kernel .... {{ s.kernel }}
+        ROCm ...... {{ s.rocm_version }}
+        GPUs ...... {{ s.gpus.count }}x {{ s.gpus.models
+                     | unique | join(', ') }}
+                    ({{ s.gpus.gfx_targets
+                     | unique | join(', ') }})
+        NVMe ...... {{ s.nvme.count }} drives
+        RDMA ...... {{ s.rdma.active_links }}/{{
+                     s.rdma.total_links }} active
+        DKMS ...... {{ s.dkms | length }} modules
+      {% endfor %}
+      =======================================
+
+- name: Write cluster summary JSON
+  ansible.builtin.copy:
+    content: "{{ cluster_summary | to_nice_json }}\n"
+    dest: >-
+      {{ hostvars[ansible_play_hosts[0]].report_dir
+      }}/summary.json
     mode: "0644"
   delegate_to: localhost

--- a/ansible/roles/host_discovery/tasks/main.yml
+++ b/ansible/roles/host_discovery/tasks/main.yml
@@ -18,6 +18,12 @@
 - name: Detect DKMS module status
   ansible.builtin.include_tasks: dkms.yml
 
+- name: Detect AIS (GPU Direct Storage) support
+  ansible.builtin.include_tasks: ais.yml
+
+- name: Detect ROCm agents via rocminfo
+  ansible.builtin.include_tasks: rocminfo.yml
+
 - name: Assemble host discovery report
   ansible.builtin.set_fact:
     host_report:
@@ -41,6 +47,8 @@
         ib_devices: "{{ rdma_ib_devices }}"
         ibstat: "{{ rdma_ibstat }}"
       dkms: "{{ dkms_modules }}"
+      ais: "{{ ais_results }}"
+      rocminfo: "{{ rocminfo_summary }}"
 
 - name: Print discovery summary to stdout
   ansible.builtin.debug:
@@ -89,6 +97,34 @@
       {% endfor %}
       {% if host_report.dkms | length == 0 %}
       (none detected)
+      {% endif %}
+
+      --- AIS (GPU Direct Storage) ---
+      {% if not host_report.ais.available %}
+      ais-check not found (hipFile not installed)
+      {% elif host_report.ais.error is defined %}
+      ais-check error: {{ host_report.ais.error }}
+      {% else %}
+      {% for k, v in host_report.ais.items() %}
+      {% if k != 'available' %}
+      {{ k }}: {{ v }}
+      {% endif %}
+      {% endfor %}
+      {% endif %}
+
+      --- ROCm Agents (rocminfo) ---
+      {% if not host_report.rocminfo.available %}
+      rocminfo not found
+      {% elif host_report.rocminfo.error is defined %}
+      rocminfo error: {{ host_report.rocminfo.error }}
+      {% else %}
+      CPUs: {{ host_report.rocminfo.cpu_count }}
+      GPUs: {{ host_report.rocminfo.gpu_count }}
+      {% for gpu in host_report.rocminfo.gpus %}
+      {{ gpu.name | default("?") }}
+        {{ gpu.marketing_name | default("") }}
+        pool: {{ gpu.pool_size | default("?") }}
+      {% endfor %}
       {% endif %}
 
       ===========================================================

--- a/ansible/roles/host_discovery/tasks/rocminfo.yml
+++ b/ansible/roles/host_discovery/tasks/rocminfo.yml
@@ -1,0 +1,94 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+---
+- name: Check for rocminfo binary
+  ansible.builtin.stat:
+    path: /opt/rocm/bin/rocminfo
+  register: rocminfo_bin
+
+- name: Run rocminfo
+  ansible.builtin.command:
+    cmd: /opt/rocm/bin/rocminfo
+  register: rocminfo_raw
+  changed_when: false
+  failed_when: false
+  when: rocminfo_bin.stat.exists
+
+- name: Parse rocminfo agent summary
+  ansible.builtin.set_fact:
+    rocminfo_summary: >-
+      {% if not rocminfo_bin.stat.exists -%}
+        {{ {'available': false} }}
+      {%- elif rocminfo_raw.rc != 0 -%}
+        {{ {'available': true,
+            'error': rocminfo_raw.stderr | trim} }}
+      {%- else -%}
+        {% set ns = namespace(agents=[],
+                              current={}) -%}
+        {% for line in rocminfo_raw.stdout_lines -%}
+          {% set t = line | trim -%}
+          {% if t.startswith('Name:') and
+                ns.current -%}
+            {% set name = t.split(':', 1)[1]
+                   | trim -%}
+            {% set _ = ns.current.update(
+                 {'name': name}) -%}
+          {% endif -%}
+          {% if t.startswith('Marketing Name:') -%}
+            {% set mname = t.split(':', 1)[1]
+                   | trim -%}
+            {% set _ = ns.current.update(
+                 {'marketing_name': mname}) -%}
+          {% endif -%}
+          {% if t.startswith('Device Type:') -%}
+            {% set dtype = t.split(':', 1)[1]
+                   | trim -%}
+            {% set _ = ns.current.update(
+                 {'device_type': dtype}) -%}
+          {% endif -%}
+          {% if t.startswith('Max Wave Size:') -%}
+            {% set ws = t.split(':', 1)[1]
+                   | trim -%}
+            {% set _ = ns.current.update(
+                 {'max_wave_size': ws}) -%}
+          {% endif -%}
+          {% if 'Pool Size' in t
+                and 'Group Memory' not in t -%}
+            {% set ps = t.split(':', 1)[1]
+                   | trim -%}
+            {% set _ = ns.current.update(
+                 {'pool_size': ps}) -%}
+          {% endif -%}
+          {% if t ==
+                '*******' -%}
+            {% if ns.current
+                  and ns.current.name is defined -%}
+              {% set _ = ns.agents.append(
+                   ns.current.copy()) -%}
+            {% endif -%}
+            {% set ns.current = {} -%}
+          {% endif -%}
+        {% endfor -%}
+        {% if ns.current
+              and ns.current.name is defined -%}
+          {% set _ = ns.agents.append(
+               ns.current.copy()) -%}
+        {% endif -%}
+        {% set gpus = ns.agents
+               | selectattr('device_type', 'defined')
+               | selectattr('device_type',
+                            'equalto', 'GPU')
+               | list -%}
+        {% set cpus = ns.agents
+               | selectattr('device_type', 'defined')
+               | selectattr('device_type',
+                            'equalto', 'CPU')
+               | list -%}
+        {{ {'available': true,
+            'gpu_count': gpus | length,
+            'cpu_count': cpus | length,
+            'gpus': gpus,
+            'cpus': cpus} }}
+      {%- endif %}


### PR DESCRIPTION
Extend the host discovery playbook with new detection tasks:

- ais-check: verify GPU Direct Storage (hipFile/AIS) support by running /opt/rocm/bin/ais-check and parsing kernel P2PDMA, HIP runtime, and amdgpu driver status.
- rocminfo: enumerate ROCm agents to surface GPU count, gfx target, marketing name, and VRAM pool size per device.
- cluster summary: a new summary.json report aggregating GPUs, NVMe drives, RDMA link status, kernel version, ROCm version, and DKMS modules per host in a compact format.

All three are included in the cross-host diff comparison so any differences are flagged automatically.

Add provision.yml playbook that installs base developer packages via the sbates130272.batesste.fave_packages Galaxy role, then layers project-specific extras defined in group_vars/gpu_nodes.yml (nvtop, numactl, nvme-cli, rdma-core, infiniband-diags, perftest, gdb, valgrind, hwloc, ipmitool, etc.).

Rename the inventory group from 'discovery' to 'gpu_nodes' so the group_vars filename is unambiguous across playbooks.
