### PR TITLE
Extend rocm-aic-exporter host metrics and MI300 monitoring stack

### DIFF
--- a/.github/workflows/vllm-radeon-python.yml
+++ b/.github/workflows/vllm-radeon-python.yml
@@ -107,9 +107,38 @@ jobs:
             --data-root tests/fixtures/lmcache-exporter \
             --prometheus-textfile "${prom}" \
             --textfile-only \
+            --skip-nfsiostat-invoke \
             --json >/dev/null
           grep -q 'rocm_aic_kv_disk_files' "${prom}"
           grep -q 'rocm_aic_kv_file_hits_histogram_bucket' "${prom}"
+          grep -q 'rocm_aic_nfsiostat_present' "${prom}"
+          grep -q 'rocm_aic_hipconfig_present' "${prom}"
+          python3 -c "
+          from importlib.machinery import SourceFileLoader
+          from pathlib import Path
+          m = SourceFileLoader('ex', 'scripts/rocm-aic-exporter.py').load_module()
+          mounts = m._parse_mountstats_nfs(
+              Path('tests/fixtures/mountstats-nfs.sample'))
+          assert len(mounts) == 1 and mounts[0].rx_bytes == 9100
+          snap = m.collect_exporter_snapshot(
+              data_root=Path('tests/fixtures/lmcache-exporter'),
+              include_host_metrics=False,
+              run_nfsiostat=False,
+              collect_hip=False,
+          )
+          body_kv = m.format_prometheus_textfile(
+              snap, include_host_metrics=False)
+          assert 'rocm_aic_nfsiostat_present' not in body_kv
+          snap_h = m.collect_exporter_snapshot(
+              data_root=Path('tests/fixtures/lmcache-exporter'),
+              include_host_metrics=True,
+              run_nfsiostat=False,
+              collect_hip=False,
+          )
+          body_all = m.format_prometheus_textfile(
+              snap_h, include_host_metrics=True)
+          assert 'rocm_aic_nfsiostat_present' in body_all
+          "
 
       - name: parse-vllm-engine-log-timeseries (CSV only)
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ tools/lmcache-io-tester/**/*.token
 recipies/vllm-radeon/logs/
 recipies/vllm-radeon/data/
 
+# slurm logs and reports
+.slurm/logs/
+.slurm/reports/
+

--- a/.slurm/run-slurm.sh
+++ b/.slurm/run-slurm.sh
@@ -18,11 +18,11 @@ cd "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 out="$(sbatch \
   --export=ALL,KURT_NVME_BLK_BPFTRACE=1,KURT_NVME_SMART_LOG=1,KURT_LMCACHE_ENABLE_KV_EVENTS=1 \
-  .slurm/vllm-from-kurt-mi300.sbatch)"
+  ./vllm-from-kurt-mi300.sbatch)"
 echo "${out}"
 jid="${out##* }"
-echo "Log: tail -f .slurm/logs/vllm-from-kurt-mi300-${jid}.log"
+echo "Log: tail -f ./logs/vllm-from-kurt-mi300-${jid}.log"
 echo "Done:  sacct -j ${jid} --format=JobID,State,ExitCode,Elapsed,End"
 
-# Example (local NVMe + traces): sbatch --export=ALL,KURT_NVME_BASE=/mnt/nvme,KURT_NVME_BLK_BPFTRACE=1 \
+# Example (from repo root): sbatch --export=ALL,KURT_NVME_BASE=/mnt/nvme,KURT_NVME_BLK_BPFTRACE=1 \
 #   .slurm/vllm-from-kurt-mi300.sbatch

--- a/.slurm/run-slurm.sh
+++ b/.slurm/run-slurm.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Submit vllm-from-kurt MI300 job with NVMe block bpftrace, LMCache VFS bpftrace
+# (when KURT_NVME_BLK_BPFTRACE=1), SMART snapshots, and LMCache KV events.
+# KURT_NVME_BASE — **set KURT_NVME_BASE to your local NVMe mount** (e.g.
+# /mnt/nvme) so HF + LMCache do not fill the root filesystem; see sbatch header.
+#
+# Exclusive-node mkfs + auto device (only when an unmounted nvme*n* exists):
+#   --export=ALL,KURT_NVME_MKFS=1,KURT_NVME_AUTO_DEVICE=1,KURT_NVME_MOUNT=/mnt/kurt-nvme,...
+# Or set KURT_NVME_DEVICE=/dev/nvme0n1 explicitly with KURT_NVME_MKFS=1.
+#
+set -euo pipefail
+cd "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+out="$(sbatch \
+  --export=ALL,KURT_NVME_BLK_BPFTRACE=1,KURT_NVME_SMART_LOG=1,KURT_LMCACHE_ENABLE_KV_EVENTS=1 \
+  .slurm/vllm-from-kurt-mi300.sbatch)"
+echo "${out}"
+jid="${out##* }"
+echo "Log: tail -f .slurm/logs/vllm-from-kurt-mi300-${jid}.log"
+echo "Done:  sacct -j ${jid} --format=JobID,State,ExitCode,Elapsed,End"
+
+# Example (local NVMe + traces): sbatch --export=ALL,KURT_NVME_BASE=/mnt/nvme,KURT_NVME_BLK_BPFTRACE=1 \
+#   .slurm/vllm-from-kurt-mi300.sbatch

--- a/ansible/inventory/group_vars/gpu_nodes.yml
+++ b/ansible/inventory/group_vars/gpu_nodes.yml
@@ -40,7 +40,9 @@ rocm_setup_run_checks: true
 rocm_setup_install_metrics_exporter: true
 
 # Prometheus node exporter (package + service; see host_setup).
+# rocm-aic-exporter timer writes rocm_aic_exporter.prom into the textfile dir.
 # RDMA and NVMe Prometheus exporters via batesste collection roles.
+host_setup_rocm_aic_exporter_radeon_host_data_root: /mnt/lmcache-nvme
 rdma_setup_install_rdma_exporter: true
 nvme_exporter_setup_install: true
 

--- a/ansible/inventory/group_vars/monitoring_server.yml
+++ b/ansible/inventory/group_vars/monitoring_server.yml
@@ -18,7 +18,7 @@ monitoring_grafana_require_admin_password: false
 # monitoring_grafana_dashboard_amd_gpu_id: "23434"
 
 # Accept Prometheus remote write at POST /api/v1/write (web.enable-remote-write-
-# receiver). Managed in /etc/default/prometheus via monitoring_stack.
+# receiver). Appended via prometheus.service.d drop-in (monitoring_stack).
 monitoring_prometheus_enable_remote_write_receiver: true
 
 # Optional: federate metrics from an llm-d / in-cluster Prometheus into this

--- a/ansible/inventory/group_vars/monitoring_server.yml
+++ b/ansible/inventory/group_vars/monitoring_server.yml
@@ -17,6 +17,10 @@ monitoring_grafana_require_admin_password: false
 # monitoring_grafana_dashboard_node_exporter_id: "1860"
 # monitoring_grafana_dashboard_amd_gpu_id: "23434"
 
+# Accept Prometheus remote write at POST /api/v1/write (web.enable-remote-write-
+# receiver). Managed in /etc/default/prometheus via monitoring_stack.
+monitoring_prometheus_enable_remote_write_receiver: true
+
 # Optional: federate metrics from an llm-d / in-cluster Prometheus into this
 # server's Prometheus TSDB.
 monitoring_llmd_prometheus_federate_enabled: false

--- a/ansible/playbooks/monitoring.yml
+++ b/ansible/playbooks/monitoring.yml
@@ -19,6 +19,9 @@
 #
 # Grafana: cluster summary dashboard UID rocm-aic-cluster (recording rules
 # rocm_icms:nvme:key / rocm_icms:rdma:key; textfile rocm_icms_software_version).
+#
+# Prometheus on monitoring_server: scrape-only config in prometheus.yml; remote
+# write receiver enabled via /etc/default/prometheus (POST /api/v1/write).
 
 - name: Install monitoring stack on monitoring server
   hosts: monitoring_server

--- a/ansible/roles/host_setup/defaults/main.yml
+++ b/ansible/roles/host_setup/defaults/main.yml
@@ -27,6 +27,10 @@ host_setup_udev_rules_file: 70-rocm-icms-net-rdma.rules
 
 # After extra_packages: enable systemd unit for prometheus-node-exporter.
 host_setup_enable_prometheus_node_exporter: true
+# Shared directory for all node_exporter textfile metrics on this host.
+host_setup_node_exporter_textfile_dir: /var/lib/node_exporter/textfile_collector
+# Extra ARGS appended in /etc/default/prometheus-node-exporter (optional).
+host_setup_node_exporter_extra_args: []
 
 # When false, skip AMD apt preclean, sbates130272.batesste.rocm_setup, and
 # post-rocm apt dedupe (faster provision when ROCm is already installed).
@@ -57,14 +61,23 @@ host_setup_fio_alternative_priority_libhipfile: 50
 host_setup_ais_hipfile_observability: false
 host_setup_ais_hipfile_install_root: /usr/lib/rocm-icms/ais-hipfile
 host_setup_ais_hipfile_textfile_metrics: true
-# Metrics appear only if prometheus-node-exporter is started with a textfile
-# collector directory (e.g. ARGS in /etc/default/prometheus-node-exporter on
-# Ubuntu). The package default often includes /var/lib/prometheus/node-exporter.
-host_setup_ais_hipfile_textfile_dir: /var/lib/prometheus/node-exporter
+# Textfile path (node_exporter ARGS configured by node_exporter.yml).
+host_setup_ais_hipfile_textfile_dir: "{{ host_setup_node_exporter_textfile_dir }}"
 
 # Textfile metrics for Grafana cluster summary (ROCm + AMDGPU versions).
 host_setup_rocm_icms_version_textfile: true
 host_setup_rocm_icms_lib_dir: /usr/lib/rocm-icms
 host_setup_rocm_icms_versions_script_path: >-
   {{ host_setup_rocm_icms_lib_dir }}/rocm-icms-stack-versions.sh
-host_setup_rocm_icms_textfile_dir: "{{ host_setup_ais_hipfile_textfile_dir }}"
+host_setup_rocm_icms_textfile_dir: "{{ host_setup_node_exporter_textfile_dir }}"
+
+# rocm-aic-exporter: LMCache / vLLM host metrics via node_exporter textfile.
+host_setup_rocm_aic_exporter_enabled: true
+host_setup_rocm_aic_exporter_install_dir: /opt/rocm-aic-exporter
+host_setup_rocm_aic_exporter_script_src: >-
+  {{ role_path }}/../../../recipies/vllm-radeon/scripts/rocm-aic-exporter.py
+host_setup_rocm_aic_exporter_textfile_path: >-
+  {{ host_setup_node_exporter_textfile_dir }}/rocm_aic_exporter.prom
+host_setup_rocm_aic_exporter_radeon_host_data_root: /mnt/lmcache-nvme
+host_setup_rocm_aic_exporter_lmcache_kv_subdir: lmcache
+host_setup_rocm_aic_exporter_lmcache_chunk_stats_subdir: lmcache_chunk_stats

--- a/ansible/roles/host_setup/handlers/main.yml
+++ b/ansible/roles/host_setup/handlers/main.yml
@@ -7,6 +7,15 @@
   ansible.builtin.systemd:
     daemon_reload: true
 
+- name: Reload systemd for rocm-aic-exporter
+  ansible.builtin.systemd:
+    daemon_reload: true
+
+- name: Restart prometheus-node-exporter
+  ansible.builtin.systemd:
+    name: prometheus-node-exporter
+    state: restarted
+
 - name: Apt update after AMD repo dedupe
   ansible.builtin.apt:
     update_cache: true

--- a/ansible/roles/host_setup/tasks/main.yml
+++ b/ansible/roles/host_setup/tasks/main.yml
@@ -49,6 +49,23 @@
     - provision
     - stack_versions
 
+- name: ROCm AIC exporter (LMCache metrics textfile + systemd timer)
+  ansible.builtin.include_tasks:
+    file: rocm_aic_exporter.yml
+    apply:
+      tags:
+        - node_exporter
+        - provision
+        - rocm_aic_exporter
+  when:
+    - host_setup_rocm_aic_exporter_enabled | default(true) | bool
+    - host_setup_enable_prometheus_node_exporter | default(true) | bool
+    - "'prometheus-node-exporter' in (extra_packages | default([]))"
+  tags:
+    - node_exporter
+    - provision
+    - rocm_aic_exporter
+
 - name: Install NVMe Prometheus exporter
   ansible.builtin.include_role:
     name: sbates130272.batesste.nvme_exporter_setup

--- a/ansible/roles/host_setup/tasks/node_exporter.yml
+++ b/ansible/roles/host_setup/tasks/node_exporter.yml
@@ -3,6 +3,10 @@
 # SPDX-License-Identifier: MIT
 
 ---
+- name: Configure node_exporter textfile collector
+  ansible.builtin.include_tasks: node_exporter_textfile_collector.yml
+  when: "'prometheus-node-exporter' in (extra_packages | default([]))"
+
 - name: Enable and start prometheus-node-exporter
   ansible.builtin.service:
     name: prometheus-node-exporter

--- a/ansible/roles/host_setup/tasks/node_exporter_textfile_collector.yml
+++ b/ansible/roles/host_setup/tasks/node_exporter_textfile_collector.yml
@@ -1,0 +1,19 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Ensures prometheus-node-exporter scrapes the shared textfile directory.
+
+---
+- name: Ensure node_exporter textfile collector directory exists
+  ansible.builtin.file:
+    path: "{{ host_setup_node_exporter_textfile_dir }}"
+    state: directory
+    mode: "0755"
+
+- name: Configure prometheus-node-exporter textfile collector
+  ansible.builtin.template:
+    src: prometheus-node-exporter.default.j2
+    dest: /etc/default/prometheus-node-exporter
+    mode: "0644"
+  notify: Restart prometheus-node-exporter

--- a/ansible/roles/host_setup/tasks/rocm_aic_exporter.yml
+++ b/ansible/roles/host_setup/tasks/rocm_aic_exporter.yml
@@ -1,0 +1,57 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Installs rocm-aic-exporter.py and a systemd timer that writes
+# rocm_aic_exporter.prom for prometheus-node-exporter textfile collection.
+
+---
+- name: Ensure rocm-aic-exporter install directory exists
+  ansible.builtin.file:
+    path: "{{ host_setup_rocm_aic_exporter_install_dir }}"
+    state: directory
+    mode: "0755"
+
+- name: Install rocm-aic-exporter.py
+  ansible.builtin.copy:
+    src: "{{ host_setup_rocm_aic_exporter_script_src }}"
+    dest: "{{ host_setup_rocm_aic_exporter_install_dir }}/rocm-aic-exporter.py"
+    mode: "0755"
+  notify: Reload systemd for rocm-aic-exporter
+
+- name: Install systemd unit for rocm-aic-exporter
+  ansible.builtin.template:
+    src: rocm-aic-exporter.service.j2
+    dest: /etc/systemd/system/rocm-aic-exporter.service
+    mode: "0644"
+  notify: Reload systemd for rocm-aic-exporter
+
+- name: Install systemd timer for rocm-aic-exporter
+  ansible.builtin.template:
+    src: rocm-aic-exporter.timer.j2
+    dest: /etc/systemd/system/rocm-aic-exporter.timer
+    mode: "0644"
+  notify: Reload systemd for rocm-aic-exporter
+
+- name: Enable and start rocm-aic-exporter timer
+  ansible.builtin.systemd:
+    name: rocm-aic-exporter.timer
+    state: started
+    enabled: true
+    daemon_reload: true
+
+- name: Run rocm-aic-exporter once
+  ansible.builtin.command:
+    cmd: >-
+      /usr/bin/python3
+      {{ host_setup_rocm_aic_exporter_install_dir }}/rocm-aic-exporter.py
+      --prometheus-textfile
+      --textfile-only
+  environment:
+    ROCM_AIC_EXPORTER_TEXTFILE: "{{ host_setup_rocm_aic_exporter_textfile_path }}"
+    ROCM_ICMS_TEXTFILE_DIR: "{{ host_setup_node_exporter_textfile_dir }}"
+    RADEON_HOST_DATA_ROOT: "{{ host_setup_rocm_aic_exporter_radeon_host_data_root }}"
+    RADEON_LMCACHE_KV_SUBDIR: "{{ host_setup_rocm_aic_exporter_lmcache_kv_subdir }}"
+    RADEON_LMCACHE_CHUNK_STATS_SUBDIR: >-
+      {{ host_setup_rocm_aic_exporter_lmcache_chunk_stats_subdir }}
+  changed_when: false

--- a/ansible/roles/host_setup/templates/prometheus-node-exporter.default.j2
+++ b/ansible/roles/host_setup/templates/prometheus-node-exporter.default.j2
@@ -1,0 +1,9 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Managed by Ansible (host_setup). Enables the textfile collector for
+# rocm-aic-exporter, stack versions, and AIS hipFile metrics.
+
+# Command-line arguments for prometheus-node-exporter (Ubuntu package).
+ARGS="--collector.textfile.directory={{ host_setup_node_exporter_textfile_dir }}{% for arg in host_setup_node_exporter_extra_args | default([]) %} {{ arg }}{% endfor %}"

--- a/ansible/roles/host_setup/templates/rocm-aic-exporter.service.j2
+++ b/ansible/roles/host_setup/templates/rocm-aic-exporter.service.j2
@@ -1,0 +1,20 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Managed by Ansible (host_setup).
+[Unit]
+Description=ROCm AIC Prometheus textfile exporter
+After=network-online.target local-fs.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+Environment=ROCM_AIC_EXPORTER_TEXTFILE={{ host_setup_rocm_aic_exporter_textfile_path }}
+Environment=ROCM_ICMS_TEXTFILE_DIR={{ host_setup_node_exporter_textfile_dir }}
+Environment=RADEON_HOST_DATA_ROOT={{ host_setup_rocm_aic_exporter_radeon_host_data_root }}
+Environment=RADEON_LMCACHE_KV_SUBDIR={{ host_setup_rocm_aic_exporter_lmcache_kv_subdir }}
+Environment=RADEON_LMCACHE_CHUNK_STATS_SUBDIR={{ host_setup_rocm_aic_exporter_lmcache_chunk_stats_subdir }}
+ExecStart=/usr/bin/python3 {{ host_setup_rocm_aic_exporter_install_dir }}/rocm-aic-exporter.py \
+  --prometheus-textfile \
+  --textfile-only

--- a/ansible/roles/host_setup/templates/rocm-aic-exporter.timer.j2
+++ b/ansible/roles/host_setup/templates/rocm-aic-exporter.timer.j2
@@ -1,0 +1,15 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Managed by Ansible (host_setup).
+[Unit]
+Description=Run Prometheus rocm-aic metric updater regularly
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=15s
+AccuracySec=1s
+
+[Install]
+WantedBy=timers.target

--- a/ansible/roles/monitoring_stack/defaults/main.yml
+++ b/ansible/roles/monitoring_stack/defaults/main.yml
@@ -32,6 +32,14 @@ monitoring_grafana_dashboard_amd_gpu_id: "23434"
 
 monitoring_grafana_provision_cluster_summary_dashboard: true
 
+# Prometheus /etc/default/prometheus ARGS (systemd EnvironmentFile).
+# Enables POST /api/v1/write on the monitoring server.
+monitoring_prometheus_enable_remote_write_receiver: true
+# Extra flags appended when monitoring_prometheus_args_override is empty.
+monitoring_prometheus_extra_args: []
+# Non-empty string replaces auto-built ARGS entirely (advanced).
+monitoring_prometheus_args_override: ""
+
 # Defaults for templates when hostvars omit collection role defaults.
 nvme_exporter_listen_address: ":9998"
 rocm_setup_metrics_exporter_port: 5000

--- a/ansible/roles/monitoring_stack/defaults/main.yml
+++ b/ansible/roles/monitoring_stack/defaults/main.yml
@@ -32,12 +32,13 @@ monitoring_grafana_dashboard_amd_gpu_id: "23434"
 
 monitoring_grafana_provision_cluster_summary_dashboard: true
 
-# Prometheus /etc/default/prometheus ARGS (systemd EnvironmentFile).
-# Enables POST /api/v1/write on the monitoring server.
+# Prometheus: remote-write receiver via systemd drop-in (preserves package
+# /etc/default/prometheus ARGS). Enables POST /api/v1/write on the server.
 monitoring_prometheus_enable_remote_write_receiver: true
-# Extra flags appended when monitoring_prometheus_args_override is empty.
+# Extra flags appended in systemd drop-in ExecStart when args_override is empty.
 monitoring_prometheus_extra_args: []
-# Non-empty string replaces auto-built ARGS entirely (advanced).
+# Non-empty string replaces /etc/default/prometheus ARGS entirely (advanced).
+# Must include required flags (--config.file, --storage.tsdb.path, etc.).
 monitoring_prometheus_args_override: ""
 
 # Defaults for templates when hostvars omit collection role defaults.

--- a/ansible/roles/monitoring_stack/handlers/main.yml
+++ b/ansible/roles/monitoring_stack/handlers/main.yml
@@ -4,9 +4,10 @@
 
 ---
 - name: Reload prometheus
-  ansible.builtin.service:
+  ansible.builtin.systemd:
     name: prometheus
     state: restarted
+    daemon_reload: true
 
 - name: Reload systemd and restart grafana-server
   ansible.builtin.systemd:

--- a/ansible/roles/monitoring_stack/tasks/prometheus.yml
+++ b/ansible/roles/monitoring_stack/tasks/prometheus.yml
@@ -3,13 +3,49 @@
 # SPDX-License-Identifier: MIT
 
 ---
-- name: Deploy Prometheus service environment (remote write receiver)
+- name: Ensure Prometheus systemd drop-in directory exists
+  ansible.builtin.file:
+    path: /etc/systemd/system/prometheus.service.d
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Restore package-style Prometheus defaults (empty ARGS)
+  ansible.builtin.template:
+    src: prometheus.default.package.j2
+    dest: /etc/default/prometheus
+    owner: root
+    group: root
+    mode: "0644"
+  when: monitoring_prometheus_args_override | default('') | length == 0
+  notify: Reload prometheus
+
+- name: Deploy Prometheus ARGS override
   ansible.builtin.template:
     src: prometheus.default.j2
     dest: /etc/default/prometheus
     owner: root
     group: root
     mode: "0644"
+  when: monitoring_prometheus_args_override | default('') | length > 0
+  notify: Reload prometheus
+
+- name: Deploy Prometheus systemd drop-in (append flags, preserve ARGS)
+  ansible.builtin.template:
+    src: prometheus-drop-in.conf.j2
+    dest: /etc/systemd/system/prometheus.service.d/rocm-aic.conf
+    owner: root
+    group: root
+    mode: "0644"
+  when: monitoring_prometheus_args_override | default('') | length == 0
+  notify: Reload prometheus
+
+- name: Remove Prometheus systemd drop-in when ARGS override is set
+  ansible.builtin.file:
+    path: /etc/systemd/system/prometheus.service.d/rocm-aic.conf
+    state: absent
+  when: monitoring_prometheus_args_override | default('') | length > 0
   notify: Reload prometheus
 
 - name: Validate llm-d federation host when enabled

--- a/ansible/roles/monitoring_stack/tasks/prometheus.yml
+++ b/ansible/roles/monitoring_stack/tasks/prometheus.yml
@@ -3,6 +3,15 @@
 # SPDX-License-Identifier: MIT
 
 ---
+- name: Deploy Prometheus service environment (remote write receiver)
+  ansible.builtin.template:
+    src: prometheus.default.j2
+    dest: /etc/default/prometheus
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Reload prometheus
+
 - name: Validate llm-d federation host when enabled
   ansible.builtin.assert:
     that:

--- a/ansible/roles/monitoring_stack/templates/prometheus-drop-in.conf.j2
+++ b/ansible/roles/monitoring_stack/templates/prometheus-drop-in.conf.j2
@@ -1,0 +1,10 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Managed by Ansible (monitoring_stack). Appends flags to $ARGS from
+# /etc/default/prometheus without replacing that file.
+
+[Service]
+ExecStart=
+ExecStart=/usr/bin/prometheus $ARGS{% if monitoring_prometheus_enable_remote_write_receiver | default(true) | bool %} --web.enable-remote-write-receiver{% endif %}{% for arg in monitoring_prometheus_extra_args | default([]) %} {{ arg }}{% endfor %}

--- a/ansible/roles/monitoring_stack/templates/prometheus.default.j2
+++ b/ansible/roles/monitoring_stack/templates/prometheus.default.j2
@@ -1,0 +1,12 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Managed by Ansible (monitoring_stack). Do not edit on host.
+# Consumed by the prometheus systemd unit: /usr/bin/prometheus $ARGS
+
+{% if monitoring_prometheus_args_override | default('') | length > 0 %}
+ARGS="{{ monitoring_prometheus_args_override }}"
+{% else %}
+ARGS="{{ ((['--web.enable-remote-write-receiver'] if (monitoring_prometheus_enable_remote_write_receiver | default(true) | bool) else []) + (monitoring_prometheus_extra_args | default([]))) | join(' ') }}"
+{% endif %}

--- a/ansible/roles/monitoring_stack/templates/prometheus.default.package.j2
+++ b/ansible/roles/monitoring_stack/templates/prometheus.default.package.j2
@@ -2,12 +2,12 @@
 #
 # SPDX-License-Identifier: MIT
 #
-# Managed by Ansible (monitoring_stack). Advanced: replaces ARGS entirely.
-# Include all required flags (e.g. --config.file, --storage.tsdb.path,
-# --web.console.*) or Prometheus may not start.
+# Managed by Ansible (monitoring_stack). Matches the Ubuntu prometheus package
+# layout: empty ARGS so deb-built defaults apply; extra flags use the systemd
+# drop-in (prometheus-drop-in.conf.j2).
 
 # Set the command-line arguments to pass to the server.
 # Due to shell escaping, to pass backslashes for regexes, you need to double
 # them (\\d for \d). If running under systemd, you need to double them again
 # (\\\\d to mean \d), and escape newlines too.
-ARGS="{{ monitoring_prometheus_args_override }}"
+ARGS=""

--- a/recipies/vllm-radeon/README.md
+++ b/recipies/vllm-radeon/README.md
@@ -64,6 +64,13 @@ Standalone exporter for LMCache / vLLM host metrics. Today it reports:
    JSONL hashes must use the same **`pre_caching_hash_algorithm`** as KV storage
    (**`lmcache-chunk-statistics-hash.patch`**). Stats collected with the default
    **builtin** hasher cannot be matched to **`sha256_cbor`** on-disk keys.
+4. **NFS** (only with **`--prometheus-textfile`**) — runs **`nfsiostat`** when
+   installed; cumulative RX/TX bytes per NFS client mount from
+   **`/proc/self/mountstats`** (label **`mount_point`**).
+   **`rocm_aic_nfsiostat_present`** is 0 when **`nfsiostat`** is absent.
+5. **ROCm** (only with **`--prometheus-textfile`**) — **`hipconfig`** for
+   HIP/ROCm version; **`rocm_aic_hipconfig_present`** is 0 when
+   **`hipconfig`** is absent.
 
 ```bash
 # Host path matches make run DATA= (default /mnt/lmcache-nvme)
@@ -90,6 +97,8 @@ Example Grafana queries (``job="node_exporter"``):
 - ``rocm_aic_kv_files{model_name=~".+"}``
 - ``rocm_aic_kv_chunk_bytes_total``
 - ``rocm_aic_data_fs_free_bytes``
+- ``rate(rocm_aic_nfs_mount_rx_bytes_total{mount_point="/mnt/..."}[5m])``
+- ``rocm_aic_rocm_version_info``
 
 ## MFU metrics (**`--enable-mfu-metrics`**)
 

--- a/recipies/vllm-radeon/grafana/vllm-lmcache-prometheus-mi300x-cluster.json
+++ b/recipies/vllm-radeon/grafana/vllm-lmcache-prometheus-mi300x-cluster.json
@@ -1,0 +1,2970 @@
+{
+    "apiVersion": "dashboard.grafana.app/v2",
+    "kind": "Dashboard",
+    "metadata": {
+        "name": "rocm-aic-vllm-lmcache",
+        "namespace": "default",
+        "uid": "7f2af756-9968-44cd-8f7a-cd8be435dd28",
+        "resourceVersion": "1779415630613006",
+        "generation": 38,
+        "creationTimestamp": "2026-05-20T23:06:44Z",
+        "labels": {
+            "grafana.app/deprecatedInternalID": "3595179651878912"
+        },
+        "annotations": {
+            "grafana.app/createdBy": "user:efjw5zjwxw7pcb",
+            "grafana.app/folder": "",
+            "grafana.app/saved-from-ui": "Grafana v13.0.1 (a100054f)",
+            "grafana.app/updatedBy": "user:afmrnm7m0xkw0e",
+            "grafana.app/updatedTimestamp": "2026-05-22T02:07:10Z"
+        }
+    },
+    "spec": {
+        "annotations": [
+            {
+                "kind": "AnnotationQuery",
+                "spec": {
+                    "query": {
+                        "kind": "DataQuery",
+                        "group": "grafana",
+                        "version": "v0",
+                        "datasource": {
+                            "name": "-- Grafana --"
+                        },
+                        "spec": {}
+                    },
+                    "enable": true,
+                    "hide": true,
+                    "iconColor": "rgba(0, 211, 255, 1)",
+                    "name": "Annotations & Alerts",
+                    "builtIn": true
+                }
+            }
+        ],
+        "cursorSync": "Crosshair",
+        "description": "A dashboard to show information relevant to the ROCm(tm) AMD Infinity Context System using for KV Cache block management and prefill offload via storage. ",
+        "editable": true,
+        "elements": {
+            "panel-31": {
+                "kind": "Panel",
+                "spec": {
+                    "id": 31,
+                    "title": "Server and GPU Power",
+                    "description": "Total power delivered to the server running vLLM.",
+                    "links": [],
+                    "data": {
+                        "kind": "QueryGroup",
+                        "spec": {
+                            "queries": [
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "local-prometheus"
+                                            },
+                                            "spec": {
+                                                "editorMode": "code",
+                                                "expr": "snoc_pinewood_plug_d_power{ }",
+                                                "fromExploreMetrics": false,
+                                                "legendFormat": "Server Power",
+                                                "range": true
+                                            }
+                                        },
+                                        "refId": "snoc_pinewood_plug_d_power-avg",
+                                        "hidden": false
+                                    }
+                                },
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "local-prometheus"
+                                            },
+                                            "spec": {
+                                                "editorMode": "code",
+                                                "expr": "amd_gpu_power_usage{instance=\"$instance\"}",
+                                                "instant": false,
+                                                "legendFormat": "__auto",
+                                                "range": true
+                                            }
+                                        },
+                                        "refId": "A",
+                                        "hidden": false
+                                    }
+                                }
+                            ],
+                            "transformations": [],
+                            "queryOptions": {
+                                "maxDataPoints": 500
+                            }
+                        }
+                    },
+                    "vizConfig": {
+                        "kind": "VizConfig",
+                        "group": "timeseries",
+                        "version": "13.0.1",
+                        "spec": {
+                            "options": {
+                                "annotations": {
+                                    "clustering": -1,
+                                    "multiLane": true
+                                },
+                                "legend": {
+                                    "calcs": [
+                                        "min",
+                                        "mean",
+                                        "max",
+                                        "lastNotNull"
+                                    ],
+                                    "displayMode": "table",
+                                    "placement": "bottom",
+                                    "showLegend": true
+                                },
+                                "tooltip": {
+                                    "hideZeros": false,
+                                    "mode": "single",
+                                    "sort": "none"
+                                }
+                            },
+                            "fieldConfig": {
+                                "defaults": {
+                                    "unit": "watt",
+                                    "min": 0,
+                                    "thresholds": {
+                                        "mode": "absolute",
+                                        "steps": [
+                                            {
+                                                "value": 0,
+                                                "color": "green"
+                                            },
+                                            {
+                                                "value": 80,
+                                                "color": "red"
+                                            }
+                                        ]
+                                    },
+                                    "color": {
+                                        "mode": "palette-classic"
+                                    },
+                                    "custom": {
+                                        "axisBorderShow": false,
+                                        "axisCenteredZero": false,
+                                        "axisColorMode": "text",
+                                        "axisLabel": "",
+                                        "axisPlacement": "auto",
+                                        "barAlignment": 0,
+                                        "barWidthFactor": 0.6,
+                                        "drawStyle": "line",
+                                        "fillOpacity": 9,
+                                        "gradientMode": "none",
+                                        "hideFrom": {
+                                            "legend": false,
+                                            "tooltip": false,
+                                            "viz": false
+                                        },
+                                        "insertNulls": false,
+                                        "lineInterpolation": "linear",
+                                        "lineWidth": 1,
+                                        "pointSize": 1,
+                                        "scaleDistribution": {
+                                            "type": "linear"
+                                        },
+                                        "showPoints": "auto",
+                                        "showValues": false,
+                                        "spanNulls": false,
+                                        "stacking": {
+                                            "group": "A",
+                                            "mode": "none"
+                                        },
+                                        "thresholdsStyle": {
+                                            "mode": "off"
+                                        }
+                                    }
+                                },
+                                "overrides": []
+                            }
+                        }
+                    }
+                }
+            },
+            "panel-32": {
+                "kind": "Panel",
+                "spec": {
+                    "id": 32,
+                    "title": "GPU Activity",
+                    "description": "The activity factor of the CUs and UMC in the GPU. This is given as a percentage of total compute power avaliable.",
+                    "links": [],
+                    "data": {
+                        "kind": "QueryGroup",
+                        "spec": {
+                            "queries": [
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "local-prometheus"
+                                            },
+                                            "spec": {
+                                                "editorMode": "code",
+                                                "expr": "sum by (instance, gpu_id) (\r\n  amd_gpu_gfx_activity{\r\n    job=\"amd_metrics_exporter\",\r\n    instance=~\"$instance\",\r\n    gpu_id=~\"$gpu_id\"\r\n  }\r\n)",
+                                                "fromExploreMetrics": false,
+                                                "legendFormat": "__auto",
+                                                "range": true
+                                            }
+                                        },
+                                        "refId": "amd_gpu_gfx_activity-avg",
+                                        "hidden": false
+                                    }
+                                },
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "local-prometheus"
+                                            },
+                                            "spec": {
+                                                "editorMode": "code",
+                                                "expr": "sum by (instance, gpu_id) (\r\n  amd_gpu_umc_activity{\r\n    job=\"amd_metrics_exporter\",\r\n    instance=~\"$instance\",\r\n    gpu_id=\"$gpu_id\"\r\n  }\r\n)",
+                                                "instant": false,
+                                                "legendFormat": "__auto",
+                                                "range": true
+                                            }
+                                        },
+                                        "refId": "A",
+                                        "hidden": false
+                                    }
+                                }
+                            ],
+                            "transformations": [],
+                            "queryOptions": {
+                                "maxDataPoints": 500
+                            }
+                        }
+                    },
+                    "vizConfig": {
+                        "kind": "VizConfig",
+                        "group": "timeseries",
+                        "version": "13.0.1",
+                        "spec": {
+                            "options": {
+                                "annotations": {
+                                    "clustering": -1,
+                                    "multiLane": true
+                                },
+                                "legend": {
+                                    "calcs": [
+                                        "min",
+                                        "mean",
+                                        "max",
+                                        "lastNotNull"
+                                    ],
+                                    "displayMode": "table",
+                                    "placement": "bottom",
+                                    "showLegend": true
+                                },
+                                "tooltip": {
+                                    "hideZeros": false,
+                                    "mode": "single",
+                                    "sort": "none"
+                                }
+                            },
+                            "fieldConfig": {
+                                "defaults": {
+                                    "unit": "percent",
+                                    "min": 0,
+                                    "thresholds": {
+                                        "mode": "absolute",
+                                        "steps": [
+                                            {
+                                                "value": 0,
+                                                "color": "green"
+                                            },
+                                            {
+                                                "value": 80,
+                                                "color": "red"
+                                            }
+                                        ]
+                                    },
+                                    "color": {
+                                        "mode": "palette-classic"
+                                    },
+                                    "custom": {
+                                        "axisBorderShow": false,
+                                        "axisCenteredZero": false,
+                                        "axisColorMode": "text",
+                                        "axisLabel": "",
+                                        "axisPlacement": "auto",
+                                        "barAlignment": 0,
+                                        "barWidthFactor": 0.6,
+                                        "drawStyle": "line",
+                                        "fillOpacity": 9,
+                                        "gradientMode": "none",
+                                        "hideFrom": {
+                                            "legend": false,
+                                            "tooltip": false,
+                                            "viz": false
+                                        },
+                                        "insertNulls": false,
+                                        "lineInterpolation": "linear",
+                                        "lineWidth": 1,
+                                        "pointSize": 1,
+                                        "scaleDistribution": {
+                                            "type": "linear"
+                                        },
+                                        "showPoints": "auto",
+                                        "showValues": false,
+                                        "spanNulls": false,
+                                        "stacking": {
+                                            "group": "A",
+                                            "mode": "none"
+                                        },
+                                        "thresholdsStyle": {
+                                            "mode": "off"
+                                        }
+                                    }
+                                },
+                                "overrides": []
+                            }
+                        }
+                    }
+                }
+            },
+            "panel-34": {
+                "kind": "Panel",
+                "spec": {
+                    "id": 34,
+                    "title": "VRAM Utilization",
+                    "description": "The amount of VRAM currently in use.",
+                    "links": [],
+                    "data": {
+                        "kind": "QueryGroup",
+                        "spec": {
+                            "queries": [
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "local-prometheus"
+                                            },
+                                            "spec": {
+                                                "editorMode": "code",
+                                                "expr": "sum by (instance) (\r\n  amd_gpu_used_vram{\r\n    job=\"amd_metrics_exporter\",\r\n    instance=~\"$instance\",\r\n    gpu_id=\"0\"\r\n  }\r\n)",
+                                                "fromExploreMetrics": false,
+                                                "legendFormat": "__auto",
+                                                "range": true
+                                            }
+                                        },
+                                        "refId": "amd_gpu_used_vram-avg",
+                                        "hidden": false
+                                    }
+                                }
+                            ],
+                            "transformations": [],
+                            "queryOptions": {
+                                "maxDataPoints": 500
+                            }
+                        }
+                    },
+                    "vizConfig": {
+                        "kind": "VizConfig",
+                        "group": "timeseries",
+                        "version": "13.0.1",
+                        "spec": {
+                            "options": {
+                                "annotations": {
+                                    "clustering": -1,
+                                    "multiLane": true
+                                },
+                                "legend": {
+                                    "calcs": [
+                                        "min",
+                                        "mean",
+                                        "max",
+                                        "lastNotNull"
+                                    ],
+                                    "displayMode": "table",
+                                    "placement": "bottom",
+                                    "showLegend": true
+                                },
+                                "tooltip": {
+                                    "hideZeros": false,
+                                    "mode": "single",
+                                    "sort": "none"
+                                }
+                            },
+                            "fieldConfig": {
+                                "defaults": {
+                                    "unit": "mbytes",
+                                    "min": 0,
+                                    "thresholds": {
+                                        "mode": "absolute",
+                                        "steps": [
+                                            {
+                                                "value": 0,
+                                                "color": "green"
+                                            },
+                                            {
+                                                "value": 80,
+                                                "color": "red"
+                                            }
+                                        ]
+                                    },
+                                    "color": {
+                                        "mode": "palette-classic"
+                                    },
+                                    "custom": {
+                                        "axisBorderShow": false,
+                                        "axisCenteredZero": false,
+                                        "axisColorMode": "text",
+                                        "axisLabel": "",
+                                        "axisPlacement": "auto",
+                                        "barAlignment": 0,
+                                        "barWidthFactor": 0.6,
+                                        "drawStyle": "line",
+                                        "fillOpacity": 9,
+                                        "gradientMode": "none",
+                                        "hideFrom": {
+                                            "legend": false,
+                                            "tooltip": false,
+                                            "viz": false
+                                        },
+                                        "insertNulls": false,
+                                        "lineInterpolation": "linear",
+                                        "lineWidth": 1,
+                                        "pointSize": 0,
+                                        "scaleDistribution": {
+                                            "type": "linear"
+                                        },
+                                        "showPoints": "auto",
+                                        "showValues": false,
+                                        "spanNulls": false,
+                                        "stacking": {
+                                            "group": "A",
+                                            "mode": "none"
+                                        },
+                                        "thresholdsStyle": {
+                                            "mode": "off"
+                                        }
+                                    }
+                                },
+                                "overrides": []
+                            }
+                        }
+                    }
+                }
+            },
+            "panel-35": {
+                "kind": "Panel",
+                "spec": {
+                    "id": 35,
+                    "title": "KV Cache Storage Bandwidth",
+                    "description": "The read and write bandwidth into and out of the AIC KV Cache Storage.",
+                    "links": [],
+                    "data": {
+                        "kind": "QueryGroup",
+                        "spec": {
+                            "queries": [
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "local-prometheus"
+                                            },
+                                            "spec": {
+                                                "editorMode": "code",
+                                                "expr": "sum(rate(node_disk_read_bytes_total{instance=\"g04u07\"}[$__rate_interval]))",
+                                                "fromExploreMetrics": false,
+                                                "legendFormat": "Read Bandwidth",
+                                                "range": true
+                                            }
+                                        },
+                                        "refId": "node_disk_written_bytes_total-sum(rate)",
+                                        "hidden": false
+                                    }
+                                },
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "local-prometheus"
+                                            },
+                                            "spec": {
+                                                "editorMode": "code",
+                                                "expr": "sum(rate(node_disk_written_bytes_total{instance=\"g04u07\"}[$__rate_interval]))",
+                                                "instant": false,
+                                                "legendFormat": "Write Bandwidth",
+                                                "range": true
+                                            }
+                                        },
+                                        "refId": "A",
+                                        "hidden": false
+                                    }
+                                }
+                            ],
+                            "transformations": [],
+                            "queryOptions": {
+                                "maxDataPoints": 500
+                            }
+                        }
+                    },
+                    "vizConfig": {
+                        "kind": "VizConfig",
+                        "group": "timeseries",
+                        "version": "13.0.1",
+                        "spec": {
+                            "options": {
+                                "annotations": {
+                                    "clustering": -1,
+                                    "multiLane": true
+                                },
+                                "legend": {
+                                    "calcs": [
+                                        "min",
+                                        "mean",
+                                        "max",
+                                        "lastNotNull"
+                                    ],
+                                    "displayMode": "table",
+                                    "placement": "bottom",
+                                    "showLegend": true
+                                },
+                                "tooltip": {
+                                    "hideZeros": false,
+                                    "mode": "single",
+                                    "sort": "none"
+                                }
+                            },
+                            "fieldConfig": {
+                                "defaults": {
+                                    "unit": "Bps",
+                                    "thresholds": {
+                                        "mode": "absolute",
+                                        "steps": [
+                                            {
+                                                "value": 0,
+                                                "color": "green"
+                                            },
+                                            {
+                                                "value": 80,
+                                                "color": "red"
+                                            }
+                                        ]
+                                    },
+                                    "color": {
+                                        "mode": "palette-classic"
+                                    },
+                                    "custom": {
+                                        "axisBorderShow": false,
+                                        "axisCenteredZero": false,
+                                        "axisColorMode": "text",
+                                        "axisLabel": "",
+                                        "axisPlacement": "auto",
+                                        "barAlignment": 0,
+                                        "barWidthFactor": 0.6,
+                                        "drawStyle": "line",
+                                        "fillOpacity": 9,
+                                        "gradientMode": "none",
+                                        "hideFrom": {
+                                            "legend": false,
+                                            "tooltip": false,
+                                            "viz": false
+                                        },
+                                        "insertNulls": false,
+                                        "lineInterpolation": "linear",
+                                        "lineWidth": 1,
+                                        "pointSize": 0,
+                                        "scaleDistribution": {
+                                            "type": "linear"
+                                        },
+                                        "showPoints": "auto",
+                                        "showValues": false,
+                                        "spanNulls": false,
+                                        "stacking": {
+                                            "group": "A",
+                                            "mode": "none"
+                                        },
+                                        "thresholdsStyle": {
+                                            "mode": "off"
+                                        }
+                                    }
+                                },
+                                "overrides": []
+                            }
+                        }
+                    }
+                }
+            },
+            "panel-37": {
+                "kind": "Panel",
+                "spec": {
+                    "id": 37,
+                    "title": "LMCache Store and Retrieve Requests",
+                    "description": "The total number of LMCache Store and Retrieve requests.",
+                    "links": [],
+                    "data": {
+                        "kind": "QueryGroup",
+                        "spec": {
+                            "queries": [
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "local-prometheus"
+                                            },
+                                            "spec": {
+                                                "editorMode": "code",
+                                                "expr": "lmcache:num_store_requests_total{ }",
+                                                "legendFormat": "Store Requests",
+                                                "range": true
+                                            }
+                                        },
+                                        "refId": "A",
+                                        "hidden": false
+                                    }
+                                },
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "local-prometheus"
+                                            },
+                                            "spec": {
+                                                "editorMode": "code",
+                                                "expr": "lmcache:num_retrieve_requests_total{ }",
+                                                "instant": false,
+                                                "legendFormat": "Retrieve Requests",
+                                                "range": true
+                                            }
+                                        },
+                                        "refId": "B",
+                                        "hidden": false
+                                    }
+                                }
+                            ],
+                            "transformations": [],
+                            "queryOptions": {}
+                        }
+                    },
+                    "vizConfig": {
+                        "kind": "VizConfig",
+                        "group": "timeseries",
+                        "version": "13.0.1",
+                        "spec": {
+                            "options": {
+                                "annotations": {
+                                    "clustering": -1,
+                                    "multiLane": false
+                                },
+                                "legend": {
+                                    "calcs": [
+                                        "min",
+                                        "mean",
+                                        "max",
+                                        "lastNotNull"
+                                    ],
+                                    "displayMode": "table",
+                                    "placement": "bottom",
+                                    "showLegend": true
+                                },
+                                "tooltip": {
+                                    "hideZeros": false,
+                                    "mode": "single",
+                                    "sort": "none"
+                                }
+                            },
+                            "fieldConfig": {
+                                "defaults": {
+                                    "thresholds": {
+                                        "mode": "absolute",
+                                        "steps": [
+                                            {
+                                                "value": 0,
+                                                "color": "green"
+                                            },
+                                            {
+                                                "value": 80,
+                                                "color": "red"
+                                            }
+                                        ]
+                                    },
+                                    "color": {
+                                        "mode": "palette-classic"
+                                    },
+                                    "custom": {
+                                        "axisBorderShow": false,
+                                        "axisCenteredZero": false,
+                                        "axisColorMode": "text",
+                                        "axisLabel": "",
+                                        "axisPlacement": "auto",
+                                        "barAlignment": 0,
+                                        "barWidthFactor": 0.6,
+                                        "drawStyle": "line",
+                                        "fillOpacity": 25,
+                                        "gradientMode": "none",
+                                        "hideFrom": {
+                                            "legend": false,
+                                            "tooltip": false,
+                                            "viz": false
+                                        },
+                                        "insertNulls": false,
+                                        "lineInterpolation": "linear",
+                                        "lineWidth": 1,
+                                        "pointSize": 0,
+                                        "scaleDistribution": {
+                                            "type": "linear"
+                                        },
+                                        "showPoints": "auto",
+                                        "showValues": false,
+                                        "spanNulls": false,
+                                        "stacking": {
+                                            "group": "A",
+                                            "mode": "none"
+                                        },
+                                        "thresholdsStyle": {
+                                            "mode": "off"
+                                        }
+                                    }
+                                },
+                                "overrides": []
+                            }
+                        }
+                    }
+                }
+            },
+            "panel-43": {
+                "kind": "Panel",
+                "spec": {
+                    "id": 43,
+                    "title": "Token Rate by Source",
+                    "description": "The tokens per second from compute, local CPU cache and AIC cache.",
+                    "links": [],
+                    "data": {
+                        "kind": "QueryGroup",
+                        "spec": {
+                            "queries": [
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "local-prometheus"
+                                            },
+                                            "spec": {
+                                                "editorMode": "code",
+                                                "expr": "sum(rate(vllm:prompt_tokens_by_source_total{source=\"local_compute\"}[$__rate_interval]))",
+                                                "instant": false,
+                                                "legendFormat": "Tokens Computed",
+                                                "range": true
+                                            }
+                                        },
+                                        "refId": "A",
+                                        "hidden": false
+                                    }
+                                },
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "local-prometheus"
+                                            },
+                                            "spec": {
+                                                "editorMode": "code",
+                                                "expr": "sum(rate(vllm:prompt_tokens_by_source_total{source=\"external_kv_transfer\"}[$__rate_interval]))",
+                                                "instant": false,
+                                                "legendFormat": "Tokens from AIC",
+                                                "range": true
+                                            }
+                                        },
+                                        "refId": "B",
+                                        "hidden": false
+                                    }
+                                },
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "local-prometheus"
+                                            },
+                                            "spec": {
+                                                "editorMode": "code",
+                                                "expr": "sum(rate(vllm:prompt_tokens_by_source_total{source=\"local_cache_hit\"}[$__rate_interval]))",
+                                                "instant": false,
+                                                "legendFormat": "Tokens from CPU Cache",
+                                                "range": true
+                                            }
+                                        },
+                                        "refId": "C",
+                                        "hidden": false
+                                    }
+                                },
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "__expr__",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "__expr__"
+                                            },
+                                            "spec": {
+                                                "expression": "$A+$B+$C",
+                                                "type": "math"
+                                            }
+                                        },
+                                        "refId": "Total Tokens",
+                                        "hidden": false
+                                    }
+                                }
+                            ],
+                            "transformations": [],
+                            "queryOptions": {}
+                        }
+                    },
+                    "vizConfig": {
+                        "kind": "VizConfig",
+                        "group": "timeseries",
+                        "version": "13.0.1",
+                        "spec": {
+                            "options": {
+                                "annotations": {
+                                    "clustering": -1,
+                                    "multiLane": false
+                                },
+                                "legend": {
+                                    "calcs": [
+                                        "min",
+                                        "mean",
+                                        "max",
+                                        "lastNotNull"
+                                    ],
+                                    "displayMode": "table",
+                                    "placement": "bottom",
+                                    "showLegend": true,
+                                    "sortBy": "Name",
+                                    "sortDesc": true
+                                },
+                                "tooltip": {
+                                    "hideZeros": false,
+                                    "mode": "single",
+                                    "sort": "none"
+                                }
+                            },
+                            "fieldConfig": {
+                                "defaults": {
+                                    "unit": "none",
+                                    "min": 0,
+                                    "thresholds": {
+                                        "mode": "absolute",
+                                        "steps": [
+                                            {
+                                                "value": 0,
+                                                "color": "green"
+                                            },
+                                            {
+                                                "value": 80,
+                                                "color": "red"
+                                            }
+                                        ]
+                                    },
+                                    "color": {
+                                        "mode": "palette-classic"
+                                    },
+                                    "custom": {
+                                        "axisBorderShow": false,
+                                        "axisCenteredZero": false,
+                                        "axisColorMode": "text",
+                                        "axisLabel": "Tokens/Secomd",
+                                        "axisPlacement": "auto",
+                                        "barAlignment": 0,
+                                        "barWidthFactor": 0.6,
+                                        "drawStyle": "line",
+                                        "fillOpacity": 0,
+                                        "gradientMode": "none",
+                                        "hideFrom": {
+                                            "legend": false,
+                                            "tooltip": false,
+                                            "viz": false
+                                        },
+                                        "insertNulls": false,
+                                        "lineInterpolation": "linear",
+                                        "lineWidth": 1,
+                                        "pointSize": 0,
+                                        "scaleDistribution": {
+                                            "type": "linear"
+                                        },
+                                        "showPoints": "auto",
+                                        "showValues": false,
+                                        "spanNulls": false,
+                                        "stacking": {
+                                            "group": "A",
+                                            "mode": "none"
+                                        },
+                                        "thresholdsStyle": {
+                                            "mode": "off"
+                                        }
+                                    }
+                                },
+                                "overrides": []
+                            }
+                        }
+                    }
+                }
+            },
+            "panel-44": {
+                "kind": "Panel",
+                "spec": {
+                    "id": 44,
+                    "title": "AIC KV Cache Block File Count",
+                    "description": "The total count of KV Cache Blocks on the AIC storage device.",
+                    "links": [],
+                    "data": {
+                        "kind": "QueryGroup",
+                        "spec": {
+                            "queries": [
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "local-prometheus"
+                                            },
+                                            "spec": {
+                                                "editorMode": "code",
+                                                "expr": "rocm_aic_kv_disk_files{ }",
+                                                "legendFormat": "AIC File Count",
+                                                "range": true
+                                            }
+                                        },
+                                        "refId": "A",
+                                        "hidden": false
+                                    }
+                                }
+                            ],
+                            "transformations": [],
+                            "queryOptions": {}
+                        }
+                    },
+                    "vizConfig": {
+                        "kind": "VizConfig",
+                        "group": "timeseries",
+                        "version": "13.0.1",
+                        "spec": {
+                            "options": {
+                                "annotations": {
+                                    "clustering": -1,
+                                    "multiLane": false
+                                },
+                                "legend": {
+                                    "calcs": [
+                                        "min",
+                                        "mean",
+                                        "max",
+                                        "lastNotNull"
+                                    ],
+                                    "displayMode": "table",
+                                    "placement": "bottom",
+                                    "showLegend": true
+                                },
+                                "tooltip": {
+                                    "hideZeros": false,
+                                    "mode": "single",
+                                    "sort": "none"
+                                }
+                            },
+                            "fieldConfig": {
+                                "defaults": {
+                                    "unit": "none",
+                                    "min": 0,
+                                    "thresholds": {
+                                        "mode": "absolute",
+                                        "steps": [
+                                            {
+                                                "value": 0,
+                                                "color": "green"
+                                            },
+                                            {
+                                                "value": 80,
+                                                "color": "red"
+                                            }
+                                        ]
+                                    },
+                                    "color": {
+                                        "mode": "palette-classic"
+                                    },
+                                    "custom": {
+                                        "axisBorderShow": false,
+                                        "axisCenteredZero": false,
+                                        "axisColorMode": "text",
+                                        "axisLabel": "",
+                                        "axisPlacement": "auto",
+                                        "barAlignment": 0,
+                                        "barWidthFactor": 0.6,
+                                        "drawStyle": "line",
+                                        "fillOpacity": 25,
+                                        "gradientMode": "none",
+                                        "hideFrom": {
+                                            "legend": false,
+                                            "tooltip": false,
+                                            "viz": false
+                                        },
+                                        "insertNulls": false,
+                                        "lineInterpolation": "linear",
+                                        "lineWidth": 1,
+                                        "pointSize": 0,
+                                        "scaleDistribution": {
+                                            "type": "linear"
+                                        },
+                                        "showPoints": "auto",
+                                        "showValues": false,
+                                        "spanNulls": false,
+                                        "stacking": {
+                                            "group": "A",
+                                            "mode": "none"
+                                        },
+                                        "thresholdsStyle": {
+                                            "mode": "off"
+                                        }
+                                    }
+                                },
+                                "overrides": []
+                            }
+                        }
+                    }
+                }
+            },
+            "panel-46": {
+                "kind": "Panel",
+                "spec": {
+                    "id": 46,
+                    "title": "AIC Free Capacity",
+                    "description": "The capacity remaining on the ROCm AIC storage system.",
+                    "links": [],
+                    "data": {
+                        "kind": "QueryGroup",
+                        "spec": {
+                            "queries": [
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "local-prometheus"
+                                            },
+                                            "spec": {
+                                                "editorMode": "code",
+                                                "expr": "rocm_aic_data_fs_free_bytes{ }",
+                                                "legendFormat": "AIC Space Remaining",
+                                                "range": true
+                                            }
+                                        },
+                                        "refId": "A",
+                                        "hidden": false
+                                    }
+                                }
+                            ],
+                            "transformations": [],
+                            "queryOptions": {}
+                        }
+                    },
+                    "vizConfig": {
+                        "kind": "VizConfig",
+                        "group": "timeseries",
+                        "version": "13.0.1",
+                        "spec": {
+                            "options": {
+                                "annotations": {
+                                    "clustering": -1,
+                                    "multiLane": false
+                                },
+                                "legend": {
+                                    "calcs": [
+                                        "min",
+                                        "mean",
+                                        "max",
+                                        "lastNotNull"
+                                    ],
+                                    "displayMode": "table",
+                                    "placement": "bottom",
+                                    "showLegend": true
+                                },
+                                "tooltip": {
+                                    "hideZeros": false,
+                                    "mode": "single",
+                                    "sort": "none"
+                                }
+                            },
+                            "fieldConfig": {
+                                "defaults": {
+                                    "unit": "decbytes",
+                                    "min": 0,
+                                    "thresholds": {
+                                        "mode": "absolute",
+                                        "steps": [
+                                            {
+                                                "value": 0,
+                                                "color": "green"
+                                            },
+                                            {
+                                                "value": 80,
+                                                "color": "red"
+                                            }
+                                        ]
+                                    },
+                                    "color": {
+                                        "mode": "palette-classic"
+                                    },
+                                    "custom": {
+                                        "axisBorderShow": false,
+                                        "axisCenteredZero": false,
+                                        "axisColorMode": "text",
+                                        "axisLabel": "",
+                                        "axisPlacement": "auto",
+                                        "barAlignment": 0,
+                                        "barWidthFactor": 0.6,
+                                        "drawStyle": "line",
+                                        "fillOpacity": 25,
+                                        "gradientMode": "none",
+                                        "hideFrom": {
+                                            "legend": false,
+                                            "tooltip": false,
+                                            "viz": false
+                                        },
+                                        "insertNulls": false,
+                                        "lineInterpolation": "linear",
+                                        "lineWidth": 1,
+                                        "pointSize": 0,
+                                        "scaleDistribution": {
+                                            "type": "linear"
+                                        },
+                                        "showPoints": "auto",
+                                        "showValues": false,
+                                        "spanNulls": false,
+                                        "stacking": {
+                                            "group": "A",
+                                            "mode": "none"
+                                        },
+                                        "thresholdsStyle": {
+                                            "mode": "off"
+                                        }
+                                    }
+                                },
+                                "overrides": []
+                            }
+                        }
+                    }
+                }
+            },
+            "panel-47": {
+                "kind": "Panel",
+                "spec": {
+                    "id": 47,
+                    "title": "KV Cache Block Hit Statistics",
+                    "description": "Time-based statistics on the AIS KV Cache Blocks and the number of times they have been \"hit\" as in retrieved by the KV Block Manager.",
+                    "links": [],
+                    "data": {
+                        "kind": "QueryGroup",
+                        "spec": {
+                            "queries": [
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "local-prometheus"
+                                            },
+                                            "spec": {
+                                                "editorMode": "code",
+                                                "expr": "sum(\r\n  rate(rocm_aic_kv_files_by_hit_count{hit_count=~\"0|1\"}[$__rate_interval])\r\n) by (instance)",
+                                                "legendFormat": "0 Hits",
+                                                "range": true
+                                            }
+                                        },
+                                        "refId": "A",
+                                        "hidden": false
+                                    }
+                                },
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "local-prometheus"
+                                            },
+                                            "spec": {
+                                                "editorMode": "code",
+                                                "expr": "sum(\r\n  rate(rocm_aic_kv_files_by_hit_count{hit_count=~\"2|3|4|5\"}[$__rate_interval])\r\n) by (instance)",
+                                                "instant": false,
+                                                "legendFormat": "1-5 Hits",
+                                                "range": true
+                                            }
+                                        },
+                                        "refId": "C",
+                                        "hidden": false
+                                    }
+                                }
+                            ],
+                            "transformations": [],
+                            "queryOptions": {}
+                        }
+                    },
+                    "vizConfig": {
+                        "kind": "VizConfig",
+                        "group": "timeseries",
+                        "version": "13.0.1",
+                        "spec": {
+                            "options": {
+                                "annotations": {
+                                    "clustering": -1,
+                                    "multiLane": false
+                                },
+                                "legend": {
+                                    "calcs": [
+                                        "min",
+                                        "mean",
+                                        "max",
+                                        "lastNotNull"
+                                    ],
+                                    "displayMode": "table",
+                                    "placement": "bottom",
+                                    "showLegend": true
+                                },
+                                "tooltip": {
+                                    "hideZeros": false,
+                                    "mode": "single",
+                                    "sort": "none"
+                                }
+                            },
+                            "fieldConfig": {
+                                "defaults": {
+                                    "thresholds": {
+                                        "mode": "absolute",
+                                        "steps": [
+                                            {
+                                                "value": 0,
+                                                "color": "green"
+                                            },
+                                            {
+                                                "value": 80,
+                                                "color": "red"
+                                            }
+                                        ]
+                                    },
+                                    "color": {
+                                        "mode": "palette-classic"
+                                    },
+                                    "custom": {
+                                        "axisBorderShow": false,
+                                        "axisCenteredZero": false,
+                                        "axisColorMode": "text",
+                                        "axisLabel": "",
+                                        "axisPlacement": "auto",
+                                        "barAlignment": 0,
+                                        "barWidthFactor": 0.6,
+                                        "drawStyle": "line",
+                                        "fillOpacity": 0,
+                                        "gradientMode": "none",
+                                        "hideFrom": {
+                                            "legend": false,
+                                            "tooltip": false,
+                                            "viz": false
+                                        },
+                                        "insertNulls": false,
+                                        "lineInterpolation": "linear",
+                                        "lineWidth": 1,
+                                        "pointSize": 0,
+                                        "scaleDistribution": {
+                                            "type": "linear"
+                                        },
+                                        "showPoints": "auto",
+                                        "showValues": false,
+                                        "spanNulls": false,
+                                        "stacking": {
+                                            "group": "A",
+                                            "mode": "none"
+                                        },
+                                        "thresholdsStyle": {
+                                            "mode": "off"
+                                        }
+                                    }
+                                },
+                                "overrides": []
+                            }
+                        }
+                    }
+                }
+            },
+            "panel-48": {
+                "kind": "Panel",
+                "spec": {
+                    "id": 48,
+                    "title": "RDMA Bandwith to AIC Storage",
+                    "description": "The RDMA transmit and receive bandwifth to and from the AIC storage backend.",
+                    "links": [],
+                    "data": {
+                        "kind": "QueryGroup",
+                        "spec": {
+                            "queries": [
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "local-prometheus"
+                                            },
+                                            "spec": {
+                                                "editorMode": "code",
+                                                "expr": "rate(rdma_port_rcv_data_total{device=\"rocep159s0\"}[$__rate_interval])",
+                                                "legendFormat": "Receive Bandwidth",
+                                                "range": true
+                                            }
+                                        },
+                                        "refId": "A",
+                                        "hidden": false
+                                    }
+                                },
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "local-prometheus"
+                                            },
+                                            "spec": {
+                                                "editorMode": "code",
+                                                "expr": "rate(rdma_port_xmit_data_total{device=\"rocep159s0\"}[$__rate_interval])",
+                                                "instant": false,
+                                                "legendFormat": "Transmit Bandwidth",
+                                                "range": true
+                                            }
+                                        },
+                                        "refId": "B",
+                                        "hidden": false
+                                    }
+                                }
+                            ],
+                            "transformations": [],
+                            "queryOptions": {}
+                        }
+                    },
+                    "vizConfig": {
+                        "kind": "VizConfig",
+                        "group": "timeseries",
+                        "version": "13.0.1",
+                        "spec": {
+                            "options": {
+                                "annotations": {
+                                    "clustering": -1,
+                                    "multiLane": false
+                                },
+                                "legend": {
+                                    "calcs": [
+                                        "min",
+                                        "mean",
+                                        "max",
+                                        "lastNotNull"
+                                    ],
+                                    "displayMode": "table",
+                                    "placement": "bottom",
+                                    "showLegend": true
+                                },
+                                "tooltip": {
+                                    "hideZeros": false,
+                                    "mode": "single",
+                                    "sort": "none"
+                                }
+                            },
+                            "fieldConfig": {
+                                "defaults": {
+                                    "unit": "binBps",
+                                    "min": 0,
+                                    "thresholds": {
+                                        "mode": "absolute",
+                                        "steps": [
+                                            {
+                                                "value": 0,
+                                                "color": "green"
+                                            },
+                                            {
+                                                "value": 80,
+                                                "color": "red"
+                                            }
+                                        ]
+                                    },
+                                    "color": {
+                                        "mode": "palette-classic"
+                                    },
+                                    "custom": {
+                                        "axisBorderShow": false,
+                                        "axisCenteredZero": false,
+                                        "axisColorMode": "text",
+                                        "axisLabel": "",
+                                        "axisPlacement": "auto",
+                                        "barAlignment": 0,
+                                        "barWidthFactor": 0.6,
+                                        "drawStyle": "line",
+                                        "fillOpacity": 0,
+                                        "gradientMode": "none",
+                                        "hideFrom": {
+                                            "legend": false,
+                                            "tooltip": false,
+                                            "viz": false
+                                        },
+                                        "insertNulls": false,
+                                        "lineInterpolation": "linear",
+                                        "lineWidth": 1,
+                                        "pointSize": 0,
+                                        "scaleDistribution": {
+                                            "type": "linear"
+                                        },
+                                        "showPoints": "auto",
+                                        "showValues": false,
+                                        "spanNulls": false,
+                                        "stacking": {
+                                            "group": "A",
+                                            "mode": "none"
+                                        },
+                                        "thresholdsStyle": {
+                                            "mode": "off"
+                                        }
+                                    }
+                                },
+                                "overrides": []
+                            }
+                        }
+                    }
+                }
+            },
+            "panel-49": {
+                "kind": "Panel",
+                "spec": {
+                    "id": 49,
+                    "title": "TPOT",
+                    "description": "Average time between output tokens",
+                    "links": [],
+                    "data": {
+                        "kind": "QueryGroup",
+                        "spec": {
+                            "queries": [
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "${datasource}"
+                                            },
+                                            "spec": {
+                                                "editorMode": "code",
+                                                "expr": "histogram_quantile(0.50, sum(rate(vllm:inter_token_latency_seconds_bucket{ }[$__rate_interval])) by (le, model_name))",
+                                                "legendFormat": "__auto",
+                                                "range": true
+                                            }
+                                        },
+                                        "refId": "A",
+                                        "hidden": false
+                                    }
+                                }
+                            ],
+                            "transformations": [],
+                            "queryOptions": {}
+                        }
+                    },
+                    "vizConfig": {
+                        "kind": "VizConfig",
+                        "group": "timeseries",
+                        "version": "13.0.1",
+                        "spec": {
+                            "options": {
+                                "annotations": {
+                                    "clustering": -1,
+                                    "multiLane": false
+                                },
+                                "legend": {
+                                    "calcs": [
+                                        "min",
+                                        "mean",
+                                        "max",
+                                        "lastNotNull"
+                                    ],
+                                    "displayMode": "table",
+                                    "placement": "bottom",
+                                    "showLegend": true
+                                },
+                                "tooltip": {
+                                    "hideZeros": false,
+                                    "mode": "single",
+                                    "sort": "none"
+                                }
+                            },
+                            "fieldConfig": {
+                                "defaults": {
+                                    "unit": "s",
+                                    "min": 0,
+                                    "thresholds": {
+                                        "mode": "absolute",
+                                        "steps": [
+                                            {
+                                                "value": 0,
+                                                "color": "green"
+                                            },
+                                            {
+                                                "value": 80,
+                                                "color": "red"
+                                            }
+                                        ]
+                                    },
+                                    "color": {
+                                        "mode": "palette-classic"
+                                    },
+                                    "custom": {
+                                        "axisBorderShow": false,
+                                        "axisCenteredZero": false,
+                                        "axisColorMode": "text",
+                                        "axisLabel": "",
+                                        "axisPlacement": "auto",
+                                        "barAlignment": 0,
+                                        "barWidthFactor": 0.6,
+                                        "drawStyle": "line",
+                                        "fillOpacity": 0,
+                                        "gradientMode": "none",
+                                        "hideFrom": {
+                                            "legend": false,
+                                            "tooltip": false,
+                                            "viz": false
+                                        },
+                                        "insertNulls": false,
+                                        "lineInterpolation": "linear",
+                                        "lineWidth": 1,
+                                        "pointSize": 0,
+                                        "scaleDistribution": {
+                                            "type": "linear"
+                                        },
+                                        "showPoints": "auto",
+                                        "showValues": false,
+                                        "spanNulls": false,
+                                        "stacking": {
+                                            "group": "A",
+                                            "mode": "none"
+                                        },
+                                        "thresholdsStyle": {
+                                            "mode": "off"
+                                        }
+                                    }
+                                },
+                                "overrides": []
+                            }
+                        }
+                    }
+                }
+            },
+            "panel-5": {
+                "kind": "Panel",
+                "spec": {
+                    "id": 5,
+                    "title": "vLLM - AIC Hit Ratio",
+                    "description": "External prefix cache (LMCache / KV connector) hit ratio from vllm:external_prefix_cache_* counters.",
+                    "links": [],
+                    "data": {
+                        "kind": "QueryGroup",
+                        "spec": {
+                            "queries": [
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "${datasource}"
+                                            },
+                                            "spec": {
+                                                "editorMode": "code",
+                                                "expr": "sum(rate(vllm:external_prefix_cache_hits_total{model_name=\"openai/gpt-oss-120b\"}[$__rate_interval])) by (instance)\n/ sum(rate(vllm:external_prefix_cache_queries_total{model_name=\"openai/gpt-oss-120b\"}[$__rate_interval])) by (instance)",
+                                                "legendFormat": "Hit Ratio",
+                                                "range": true
+                                            }
+                                        },
+                                        "refId": "A",
+                                        "hidden": false
+                                    }
+                                }
+                            ],
+                            "transformations": [],
+                            "queryOptions": {}
+                        }
+                    },
+                    "vizConfig": {
+                        "kind": "VizConfig",
+                        "group": "timeseries",
+                        "version": "13.0.1",
+                        "spec": {
+                            "options": {
+                                "annotations": {
+                                    "clustering": -1,
+                                    "multiLane": false
+                                },
+                                "legend": {
+                                    "calcs": [
+                                        "min",
+                                        "mean",
+                                        "max",
+                                        "lastNotNull"
+                                    ],
+                                    "displayMode": "table",
+                                    "placement": "bottom",
+                                    "showLegend": true
+                                },
+                                "tooltip": {
+                                    "hideZeros": false,
+                                    "mode": "multi",
+                                    "sort": "desc"
+                                }
+                            },
+                            "fieldConfig": {
+                                "defaults": {
+                                    "unit": "percentunit",
+                                    "min": 0,
+                                    "max": 1,
+                                    "thresholds": {
+                                        "mode": "absolute",
+                                        "steps": [
+                                            {
+                                                "value": 0,
+                                                "color": "green"
+                                            },
+                                            {
+                                                "value": 80,
+                                                "color": "red"
+                                            }
+                                        ]
+                                    },
+                                    "color": {
+                                        "mode": "palette-classic"
+                                    },
+                                    "custom": {
+                                        "axisBorderShow": false,
+                                        "axisCenteredZero": false,
+                                        "axisColorMode": "text",
+                                        "axisLabel": "",
+                                        "axisPlacement": "auto",
+                                        "barAlignment": 0,
+                                        "barWidthFactor": 0.6,
+                                        "drawStyle": "line",
+                                        "fillOpacity": 10,
+                                        "gradientMode": "none",
+                                        "hideFrom": {
+                                            "legend": false,
+                                            "tooltip": false,
+                                            "viz": false
+                                        },
+                                        "insertNulls": false,
+                                        "lineInterpolation": "smooth",
+                                        "lineWidth": 1,
+                                        "pointSize": 5,
+                                        "scaleDistribution": {
+                                            "type": "linear"
+                                        },
+                                        "showPoints": "never",
+                                        "showValues": false,
+                                        "spanNulls": false,
+                                        "stacking": {
+                                            "group": "A",
+                                            "mode": "none"
+                                        },
+                                        "thresholdsStyle": {
+                                            "mode": "off"
+                                        }
+                                    }
+                                },
+                                "overrides": []
+                            }
+                        }
+                    }
+                }
+            },
+            "panel-50": {
+                "kind": "Panel",
+                "spec": {
+                    "id": 50,
+                    "title": "Output Tokens per Second",
+                    "description": "The average output tokens per second.",
+                    "links": [],
+                    "data": {
+                        "kind": "QueryGroup",
+                        "spec": {
+                            "queries": [
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "local-prometheus"
+                                            },
+                                            "spec": {
+                                                "editorMode": "code",
+                                                "expr": "sum(rate(vllm:generation_tokens_total{ }[$__rate_interval])) by (instance, model_name)",
+                                                "legendFormat": "__auto",
+                                                "range": true
+                                            }
+                                        },
+                                        "refId": "A",
+                                        "hidden": false
+                                    }
+                                }
+                            ],
+                            "transformations": [],
+                            "queryOptions": {}
+                        }
+                    },
+                    "vizConfig": {
+                        "kind": "VizConfig",
+                        "group": "timeseries",
+                        "version": "13.0.1",
+                        "spec": {
+                            "options": {
+                                "annotations": {
+                                    "clustering": -1,
+                                    "multiLane": false
+                                },
+                                "legend": {
+                                    "calcs": [
+                                        "min",
+                                        "mean",
+                                        "max",
+                                        "lastNotNull"
+                                    ],
+                                    "displayMode": "table",
+                                    "placement": "bottom",
+                                    "showLegend": true
+                                },
+                                "tooltip": {
+                                    "hideZeros": false,
+                                    "mode": "single",
+                                    "sort": "none"
+                                }
+                            },
+                            "fieldConfig": {
+                                "defaults": {
+                                    "unit": "none",
+                                    "min": 0,
+                                    "thresholds": {
+                                        "mode": "absolute",
+                                        "steps": [
+                                            {
+                                                "value": 0,
+                                                "color": "green"
+                                            },
+                                            {
+                                                "value": 80,
+                                                "color": "red"
+                                            }
+                                        ]
+                                    },
+                                    "color": {
+                                        "mode": "palette-classic"
+                                    },
+                                    "custom": {
+                                        "axisBorderShow": false,
+                                        "axisCenteredZero": false,
+                                        "axisColorMode": "text",
+                                        "axisLabel": "",
+                                        "axisPlacement": "auto",
+                                        "barAlignment": 0,
+                                        "barWidthFactor": 0.6,
+                                        "drawStyle": "line",
+                                        "fillOpacity": 0,
+                                        "gradientMode": "none",
+                                        "hideFrom": {
+                                            "legend": false,
+                                            "tooltip": false,
+                                            "viz": false
+                                        },
+                                        "insertNulls": false,
+                                        "lineInterpolation": "linear",
+                                        "lineWidth": 1,
+                                        "pointSize": 0,
+                                        "scaleDistribution": {
+                                            "type": "linear"
+                                        },
+                                        "showPoints": "auto",
+                                        "showValues": false,
+                                        "spanNulls": false,
+                                        "stacking": {
+                                            "group": "A",
+                                            "mode": "none"
+                                        },
+                                        "thresholdsStyle": {
+                                            "mode": "off"
+                                        }
+                                    }
+                                },
+                                "overrides": []
+                            }
+                        }
+                    }
+                }
+            },
+            "panel-51": {
+                "kind": "Panel",
+                "spec": {
+                    "id": 51,
+                    "title": "NFS Server Bandwidth",
+                    "description": "The bandwidth of read and write traffic to/from the NFS mount(s) on a system.",
+                    "links": [],
+                    "data": {
+                        "kind": "QueryGroup",
+                        "spec": {
+                            "queries": [
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "local-prometheus"
+                                            },
+                                            "spec": {
+                                                "editorMode": "code",
+                                                "expr": "rate(node_nfsd_disk_bytes_read_total{ }[$__rate_interval])",
+                                                "legendFormat": "__auto",
+                                                "range": true
+                                            }
+                                        },
+                                        "refId": "A",
+                                        "hidden": false
+                                    }
+                                },
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "local-prometheus"
+                                            },
+                                            "spec": {
+                                                "editorMode": "code",
+                                                "expr": "rate(node_nfsd_disk_bytes_written_total{ }[$__rate_interval])",
+                                                "instant": false,
+                                                "legendFormat": "__auto",
+                                                "range": true
+                                            }
+                                        },
+                                        "refId": "B",
+                                        "hidden": false
+                                    }
+                                }
+                            ],
+                            "transformations": [],
+                            "queryOptions": {}
+                        }
+                    },
+                    "vizConfig": {
+                        "kind": "VizConfig",
+                        "group": "timeseries",
+                        "version": "13.0.1",
+                        "spec": {
+                            "options": {
+                                "annotations": {
+                                    "clustering": -1,
+                                    "multiLane": false
+                                },
+                                "legend": {
+                                    "calcs": [
+                                        "min",
+                                        "mean",
+                                        "max",
+                                        "lastNotNull"
+                                    ],
+                                    "displayMode": "table",
+                                    "placement": "bottom",
+                                    "showLegend": true
+                                },
+                                "tooltip": {
+                                    "hideZeros": false,
+                                    "mode": "single",
+                                    "sort": "none"
+                                }
+                            },
+                            "fieldConfig": {
+                                "defaults": {
+                                    "unit": "binBps",
+                                    "thresholds": {
+                                        "mode": "absolute",
+                                        "steps": [
+                                            {
+                                                "value": 0,
+                                                "color": "green"
+                                            },
+                                            {
+                                                "value": 80,
+                                                "color": "red"
+                                            }
+                                        ]
+                                    },
+                                    "color": {
+                                        "mode": "palette-classic"
+                                    },
+                                    "custom": {
+                                        "axisBorderShow": false,
+                                        "axisCenteredZero": false,
+                                        "axisColorMode": "text",
+                                        "axisLabel": "",
+                                        "axisPlacement": "auto",
+                                        "barAlignment": 0,
+                                        "barWidthFactor": 0.6,
+                                        "drawStyle": "line",
+                                        "fillOpacity": 0,
+                                        "gradientMode": "none",
+                                        "hideFrom": {
+                                            "legend": false,
+                                            "tooltip": false,
+                                            "viz": false
+                                        },
+                                        "insertNulls": false,
+                                        "lineInterpolation": "linear",
+                                        "lineWidth": 1,
+                                        "pointSize": 5,
+                                        "scaleDistribution": {
+                                            "type": "linear"
+                                        },
+                                        "showPoints": "auto",
+                                        "showValues": false,
+                                        "spanNulls": false,
+                                        "stacking": {
+                                            "group": "A",
+                                            "mode": "none"
+                                        },
+                                        "thresholdsStyle": {
+                                            "mode": "off"
+                                        }
+                                    }
+                                },
+                                "overrides": []
+                            }
+                        }
+                    }
+                }
+            },
+            "panel-52": {
+                "kind": "Panel",
+                "spec": {
+                    "id": 52,
+                    "title": "NFS Client Bandwidth",
+                    "description": "The NFS throughput as measured on the NFS client(s) via the nfsiostat tool.",
+                    "links": [],
+                    "data": {
+                        "kind": "QueryGroup",
+                        "spec": {
+                            "queries": [
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "local-prometheus"
+                                            },
+                                            "spec": {
+                                                "editorMode": "code",
+                                                "expr": "rate(rocm_aic_nfs_mount_rx_bytes_total{mount_point=\"/mnt/rocm-icms-cache\"}[$__rate_interval])",
+                                                "legendFormat": "__auto",
+                                                "range": true
+                                            }
+                                        },
+                                        "refId": "A",
+                                        "hidden": false
+                                    }
+                                },
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "local-prometheus"
+                                            },
+                                            "spec": {
+                                                "editorMode": "code",
+                                                "expr": "rate(rocm_aic_nfs_mount_tx_bytes_total{mount_point=\"/mnt/rocm-icms-cache\"}[$__rate_interval])",
+                                                "instant": false,
+                                                "legendFormat": "__auto",
+                                                "range": true
+                                            }
+                                        },
+                                        "refId": "B",
+                                        "hidden": false
+                                    }
+                                }
+                            ],
+                            "transformations": [],
+                            "queryOptions": {}
+                        }
+                    },
+                    "vizConfig": {
+                        "kind": "VizConfig",
+                        "group": "timeseries",
+                        "version": "13.0.1",
+                        "spec": {
+                            "options": {
+                                "annotations": {
+                                    "clustering": -1,
+                                    "multiLane": false
+                                },
+                                "legend": {
+                                    "calcs": [
+                                        "min",
+                                        "mean",
+                                        "max",
+                                        "lastNotNull"
+                                    ],
+                                    "displayMode": "table",
+                                    "placement": "bottom",
+                                    "showLegend": true,
+                                    "sortBy": "Name",
+                                    "sortDesc": true
+                                },
+                                "tooltip": {
+                                    "hideZeros": false,
+                                    "mode": "single",
+                                    "sort": "none"
+                                }
+                            },
+                            "fieldConfig": {
+                                "defaults": {
+                                    "unit": "Bps",
+                                    "min": 0,
+                                    "thresholds": {
+                                        "mode": "absolute",
+                                        "steps": [
+                                            {
+                                                "value": 0,
+                                                "color": "green"
+                                            },
+                                            {
+                                                "value": 80,
+                                                "color": "red"
+                                            }
+                                        ]
+                                    },
+                                    "color": {
+                                        "mode": "palette-classic"
+                                    },
+                                    "custom": {
+                                        "axisBorderShow": false,
+                                        "axisCenteredZero": false,
+                                        "axisColorMode": "text",
+                                        "axisLabel": "",
+                                        "axisPlacement": "auto",
+                                        "barAlignment": 0,
+                                        "barWidthFactor": 0.6,
+                                        "drawStyle": "line",
+                                        "fillOpacity": 0,
+                                        "gradientMode": "none",
+                                        "hideFrom": {
+                                            "legend": false,
+                                            "tooltip": false,
+                                            "viz": false
+                                        },
+                                        "insertNulls": false,
+                                        "lineInterpolation": "linear",
+                                        "lineWidth": 1,
+                                        "pointSize": 0,
+                                        "scaleDistribution": {
+                                            "type": "linear"
+                                        },
+                                        "showPoints": "auto",
+                                        "showValues": false,
+                                        "spanNulls": false,
+                                        "stacking": {
+                                            "group": "A",
+                                            "mode": "none"
+                                        },
+                                        "thresholdsStyle": {
+                                            "mode": "off"
+                                        }
+                                    }
+                                },
+                                "overrides": []
+                            }
+                        }
+                    }
+                }
+            },
+            "panel-53": {
+                "kind": "Panel",
+                "spec": {
+                    "id": 53,
+                    "title": "ROCm Version",
+                    "description": "The version of ROCm running on the given node(s).",
+                    "links": [],
+                    "data": {
+                        "kind": "QueryGroup",
+                        "spec": {
+                            "queries": [
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "local-prometheus"
+                                            },
+                                            "spec": {
+                                                "editorMode": "code",
+                                                "expr": "rocm_aic_rocm_version_info{ }",
+                                                "legendFormat": "__auto",
+                                                "range": true
+                                            }
+                                        },
+                                        "refId": "A",
+                                        "hidden": false
+                                    }
+                                }
+                            ],
+                            "transformations": [
+                                {
+                                    "kind": "Transformation",
+                                    "group": "labelsToFields",
+                                    "spec": {
+                                        "options": {
+                                            "keepLabels": [
+                                                "version",
+                                                "instance"
+                                            ],
+                                            "mode": "rows",
+                                            "valueLabel": "version"
+                                        }
+                                    }
+                                }
+                            ],
+                            "queryOptions": {}
+                        }
+                    },
+                    "vizConfig": {
+                        "kind": "VizConfig",
+                        "group": "table",
+                        "version": "13.0.1",
+                        "spec": {
+                            "options": {
+                                "cellHeight": "sm",
+                                "showHeader": true
+                            },
+                            "fieldConfig": {
+                                "defaults": {
+                                    "thresholds": {
+                                        "mode": "absolute",
+                                        "steps": [
+                                            {
+                                                "value": 0,
+                                                "color": "green"
+                                            },
+                                            {
+                                                "value": 80,
+                                                "color": "red"
+                                            }
+                                        ]
+                                    },
+                                    "color": {
+                                        "mode": "thresholds"
+                                    },
+                                    "custom": {
+                                        "align": "auto",
+                                        "cellOptions": {
+                                            "type": "auto"
+                                        },
+                                        "footer": {
+                                            "reducers": []
+                                        },
+                                        "inspect": false
+                                    }
+                                },
+                                "overrides": []
+                            }
+                        }
+                    }
+                }
+            },
+            "panel-54": {
+                "kind": "Panel",
+                "spec": {
+                    "id": 54,
+                    "title": "Online GPUs",
+                    "description": "The GPUs that are currently online across the cluster, broken out by server.",
+                    "links": [],
+                    "data": {
+                        "kind": "QueryGroup",
+                        "spec": {
+                            "queries": [
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "local-prometheus"
+                                            },
+                                            "spec": {
+                                                "editorMode": "code",
+                                                "expr": "count by (instance) (\r\n  amd_gpu_package_power{job=\"amd_metrics_exporter\"}\r\n)",
+                                                "legendFormat": "__auto",
+                                                "range": true
+                                            }
+                                        },
+                                        "refId": "A",
+                                        "hidden": false
+                                    }
+                                }
+                            ],
+                            "transformations": [],
+                            "queryOptions": {}
+                        }
+                    },
+                    "vizConfig": {
+                        "kind": "VizConfig",
+                        "group": "stat",
+                        "version": "13.0.1",
+                        "spec": {
+                            "options": {
+                                "colorMode": "value",
+                                "graphMode": "area",
+                                "justifyMode": "auto",
+                                "orientation": "auto",
+                                "percentChangeColorMode": "standard",
+                                "reduceOptions": {
+                                    "calcs": [
+                                        "lastNotNull"
+                                    ],
+                                    "fields": "",
+                                    "values": false
+                                },
+                                "showPercentChange": false,
+                                "textMode": "auto",
+                                "wideLayout": true
+                            },
+                            "fieldConfig": {
+                                "defaults": {
+                                    "unit": "none",
+                                    "min": 0,
+                                    "max": 8,
+                                    "thresholds": {
+                                        "mode": "absolute",
+                                        "steps": [
+                                            {
+                                                "value": 0,
+                                                "color": "green"
+                                            },
+                                            {
+                                                "value": 80,
+                                                "color": "red"
+                                            }
+                                        ]
+                                    },
+                                    "color": {
+                                        "mode": "thresholds"
+                                    }
+                                },
+                                "overrides": []
+                            }
+                        }
+                    }
+                }
+            },
+            "panel-6": {
+                "kind": "Panel",
+                "spec": {
+                    "id": 6,
+                    "title": "Time to First Token",
+                    "description": "Time-to-first-token latency from vllm:time_to_first_token_seconds_bucket; p50 and p99 quantiles over $__rate_interval.",
+                    "links": [],
+                    "data": {
+                        "kind": "QueryGroup",
+                        "spec": {
+                            "queries": [
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "local-prometheus"
+                                            },
+                                            "spec": {
+                                                "editorMode": "code",
+                                                "expr": "histogram_quantile(0.50, sum(rate(vllm:time_to_first_token_seconds_bucket{job=\"vllm-exporter\",instance=\"10.245.130.131:8000\"}[$__rate_interval])) by (le, instance, model_name))",
+                                                "legendFormat": "p50 TTFT",
+                                                "range": true
+                                            }
+                                        },
+                                        "refId": "A",
+                                        "hidden": false
+                                    }
+                                },
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "local-prometheus"
+                                            },
+                                            "spec": {
+                                                "editorMode": "code",
+                                                "expr": "histogram_quantile(0.90, sum(rate(vllm:time_to_first_token_seconds_bucket{job=\"vllm-exporter\",instance=\"10.245.130.131:8000\"}[$__rate_interval])) by (le, instance, model_name))",
+                                                "legendFormat": "p90 TTFT ",
+                                                "range": true
+                                            }
+                                        },
+                                        "refId": "B",
+                                        "hidden": false
+                                    }
+                                },
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "local-prometheus"
+                                            },
+                                            "spec": {
+                                                "editorMode": "code",
+                                                "expr": "histogram_quantile(0.99, sum(rate(vllm:time_to_first_token_seconds_bucket{job=\"vllm-exporter\",instance=\"10.245.130.131:8000\"}[$__rate_interval])) by (le, instance, model_name))",
+                                                "instant": false,
+                                                "legendFormat": "p99 TTFT",
+                                                "range": true
+                                            }
+                                        },
+                                        "refId": "C",
+                                        "hidden": false
+                                    }
+                                }
+                            ],
+                            "transformations": [],
+                            "queryOptions": {}
+                        }
+                    },
+                    "vizConfig": {
+                        "kind": "VizConfig",
+                        "group": "timeseries",
+                        "version": "13.0.1",
+                        "spec": {
+                            "options": {
+                                "annotations": {
+                                    "clustering": -1,
+                                    "multiLane": false
+                                },
+                                "legend": {
+                                    "calcs": [
+                                        "min",
+                                        "mean",
+                                        "max",
+                                        "lastNotNull"
+                                    ],
+                                    "displayMode": "table",
+                                    "placement": "bottom",
+                                    "showLegend": true
+                                },
+                                "tooltip": {
+                                    "hideZeros": false,
+                                    "mode": "multi",
+                                    "sort": "desc"
+                                }
+                            },
+                            "fieldConfig": {
+                                "defaults": {
+                                    "unit": "s",
+                                    "thresholds": {
+                                        "mode": "absolute",
+                                        "steps": [
+                                            {
+                                                "value": 0,
+                                                "color": "green"
+                                            },
+                                            {
+                                                "value": 80,
+                                                "color": "red"
+                                            }
+                                        ]
+                                    },
+                                    "color": {
+                                        "mode": "palette-classic"
+                                    },
+                                    "custom": {
+                                        "axisBorderShow": false,
+                                        "axisCenteredZero": false,
+                                        "axisColorMode": "text",
+                                        "axisLabel": "",
+                                        "axisPlacement": "auto",
+                                        "barAlignment": 0,
+                                        "barWidthFactor": 0.6,
+                                        "drawStyle": "line",
+                                        "fillOpacity": 10,
+                                        "gradientMode": "none",
+                                        "hideFrom": {
+                                            "legend": false,
+                                            "tooltip": false,
+                                            "viz": false
+                                        },
+                                        "insertNulls": false,
+                                        "lineInterpolation": "smooth",
+                                        "lineWidth": 1,
+                                        "pointSize": 5,
+                                        "scaleDistribution": {
+                                            "type": "linear"
+                                        },
+                                        "showPoints": "never",
+                                        "showValues": false,
+                                        "spanNulls": false,
+                                        "stacking": {
+                                            "group": "A",
+                                            "mode": "none"
+                                        },
+                                        "thresholdsStyle": {
+                                            "mode": "off"
+                                        }
+                                    }
+                                },
+                                "overrides": []
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "layout": {
+            "kind": "GridLayout",
+            "spec": {
+                "items": [
+                    {
+                        "kind": "GridLayoutItem",
+                        "spec": {
+                            "x": 0,
+                            "y": 0,
+                            "width": 6,
+                            "height": 6,
+                            "element": {
+                                "kind": "ElementReference",
+                                "name": "panel-54"
+                            }
+                        }
+                    },
+                    {
+                        "kind": "GridLayoutItem",
+                        "spec": {
+                            "x": 6,
+                            "y": 0,
+                            "width": 18,
+                            "height": 6,
+                            "element": {
+                                "kind": "ElementReference",
+                                "name": "panel-53"
+                            }
+                        }
+                    },
+                    {
+                        "kind": "GridLayoutItem",
+                        "spec": {
+                            "x": 0,
+                            "y": 6,
+                            "width": 8,
+                            "height": 13,
+                            "element": {
+                                "kind": "ElementReference",
+                                "name": "panel-32"
+                            }
+                        }
+                    },
+                    {
+                        "kind": "GridLayoutItem",
+                        "spec": {
+                            "x": 8,
+                            "y": 6,
+                            "width": 8,
+                            "height": 13,
+                            "element": {
+                                "kind": "ElementReference",
+                                "name": "panel-34"
+                            }
+                        }
+                    },
+                    {
+                        "kind": "GridLayoutItem",
+                        "spec": {
+                            "x": 16,
+                            "y": 6,
+                            "width": 8,
+                            "height": 13,
+                            "element": {
+                                "kind": "ElementReference",
+                                "name": "panel-31"
+                            }
+                        }
+                    },
+                    {
+                        "kind": "GridLayoutItem",
+                        "spec": {
+                            "x": 0,
+                            "y": 19,
+                            "width": 12,
+                            "height": 20,
+                            "element": {
+                                "kind": "ElementReference",
+                                "name": "panel-5"
+                            }
+                        }
+                    },
+                    {
+                        "kind": "GridLayoutItem",
+                        "spec": {
+                            "x": 12,
+                            "y": 19,
+                            "width": 12,
+                            "height": 20,
+                            "element": {
+                                "kind": "ElementReference",
+                                "name": "panel-43"
+                            }
+                        }
+                    },
+                    {
+                        "kind": "GridLayoutItem",
+                        "spec": {
+                            "x": 0,
+                            "y": 39,
+                            "width": 8,
+                            "height": 20,
+                            "element": {
+                                "kind": "ElementReference",
+                                "name": "panel-35"
+                            }
+                        }
+                    },
+                    {
+                        "kind": "GridLayoutItem",
+                        "spec": {
+                            "x": 8,
+                            "y": 39,
+                            "width": 8,
+                            "height": 20,
+                            "element": {
+                                "kind": "ElementReference",
+                                "name": "panel-6"
+                            }
+                        }
+                    },
+                    {
+                        "kind": "GridLayoutItem",
+                        "spec": {
+                            "x": 16,
+                            "y": 39,
+                            "width": 8,
+                            "height": 20,
+                            "element": {
+                                "kind": "ElementReference",
+                                "name": "panel-50"
+                            }
+                        }
+                    },
+                    {
+                        "kind": "GridLayoutItem",
+                        "spec": {
+                            "x": 0,
+                            "y": 59,
+                            "width": 8,
+                            "height": 14,
+                            "element": {
+                                "kind": "ElementReference",
+                                "name": "panel-48"
+                            }
+                        }
+                    },
+                    {
+                        "kind": "GridLayoutItem",
+                        "spec": {
+                            "x": 8,
+                            "y": 59,
+                            "width": 8,
+                            "height": 14,
+                            "element": {
+                                "kind": "ElementReference",
+                                "name": "panel-49"
+                            }
+                        }
+                    },
+                    {
+                        "kind": "GridLayoutItem",
+                        "spec": {
+                            "x": 16,
+                            "y": 59,
+                            "width": 8,
+                            "height": 14,
+                            "element": {
+                                "kind": "ElementReference",
+                                "name": "panel-47"
+                            }
+                        }
+                    },
+                    {
+                        "kind": "GridLayoutItem",
+                        "spec": {
+                            "x": 0,
+                            "y": 73,
+                            "width": 8,
+                            "height": 10,
+                            "element": {
+                                "kind": "ElementReference",
+                                "name": "panel-44"
+                            }
+                        }
+                    },
+                    {
+                        "kind": "GridLayoutItem",
+                        "spec": {
+                            "x": 8,
+                            "y": 73,
+                            "width": 8,
+                            "height": 10,
+                            "element": {
+                                "kind": "ElementReference",
+                                "name": "panel-52"
+                            }
+                        }
+                    },
+                    {
+                        "kind": "GridLayoutItem",
+                        "spec": {
+                            "x": 16,
+                            "y": 73,
+                            "width": 8,
+                            "height": 10,
+                            "element": {
+                                "kind": "ElementReference",
+                                "name": "panel-51"
+                            }
+                        }
+                    },
+                    {
+                        "kind": "GridLayoutItem",
+                        "spec": {
+                            "x": 0,
+                            "y": 83,
+                            "width": 12,
+                            "height": 10,
+                            "element": {
+                                "kind": "ElementReference",
+                                "name": "panel-46"
+                            }
+                        }
+                    },
+                    {
+                        "kind": "GridLayoutItem",
+                        "spec": {
+                            "x": 12,
+                            "y": 83,
+                            "width": 12,
+                            "height": 10,
+                            "element": {
+                                "kind": "ElementReference",
+                                "name": "panel-37"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "links": [],
+        "liveNow": false,
+        "preload": false,
+        "tags": [
+            "vllm",
+            "lmcache",
+            "prometheus",
+            "rocm-aic",
+            "node_exporter",
+            "nvme_exporter",
+            "amd_metrics_exporter"
+        ],
+        "timeSettings": {
+            "timezone": "browser",
+            "from": "now-24h",
+            "to": "now",
+            "autoRefresh": "auto",
+            "autoRefreshIntervals": [
+                "5s",
+                "10s",
+                "30s",
+                "1m",
+                "5m",
+                "15m",
+                "30m",
+                "1h",
+                "2h",
+                "1d"
+            ],
+            "hideTimepicker": false,
+            "fiscalYearStartMonth": 0
+        },
+        "title": "ROCm(tm) AMD Infinity Context Dashboard",
+        "variables": [
+            {
+                "kind": "DatasourceVariable",
+                "spec": {
+                    "name": "datasource",
+                    "pluginId": "prometheus",
+                    "refresh": "onDashboardLoad",
+                    "regex": "",
+                    "current": {
+                        "text": "Prometheus",
+                        "value": "local-prometheus"
+                    },
+                    "options": [],
+                    "multi": false,
+                    "includeAll": false,
+                    "label": "Data source",
+                    "hide": "hideVariable",
+                    "skipUrlSync": false,
+                    "allowCustomValue": false
+                }
+            },
+            {
+                "kind": "QueryVariable",
+                "spec": {
+                    "name": "instance",
+                    "current": {
+                        "text": [
+                            "g04u07"
+                        ],
+                        "value": [
+                            "g04u07"
+                        ]
+                    },
+                    "label": "Server Instance",
+                    "hide": "dontHide",
+                    "refresh": "onDashboardLoad",
+                    "skipUrlSync": false,
+                    "description": "The server instance (node) that you wish to display metrics for.",
+                    "query": {
+                        "kind": "DataQuery",
+                        "group": "prometheus",
+                        "version": "v0",
+                        "datasource": {
+                            "name": "local-prometheus"
+                        },
+                        "spec": {
+                            "qryType": 1,
+                            "query": "label_values(node_arp_entries,instance)",
+                            "refId": "PrometheusVariableQueryEditor-VariableQuery"
+                        }
+                    },
+                    "regex": "",
+                    "regexApplyTo": "value",
+                    "sort": "alphabeticalAsc",
+                    "definition": "label_values(node_arp_entries,instance)",
+                    "options": [],
+                    "multi": true,
+                    "includeAll": true,
+                    "allowCustomValue": false
+                }
+            },
+            {
+                "kind": "QueryVariable",
+                "spec": {
+                    "name": "model",
+                    "current": {
+                        "text": "Qwen/Qwen2.5-3B-Instruct",
+                        "value": "Qwen/Qwen2.5-3B-Instruct"
+                    },
+                    "label": "LLM Model",
+                    "hide": "dontHide",
+                    "refresh": "onDashboardLoad",
+                    "skipUrlSync": false,
+                    "description": "The LLM model in use. Note this is only appropriate for certain panels and metrics on this dashboard.",
+                    "query": {
+                        "kind": "DataQuery",
+                        "group": "prometheus",
+                        "version": "v0",
+                        "datasource": {
+                            "name": "local-prometheus"
+                        },
+                        "spec": {
+                            "qryType": 1,
+                            "query": "label_values(vllm:e2e_request_latency_seconds_bucket,model_name)",
+                            "refId": "PrometheusVariableQueryEditor-VariableQuery"
+                        }
+                    },
+                    "regex": "",
+                    "regexApplyTo": "value",
+                    "sort": "disabled",
+                    "definition": "label_values(vllm:e2e_request_latency_seconds_bucket,model_name)",
+                    "options": [],
+                    "multi": true,
+                    "includeAll": true,
+                    "allowCustomValue": false
+                }
+            },
+            {
+                "kind": "QueryVariable",
+                "spec": {
+                    "name": "blkdevice",
+                    "current": {
+                        "text": "dm-0",
+                        "value": "dm-0"
+                    },
+                    "label": "Block Device",
+                    "hide": "dontHide",
+                    "refresh": "onDashboardLoad",
+                    "skipUrlSync": false,
+                    "description": "The specific block device (or devices) you want to visualize in a certain panels.",
+                    "query": {
+                        "kind": "DataQuery",
+                        "group": "prometheus",
+                        "version": "v0",
+                        "datasource": {
+                            "name": "local-prometheus"
+                        },
+                        "spec": {
+                            "qryType": 1,
+                            "query": "label_values(node_disk_read_bytes_total,device)",
+                            "refId": "PrometheusVariableQueryEditor-VariableQuery"
+                        }
+                    },
+                    "regex": "",
+                    "regexApplyTo": "value",
+                    "sort": "alphabeticalAsc",
+                    "definition": "label_values(node_disk_read_bytes_total,device)",
+                    "options": [],
+                    "multi": true,
+                    "includeAll": true,
+                    "allowCustomValue": false
+                }
+            },
+            {
+                "kind": "QueryVariable",
+                "spec": {
+                    "name": "gpu_id",
+                    "current": {
+                        "text": "0",
+                        "value": "0"
+                    },
+                    "label": "GPU ID",
+                    "hide": "dontHide",
+                    "refresh": "onDashboardLoad",
+                    "skipUrlSync": false,
+                    "description": "The gpu_id as given by rocm-smi on the target node.",
+                    "query": {
+                        "kind": "DataQuery",
+                        "group": "prometheus",
+                        "version": "v0",
+                        "datasource": {
+                            "name": "local-prometheus"
+                        },
+                        "spec": {
+                            "qryType": 1,
+                            "query": "label_values(amd_gpu_power_usage,gpu_id)",
+                            "refId": "PrometheusVariableQueryEditor-VariableQuery"
+                        }
+                    },
+                    "regex": "",
+                    "regexApplyTo": "value",
+                    "sort": "disabled",
+                    "definition": "label_values(amd_gpu_power_usage,gpu_id)",
+                    "options": [],
+                    "multi": false,
+                    "includeAll": false,
+                    "allowCustomValue": false
+                }
+            }
+        ]
+    }
+}

--- a/recipies/vllm-radeon/grafana/vllm-lmcache-prometheus-mi300x-cluster.json
+++ b/recipies/vllm-radeon/grafana/vllm-lmcache-prometheus-mi300x-cluster.json
@@ -200,7 +200,7 @@
                 "spec": {
                     "id": 32,
                     "title": "GPU Activity",
-                    "description": "The activity factor of the CUs and UMC in the GPU. This is given as a percentage of total compute power avaliable.",
+                    "description": "The activity factor of the CUs and UMC in the GPU. This is given as a percentage of total compute power available.",
                     "links": [],
                     "data": {
                         "kind": "QueryGroup",
@@ -496,7 +496,7 @@
                                             },
                                             "spec": {
                                                 "editorMode": "code",
-                                                "expr": "sum(rate(node_disk_read_bytes_total{instance=\"g04u07\"}[$__rate_interval]))",
+                                                "expr": "sum(rate(node_disk_read_bytes_total{instance=~\"$instance\"}[$__rate_interval]))",
                                                 "fromExploreMetrics": false,
                                                 "legendFormat": "Read Bandwidth",
                                                 "range": true
@@ -518,7 +518,7 @@
                                             },
                                             "spec": {
                                                 "editorMode": "code",
-                                                "expr": "sum(rate(node_disk_written_bytes_total{instance=\"g04u07\"}[$__rate_interval]))",
+                                                "expr": "sum(rate(node_disk_written_bytes_total{instance=~\"$instance\"}[$__rate_interval]))",
                                                 "instant": false,
                                                 "legendFormat": "Write Bandwidth",
                                                 "range": true
@@ -921,7 +921,7 @@
                                         "axisBorderShow": false,
                                         "axisCenteredZero": false,
                                         "axisColorMode": "text",
-                                        "axisLabel": "Tokens/Secomd",
+                                        "axisLabel": "Tokens/Second",
                                         "axisPlacement": "auto",
                                         "barAlignment": 0,
                                         "barWidthFactor": 0.6,
@@ -1213,7 +1213,7 @@
                 "spec": {
                     "id": 47,
                     "title": "KV Cache Block Hit Statistics",
-                    "description": "Time-based statistics on the AIS KV Cache Blocks and the number of times they have been \"hit\" as in retrieved by the KV Block Manager.",
+                    "description": "Time-based statistics on the AIC KV Cache Blocks and the number of times they have been \"hit\" as in retrieved by the KV Block Manager.",
                     "links": [],
                     "data": {
                         "kind": "QueryGroup",
@@ -1357,8 +1357,8 @@
                 "kind": "Panel",
                 "spec": {
                     "id": 48,
-                    "title": "RDMA Bandwith to AIC Storage",
-                    "description": "The RDMA transmit and receive bandwifth to and from the AIC storage backend.",
+                    "title": "RDMA Bandwidth to AIC Storage",
+                    "description": "The RDMA transmit and receive bandwidth to and from the AIC storage backend.",
                     "links": [],
                     "data": {
                         "kind": "QueryGroup",

--- a/recipies/vllm-radeon/scripts/rocm-aic-exporter.py
+++ b/recipies/vllm-radeon/scripts/rocm-aic-exporter.py
@@ -282,6 +282,15 @@ def _empty_hip_stats() -> HipconfigStats:
     )
 
 
+def _skipped_hip_stats() -> HipconfigStats:
+    """PATH presence only; hipconfig not executed (--skip-hipconfig)."""
+    return HipconfigStats(
+        hipconfig_present=_hipconfig_path() is not None,
+        rocm_version="",
+        hipconfig_error="skipped",
+    )
+
+
 @dataclass(frozen=True)
 class ChunkHitSummary:
     data_root: Path
@@ -532,15 +541,7 @@ def collect_exporter_snapshot(
             hip=_empty_hip_stats(),
             host_metrics_collected=False,
         )
-    hip = (
-        collect_hipconfig_stats()
-        if collect_hip
-        else HipconfigStats(
-            hipconfig_present=False,
-            rocm_version="",
-            hipconfig_error="skipped",
-        )
-    )
+    hip = collect_hipconfig_stats() if collect_hip else _skipped_hip_stats()
     return ExporterSnapshot(
         chunk=chunk,
         nfs=collect_nfs_io_stats(
@@ -761,28 +762,29 @@ def format_prometheus_textfile(
         )
 
         hip = snapshot.hip
-        emit(
-            f"{_METRIC_PREFIX}_hipconfig_present",
-            "1 if hipconfig is installed on PATH, else 0.",
-            "gauge",
-            [
-                f"{_METRIC_PREFIX}_hipconfig_present{labels} "
-                f"{1 if hip.hipconfig_present else 0}"
-            ],
-        )
-        if hip.hipconfig_present and hip.rocm_version:
-            ver_lbl = _label_set(
-                {
-                    **(extra_labels or {}),
-                    "version": hip.rocm_version,
-                }
-            )
+        if hip.hipconfig_error != "skipped":
             emit(
-                f"{_METRIC_PREFIX}_rocm_version_info",
-                "ROCm/HIP stack version from hipconfig (gauge 1).",
+                f"{_METRIC_PREFIX}_hipconfig_present",
+                "1 if hipconfig is installed on PATH, else 0.",
                 "gauge",
-                [f"{_METRIC_PREFIX}_rocm_version_info{ver_lbl} 1"],
+                [
+                    f"{_METRIC_PREFIX}_hipconfig_present{labels} "
+                    f"{1 if hip.hipconfig_present else 0}"
+                ],
             )
+            if hip.hipconfig_present and hip.rocm_version:
+                ver_lbl = _label_set(
+                    {
+                        **(extra_labels or {}),
+                        "version": hip.rocm_version,
+                    }
+                )
+                emit(
+                    f"{_METRIC_PREFIX}_rocm_version_info",
+                    "ROCm/HIP stack version from hipconfig (gauge 1).",
+                    "gauge",
+                    [f"{_METRIC_PREFIX}_rocm_version_info{ver_lbl} 1"],
+                )
 
     lines.append(
         f"# {_METRIC_PREFIX} generated_at={int(time.time())} "
@@ -905,6 +907,10 @@ def _print_host_observability(snapshot: ExporterSnapshot) -> None:
 
     hip = snapshot.hip
     print("\nROCm / HIP (hipconfig)")
+    if hip.hipconfig_error == "skipped":
+        print("hipconfig collection skipped (--skip-hipconfig)")
+        print(f"hipconfig on PATH = {hip.hipconfig_present}")
+        return
     print(f"hipconfig present = {hip.hipconfig_present}")
     if hip.hipconfig_present:
         print(f"ROCm/HIP version = {hip.rocm_version or 'unknown'}")
@@ -1012,7 +1018,10 @@ def main() -> int:
     p.add_argument(
         "--skip-hipconfig",
         action="store_true",
-        help="Do not run hipconfig or emit ROCm version metrics.",
+        help=(
+            "Do not run hipconfig; omit hipconfig_present and rocm_version_info "
+            "from the textfile (PATH lookup still reported in JSON/CLI)."
+        ),
     )
     args = p.parse_args()
 

--- a/recipies/vllm-radeon/scripts/rocm-aic-exporter.py
+++ b/recipies/vllm-radeon/scripts/rocm-aic-exporter.py
@@ -5,10 +5,11 @@
 #
 """ROCm AIC Prometheus textfile exporter for vLLM + LMCache host stats.
 
-Currently exports LMCache KV inventory (per-model file counts and chunk
-bytes), filesystem free space on the data mount, and a **Hits per KV file**
-histogram from ``chunk_hashes_*.jsonl`` (on-disk ``.data`` files only;
-deleted chunks are excluded from the histogram universe).
+Exports LMCache KV inventory (per-model file counts and chunk bytes),
+filesystem free space on the data mount, a **Hits per KV file** histogram
+from ``chunk_hashes_*.jsonl`` (on-disk ``.data`` files only), NFS client
+byte totals per mount (via ``nfsiostat`` + ``/proc/self/mountstats``), and
+ROCm/HIP version from ``hipconfig``.
 
 Use ``--prometheus-textfile`` to write metrics for the node_exporter
 textfile collector (same pattern as ``rocm_icms_stack_versions.prom``).
@@ -22,6 +23,7 @@ import json
 import os
 import re
 import shutil
+import subprocess
 import sys
 import time
 from collections import Counter
@@ -38,6 +40,21 @@ _DATA_FILE_RE = re.compile(
 )
 
 _METRIC_PREFIX = "rocm_aic"
+_MOUNTSTATS_DEVICE_RE = re.compile(
+    r"^device\s+(.+?)\s+mounted on\s+(.+?)\s+with fstype\s+(\S+)",
+)
+_MOUNTSTATS_OP_RE = re.compile(r"^\s+([A-Z][A-Z0-9_]+):\s+(.+)$")
+_HIP_VERSION_RE = re.compile(
+    r"^HIP\s+version:\s*(\S+)",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def _is_nfs_client_fstype(fstype: str) -> bool:
+    fs = fstype.lower()
+    if fs == "nfsd":
+        return False
+    return fs.startswith("nfs")
 
 
 def _norm_jsonl_hash(raw: str) -> str:
@@ -213,6 +230,59 @@ def kv_block_hit_histogram(
 
 
 @dataclass(frozen=True)
+class NfsMountBytes:
+    """Cumulative NFS client bytes for one mount (from mountstats)."""
+
+    mount_point: str
+    rx_bytes: int
+    tx_bytes: int
+
+
+@dataclass(frozen=True)
+class NfsIoStats:
+    """NFS observability: ``nfsiostat`` presence and per-mount byte totals."""
+
+    nfsiostat_present: bool
+    mounts: tuple[NfsMountBytes, ...]
+    mountstats_path: Path
+    nfsiostat_error: str | None = None
+
+
+@dataclass(frozen=True)
+class HipconfigStats:
+    """ROCm/HIP version from ``hipconfig``."""
+
+    hipconfig_present: bool
+    rocm_version: str
+    hipconfig_error: str | None = None
+
+
+@dataclass(frozen=True)
+class ExporterSnapshot:
+    chunk: ChunkHitSummary
+    nfs: NfsIoStats
+    hip: HipconfigStats
+    host_metrics_collected: bool = False
+
+
+def _empty_nfs_stats(mountstats_path: Path) -> NfsIoStats:
+    return NfsIoStats(
+        nfsiostat_present=False,
+        mounts=(),
+        mountstats_path=mountstats_path,
+        nfsiostat_error=None,
+    )
+
+
+def _empty_hip_stats() -> HipconfigStats:
+    return HipconfigStats(
+        hipconfig_present=False,
+        rocm_version="",
+        hipconfig_error=None,
+    )
+
+
+@dataclass(frozen=True)
 class ChunkHitSummary:
     data_root: Path
     kv_dir: Path
@@ -275,6 +345,213 @@ def collect_chunk_hit_summary(
     )
 
 
+def _nfsiostat_path() -> str | None:
+    return shutil.which("nfsiostat")
+
+
+def _hipconfig_path() -> str | None:
+    return shutil.which("hipconfig")
+
+
+def _invoke_nfsiostat(*, interval: int = 1, count: int = 1) -> str | None:
+    """Run ``nfsiostat`` once; return an error string on failure."""
+    bin_path = _nfsiostat_path()
+    if not bin_path:
+        return "nfsiostat not found in PATH"
+    try:
+        proc = subprocess.run(
+            [bin_path, str(interval), str(count)],
+            capture_output=True,
+            text=True,
+            timeout=max(30, interval * count + 15),
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return str(exc)
+    if proc.returncode != 0:
+        err = (proc.stderr or proc.stdout or "").strip()
+        return err or f"nfsiostat exited {proc.returncode}"
+    return None
+
+
+def _parse_mountstats_nfs(path: Path) -> list[NfsMountBytes]:
+    """Parse cumulative NFS client bytes per mount from mountstats.
+
+    Per-op lines follow the kernel layout documented in
+    Documentation/filesystems/nfs/nfs-stats.txt (bytes_sent, bytes_recv).
+    """
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+
+    mounts: list[NfsMountBytes] = []
+    current_mount: str | None = None
+    current_fstype: str | None = None
+    rx = 0
+    tx = 0
+
+    def flush() -> None:
+        nonlocal current_mount, current_fstype, rx, tx
+        if current_mount is None or current_fstype is None:
+            return
+        if not _is_nfs_client_fstype(current_fstype):
+            return
+        mounts.append(
+            NfsMountBytes(
+                mount_point=current_mount,
+                rx_bytes=rx,
+                tx_bytes=tx,
+            )
+        )
+
+    for raw in text.splitlines():
+        dev = _MOUNTSTATS_DEVICE_RE.match(raw)
+        if dev is not None:
+            flush()
+            current_mount = dev.group(2)
+            current_fstype = dev.group(3)
+            rx = 0
+            tx = 0
+            continue
+        if current_mount is None:
+            continue
+        op = _MOUNTSTATS_OP_RE.match(raw)
+        if op is None:
+            continue
+        fields = op.group(2).split()
+        if len(fields) < 5:
+            continue
+        try:
+            bytes_sent = int(fields[3])
+            bytes_recv = int(fields[4])
+        except ValueError:
+            continue
+        tx += bytes_sent
+        rx += bytes_recv
+
+    flush()
+    mounts.sort(key=lambda m: m.mount_point)
+    return mounts
+
+
+def collect_nfs_io_stats(
+    *,
+    mountstats_path: Path | None = None,
+    run_nfsiostat: bool = True,
+) -> NfsIoStats:
+    """Collect NFS byte totals; call ``nfsiostat`` when the binary exists."""
+    mpath = mountstats_path or Path("/proc/self/mountstats")
+    present = _nfsiostat_path() is not None
+    nfs_err: str | None = None
+    if present and run_nfsiostat:
+        nfs_err = _invoke_nfsiostat()
+    mounts = tuple(_parse_mountstats_nfs(mpath)) if mpath.is_file() else ()
+    return NfsIoStats(
+        nfsiostat_present=present,
+        mounts=mounts,
+        mountstats_path=mpath,
+        nfsiostat_error=nfs_err,
+    )
+
+
+def _parse_hipconfig_version(text: str) -> str:
+    m = _HIP_VERSION_RE.search(text)
+    if m:
+        return m.group(1).strip()
+    for line in text.splitlines():
+        line = line.strip()
+        if line.lower().startswith("rocm version"):
+            parts = line.split(":", 1)
+            if len(parts) == 2 and parts[1].strip():
+                return parts[1].strip()
+    return ""
+
+
+def collect_hipconfig_stats() -> HipconfigStats:
+    """Run ``hipconfig`` and parse the HIP/ROCm version string."""
+    bin_path = _hipconfig_path()
+    if not bin_path:
+        return HipconfigStats(
+            hipconfig_present=False,
+            rocm_version="",
+            hipconfig_error="hipconfig not found in PATH",
+        )
+    try:
+        proc = subprocess.run(
+            [bin_path],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return HipconfigStats(
+            hipconfig_present=True,
+            rocm_version="",
+            hipconfig_error=str(exc),
+        )
+    combined = (proc.stdout or "") + "\n" + (proc.stderr or "")
+    version = _parse_hipconfig_version(combined)
+    err: str | None = None
+    if proc.returncode != 0:
+        err = (proc.stderr or proc.stdout or "").strip() or (
+            f"hipconfig exited {proc.returncode}"
+        )
+    elif not version:
+        err = "hipconfig output did not contain HIP version"
+        version = "unknown"
+    return HipconfigStats(
+        hipconfig_present=True,
+        rocm_version=version,
+        hipconfig_error=err,
+    )
+
+
+def collect_exporter_snapshot(
+    *,
+    data_root: Path,
+    kv_subdir: str = "lmcache",
+    stats_subdir: str = "lmcache_chunk_stats",
+    mountstats_path: Path | None = None,
+    run_nfsiostat: bool = True,
+    collect_hip: bool = True,
+    include_host_metrics: bool = False,
+) -> ExporterSnapshot:
+    """Collect LMCache stats; NFS/hip only when ``include_host_metrics``."""
+    mpath = mountstats_path or Path("/proc/self/mountstats")
+    chunk = collect_chunk_hit_summary(
+        data_root=data_root,
+        kv_subdir=kv_subdir,
+        stats_subdir=stats_subdir,
+    )
+    if not include_host_metrics:
+        return ExporterSnapshot(
+            chunk=chunk,
+            nfs=_empty_nfs_stats(mpath),
+            hip=_empty_hip_stats(),
+            host_metrics_collected=False,
+        )
+    hip = (
+        collect_hipconfig_stats()
+        if collect_hip
+        else HipconfigStats(
+            hipconfig_present=False,
+            rocm_version="",
+            hipconfig_error="skipped",
+        )
+    )
+    return ExporterSnapshot(
+        chunk=chunk,
+        nfs=collect_nfs_io_stats(
+            mountstats_path=mpath,
+            run_nfsiostat=run_nfsiostat,
+        ),
+        hip=hip,
+        host_metrics_collected=True,
+    )
+
+
 def _prom_label_escape(value: str) -> str:
     return value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "")
 
@@ -291,11 +568,17 @@ def _label_set(extra: dict[str, str] | None) -> str:
 
 
 def format_prometheus_textfile(
-    summary: ChunkHitSummary,
+    snapshot: ExporterSnapshot,
     *,
     extra_labels: dict[str, str] | None = None,
+    include_host_metrics: bool = False,
 ) -> str:
-    """Exposition text for node_exporter ``collector.textfile.directory``."""
+    """Exposition text for node_exporter ``collector.textfile.directory``.
+
+    NFS and hipconfig series are included only when
+    ``include_host_metrics`` is true (set when ``--prometheus-textfile`` runs).
+    """
+    summary = snapshot.chunk
     labels = _label_set(extra_labels)
     hist = summary.kv_block_hit_histogram
     lines: list[str] = []
@@ -441,6 +724,66 @@ def format_prometheus_textfile(
         bucket_lines,
     )
 
+    if include_host_metrics:
+        nfs = snapshot.nfs
+        emit(
+            f"{_METRIC_PREFIX}_nfsiostat_present",
+            "1 if nfsiostat is installed on PATH, else 0.",
+            "gauge",
+            [
+                f"{_METRIC_PREFIX}_nfsiostat_present{labels} "
+                f"{1 if nfs.nfsiostat_present else 0}"
+            ],
+        )
+        rx_lines = [
+            f"{_METRIC_PREFIX}_nfs_mount_rx_bytes_total"
+            f"{_label_set({**(extra_labels or {}), 'mount_point': m.mount_point})} "
+            f"{m.rx_bytes}"
+            for m in nfs.mounts
+        ]
+        emit(
+            f"{_METRIC_PREFIX}_nfs_mount_rx_bytes_total",
+            "Cumulative NFS client bytes received (sum of per-op bytes_recv).",
+            "counter",
+            rx_lines,
+        )
+        tx_lines = [
+            f"{_METRIC_PREFIX}_nfs_mount_tx_bytes_total"
+            f"{_label_set({**(extra_labels or {}), 'mount_point': m.mount_point})} "
+            f"{m.tx_bytes}"
+            for m in nfs.mounts
+        ]
+        emit(
+            f"{_METRIC_PREFIX}_nfs_mount_tx_bytes_total",
+            "Cumulative NFS client bytes sent (sum of per-op bytes_sent).",
+            "counter",
+            tx_lines,
+        )
+
+        hip = snapshot.hip
+        emit(
+            f"{_METRIC_PREFIX}_hipconfig_present",
+            "1 if hipconfig is installed on PATH, else 0.",
+            "gauge",
+            [
+                f"{_METRIC_PREFIX}_hipconfig_present{labels} "
+                f"{1 if hip.hipconfig_present else 0}"
+            ],
+        )
+        if hip.hipconfig_present and hip.rocm_version:
+            ver_lbl = _label_set(
+                {
+                    **(extra_labels or {}),
+                    "version": hip.rocm_version,
+                }
+            )
+            emit(
+                f"{_METRIC_PREFIX}_rocm_version_info",
+                "ROCm/HIP stack version from hipconfig (gauge 1).",
+                "gauge",
+                [f"{_METRIC_PREFIX}_rocm_version_info{ver_lbl} 1"],
+            )
+
     lines.append(
         f"# {_METRIC_PREFIX} generated_at={int(time.time())} "
         f"data_root={summary.data_root}"
@@ -541,6 +884,34 @@ def _print_histogram(summary: ChunkHitSummary) -> None:
     print(f"{tail_label:<{label_w}}{ov_sum:>{cnt_w}d}")
 
 
+def _print_host_observability(snapshot: ExporterSnapshot) -> None:
+    nfs = snapshot.nfs
+    print("\nNFS client stats (mountstats)")
+    print(f"nfsiostat present = {nfs.nfsiostat_present}")
+    if nfs.nfsiostat_error:
+        print(f"nfsiostat run note = {nfs.nfsiostat_error}")
+    print(f"mountstats = {nfs.mountstats_path}")
+    if not nfs.mounts:
+        print("No NFS mounts in mountstats.")
+    else:
+        print(f"{'Mount':<32} {'RX':>16} {'TX':>16}")
+        print("-" * 66)
+        for m in nfs.mounts:
+            print(
+                f"{m.mount_point:<32} "
+                f"{_format_bytes(m.rx_bytes):>16} "
+                f"{_format_bytes(m.tx_bytes):>16}"
+            )
+
+    hip = snapshot.hip
+    print("\nROCm / HIP (hipconfig)")
+    print(f"hipconfig present = {hip.hipconfig_present}")
+    if hip.hipconfig_present:
+        print(f"ROCm/HIP version = {hip.rocm_version or 'unknown'}")
+    if hip.hipconfig_error:
+        print(f"hipconfig note = {hip.hipconfig_error}")
+
+
 def _default_data_root(recipe_root: Path) -> Path:
     host = os.environ.get("RADEON_HOST_DATA_ROOT", "").strip()
     if host:
@@ -627,6 +998,22 @@ def main() -> int:
         action="store_true",
         help="Print JSON summary (stdout).",
     )
+    p.add_argument(
+        "--mountstats-path",
+        type=Path,
+        default=Path("/proc/self/mountstats"),
+        help="NFS mountstats file (default: /proc/self/mountstats).",
+    )
+    p.add_argument(
+        "--skip-nfsiostat-invoke",
+        action="store_true",
+        help="Do not run nfsiostat; still parse mountstats if readable.",
+    )
+    p.add_argument(
+        "--skip-hipconfig",
+        action="store_true",
+        help="Do not run hipconfig or emit ROCm version metrics.",
+    )
     args = p.parse_args()
 
     extra_labels: dict[str, str] = {}
@@ -645,11 +1032,17 @@ def main() -> int:
         )
         return 1
 
-    summary = collect_chunk_hit_summary(
+    prom_path = args.prometheus_textfile
+    snapshot = collect_exporter_snapshot(
         data_root=data_root,
         kv_subdir=args.kv_subdir,
         stats_subdir=args.stats_subdir,
+        mountstats_path=args.mountstats_path,
+        run_nfsiostat=not args.skip_nfsiostat_invoke,
+        collect_hip=not args.skip_hipconfig,
+        include_host_metrics=prom_path is not None,
     )
+    summary = snapshot.chunk
 
     if summary.disk_file_count == 0:
         print(
@@ -682,9 +1075,33 @@ def main() -> int:
             file=sys.stderr,
         )
 
-    prom_path = args.prometheus_textfile
+    if prom_path is not None and snapshot.host_metrics_collected:
+        if not snapshot.nfs.nfsiostat_present:
+            print(
+                "warning: nfsiostat not found; nfs byte metrics use "
+                "mountstats only",
+                file=sys.stderr,
+            )
+        elif snapshot.nfs.nfsiostat_error:
+            print(
+                f"warning: nfsiostat: {snapshot.nfs.nfsiostat_error}",
+                file=sys.stderr,
+            )
+        if not args.skip_hipconfig:
+            if not snapshot.hip.hipconfig_present:
+                print("warning: hipconfig not found in PATH", file=sys.stderr)
+            elif snapshot.hip.hipconfig_error:
+                print(
+                    f"warning: hipconfig: {snapshot.hip.hipconfig_error}",
+                    file=sys.stderr,
+                )
+
     if prom_path is not None:
-        body = format_prometheus_textfile(summary, extra_labels=extra_labels or None)
+        body = format_prometheus_textfile(
+            snapshot,
+            extra_labels=extra_labels or None,
+            include_host_metrics=True,
+        )
         write_prometheus_textfile(prom_path, body)
         print(f"wrote {prom_path}", file=sys.stderr)
 
@@ -715,6 +1132,33 @@ def main() -> int:
                         else None
                     ),
                     "prometheus_textfile": str(prom_path) if prom_path else None,
+                    "host_metrics_collected": snapshot.host_metrics_collected,
+                    "nfs": (
+                        {
+                            "nfsiostat_present": snapshot.nfs.nfsiostat_present,
+                            "mountstats_path": str(snapshot.nfs.mountstats_path),
+                            "nfsiostat_error": snapshot.nfs.nfsiostat_error,
+                            "mounts": [
+                                {
+                                    "mount_point": m.mount_point,
+                                    "rx_bytes": m.rx_bytes,
+                                    "tx_bytes": m.tx_bytes,
+                                }
+                                for m in snapshot.nfs.mounts
+                            ],
+                        }
+                        if snapshot.host_metrics_collected
+                        else None
+                    ),
+                    "hipconfig": (
+                        {
+                            "hipconfig_present": snapshot.hip.hipconfig_present,
+                            "rocm_version": snapshot.hip.rocm_version,
+                            "hipconfig_error": snapshot.hip.hipconfig_error,
+                        }
+                        if snapshot.host_metrics_collected
+                        else None
+                    ),
                 },
                 indent=2,
             )
@@ -727,6 +1171,8 @@ def main() -> int:
             flush=True,
         )
         _print_histogram(summary)
+        if snapshot.host_metrics_collected:
+            _print_host_observability(snapshot)
         if args.top > 0:
             disk = _scan_disk_kv_files(summary.kv_dir)
             hits, _, _ = _load_hit_counts(

--- a/recipies/vllm-radeon/tests/fixtures/mountstats-nfs.sample
+++ b/recipies/vllm-radeon/tests/fixtures/mountstats-nfs.sample
@@ -1,0 +1,10 @@
+device 10.0.0.1:/export mounted on /mnt/nfs-data with fstype nfs4 statvers=1.1
+	opts:	vers=4.1
+	age:	100
+	bytes:	1000 0 0 0 0 0 0 0
+	RPC iostats version: 1.1  p/v: 100003/4 (nfs)
+	        READ: 10 10 0 500 9000 0 0 0 0
+	       WRITE: 5 5 0 3000 100 0 0 0 0
+device /dev/sda1 mounted on / with fstype ext4
+	bytes:	0 0 0 0 0 0 0 0
+	        READ: 1 1 0 10 20 0 0 0 0


### PR DESCRIPTION
rocm-aic-exporter: when --prometheus-textfile is set, collect NFS client RX/TX byte counters per mount_point from /proc/self/mountstats (after nfsiostat when installed), emit rocm_aic_nfsiostat_present, and report ROCm/HIP version via hipconfig with rocm_aic_hipconfig_present and rocm_aic_rocm_version_info. Skip nfsd mounts; do not run nfsiostat or hipconfig on interactive-only runs. Add mountstats fixture and CI checks.

Monitoring: deploy /etc/default/prometheus from Ansible so --web.enable-remote-write-receiver is enabled on the monitoring server; document in monitoring playbook and group_vars. Add Grafana dashboard vllm-lmcache-prometheus-mi300x-cluster.json for MI300X cluster views.

Slurm: add run-slurm.sh helper to submit vllm-from-kurt-mi300 jobs.
.gitignore: ignore .slurm/logs/ and .slurm/reports/.

