### PR TITLE
Move the LMCache directory out of the NVMe root to declutter.

### DIFF
--- a/deployments/llm-d/tiered-prefix-cache/manifests/vllm/flavors/lmcache-hipfile/kustomization.yaml
+++ b/deployments/llm-d/tiered-prefix-cache/manifests/vllm/flavors/lmcache-hipfile/kustomization.yaml
@@ -19,7 +19,7 @@ configMapGenerator:
         lmcache_config.yaml=chunk_size: 256
         save_decode_cache: True
         local_cpu: false
-        gds_path: "/hipfile"
+        gds_path: "/hipfile/lmcache"
         cufile_buffer_size: 8192
         extra_config:
           use_hipfile: true


### PR DESCRIPTION
## Motivation

Declutter the NVMe root by keeping LMCache files in a sub-directory.

## Technical Details

Path` change in LMCache config.

## Test Plan

Trivial.

## Test Result

Success.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
