### PR TITLE
Add vllm-atom-andy recipe for ATOM + LMCache on MI300X.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 .venv
 __pycache__
 
+# VSCode related
+.vscode/
+
 # Large archives
 vendors/weka/weka-drops/*.tar
 vendors/weka/weka-drops/*.squashfs
@@ -55,6 +58,7 @@ recipies/vllm-lmcache-hipfile/logs/
 recipies/vllm-lmcache-hipfile/data/
 recipies/vllm-lmcache-nixl/data/
 recipies/vllm-lmcache-nixl/logs/
+recipies/vllm-atom-andy/logs/
 
 # benchmark logs and reports
 benchmarks/ttft-lmcache/logs/

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -346,7 +346,6 @@ Luo
 Luo's
 MiniMax
 FP
-entrypoint
 SLO
 PyPI
 GMU

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -340,3 +340,14 @@ NixlStorageBackend
 OOM
 timeseries
 tm
+andy
+AiTer
+Luo
+Luo's
+MiniMax
+FP
+entrypoint
+SLO
+PyPI
+GMU
+callanjfox

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ need only `openai` unless you use the full tool stack.
 | vLLM + LMCache hipfile recipe | [recipies/vllm-lmcache-hipfile][r-vr] | [README][r-vr] |
 | Grafana dashboards | [grafana/][grafana-dir] | [README][grafana-readme] |
 | vLLM + LMCache NIXL recipe | [recipies/vllm-lmcache-nixl][r-vn] | [README][r-vn] |
+| vLLM + ATOM + LMCache (Andy blog) | [recipies/vllm-atom-andy][r-vaa] | [README][r-vaa] |
 | LMCache patch index | [recipies/vllm-lmcache-hipfile/patches][r-patches] | [README][r-patches] |
 | ROCm inference stack image | [recipies/rocm-inference-stack][r-ris] | [README][r-ris] |
 | LMCache IO simulator | [tools/lmcache-io-tester][t-lit] | [README][t-lit-readme] |
@@ -163,6 +164,7 @@ rocm-icms/
 [grafana-dir]: grafana/
 [grafana-readme]: grafana/README.md
 [r-vn]: recipies/vllm-lmcache-nixl/
+[r-vaa]: recipies/vllm-atom-andy/
 [r-patches]: recipies/vllm-lmcache-hipfile/patches/README.md
 [r-ris]: recipies/rocm-inference-stack/README.md
 [t-lit]: tools/lmcache-io-tester/

--- a/recipies/vllm-atom-andy/Dockerfile
+++ b/recipies/vllm-atom-andy/Dockerfile
@@ -1,0 +1,75 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+
+# ATOM + vLLM + ROCm 7.2.x (Andy Luo ATOM+LMCache blog, May 2026).
+# Pinned base — do not use vllm-latest (moving tag).
+# Tag:  rocm/atom-dev:vllm-v0.19.0-nightly_20260522 (published 2026-05-22)
+# Digest from Docker Hub API 2026-06-02; override: make build ATOM_DEV_DIGEST=sha256:...
+ARG ATOM_DEV_DIGEST=sha256:c7e019b4872efe85557097731e863207189aaaa80ce8071c534565b20d03a509
+FROM rocm/atom-dev@${ATOM_DEV_DIGEST}
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+ARG ROCM_ARCH
+RUN test -n "$ROCM_ARCH" || (echo "ERROR: ROCM_ARCH is not set" && exit 1)
+
+ARG LMCACHE_SHA=92fe433ac8e21baf33d9a1b5dda835e1e56c53dd
+ARG LMCACHE_CACHE_SALT_PATCH=lmcache-pr-3008-cache-salt.patch
+
+RUN apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates \
+        cmake \
+        git \
+        libboost-all-dev \
+        libmount-dev \
+        ninja-build \
+        pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+# Use atom-dev venv explicitly; do not `pip install --upgrade pip` (can break pins).
+
+COPY recipies/vllm-lmcache-hipfile/patches/lmcache-pr-3008-cache-salt.patch \
+    recipies/vllm-atom-andy/requirements-lmcache-runtime.txt \
+    /app/patches/
+
+RUN cd /app && \
+    git clone https://github.com/riley-dixon/LMCache.git && \
+    cd LMCache && \
+    git checkout "${LMCACHE_SHA}" && \
+    git apply "/app/patches/${LMCACHE_CACHE_SALT_PATCH}" && \
+    PYTORCH_ROCM_ARCH=${ROCM_ARCH} \
+        TORCH_DONT_CHECK_COMPILER_ABI=1 \
+        CXX=hipcc \
+        BUILD_WITH_HIP=1 \
+        /opt/venv/bin/pip install --no-build-isolation --no-cache-dir -e . --no-deps && \
+    /opt/venv/bin/pip install --no-cache-dir -r /app/patches/requirements-lmcache-runtime.txt
+
+RUN python3 <<'PY'
+from pathlib import Path
+
+p = Path("/app/LMCache/benchmarks/long_doc_qa/long_doc_qa.py")
+if p.is_file():
+    text = p.read_text(encoding="utf-8")
+    needle = "before averaging. Example: 0.1 drops bottom 10% and top 10%."
+    if needle in text:
+        p.write_text(text.replace(needle, needle.replace("%", "%%"), 1), encoding="utf-8")
+PY
+
+RUN mkdir -p /app/configs /app/scripts
+
+COPY recipies/vllm-atom-andy/scripts/ /app/scripts/
+COPY recipies/vllm-atom-andy/configs/ /app/configs/
+
+# Guard: LMCache must not upgrade atom-dev's ROCm PyTorch; c_ops .so must exist.
+RUN /opt/venv/bin/python /app/scripts/verify-lmcache-hip.py
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONHASHSEED=0 \
+    LD_LIBRARY_PATH=/opt/venv/lib/python3.12/site-packages/torch/lib:/opt/rocm/lib \
+    PATH=/opt/venv/bin:/opt/rocm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+ENTRYPOINT ["python3", "/app/scripts/vllm-server"]

--- a/recipies/vllm-atom-andy/Makefile
+++ b/recipies/vllm-atom-andy/Makefile
@@ -1,0 +1,159 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+
+REPO_ROOT := $(abspath $(CURDIR)/../..)
+IMAGE_NAME ?= vllm-atom-andy
+GPU ?= 0
+CONTAINER_NAME ?= $(IMAGE_NAME)-gpu$(GPU)
+DATA ?= /mnt/lmcache-nvme
+LOG ?= $(CURDIR)/logs
+HF_HOME ?= $(HOME)/.cache/huggingface
+HF_TOKEN_FILE ?=
+CONTAINER_HF_HOME ?= /hf
+CONTAINER_DATA_DIR ?= /data
+CONTAINER_LOG_DIR ?= /var/log/vllm-atom-andy
+TZ ?= America/Edmonton
+VAA_LMCACHE_TIER ?= cpu
+VAA_LMCACHE_LOG_LEVEL ?=
+VAA_TENSOR_PARALLEL_SIZE ?=
+VAA_GPU_MEMORY_UTILIZATION ?=
+VAA_MAX_MODEL_LEN ?=
+VAA_MAX_NUM_BATCHED_TOKENS ?=
+VAA_LMCACHE_MAX_LOCAL_CPU_SIZE ?=
+VAA_MODEL_PROFILE ?=
+VLLM_SERVER_DEV_MODE ?= 1
+VLLM_MODEL ?=
+ARGS ?=
+EXTRA_DOCKER_RUN_FLAGS ?=
+DOCKER_RUN_ATTACH ?= -it
+
+# rocm/atom-dev:vllm-v0.19.0-nightly_20260522 (Andy blog era; not vllm-latest)
+ATOM_DEV_DIGEST ?= sha256:c7e019b4872efe85557097731e863207189aaaa80ce8071c534565b20d03a509
+
+_ROCM_ARCH_DETECTED := $(shell rocm_agent_enumerator 2>/dev/null | \
+	grep -E '^gfx' | head -1)
+ROCM_ARCH := $(if $(strip $(ROCM_ARCH)),$(strip $(ROCM_ARCH)),$(_ROCM_ARCH_DETECTED))
+
+BUILD_ARGS := --build-arg ROCM_ARCH=$(ROCM_ARCH)
+ifneq ($(strip $(ATOM_DEV_DIGEST)),)
+BUILD_ARGS += --build-arg ATOM_DEV_DIGEST=$(ATOM_DEV_DIGEST)
+endif
+ifneq ($(strip $(LMCACHE_SHA)),)
+BUILD_ARGS += --build-arg LMCACHE_SHA=$(LMCACHE_SHA)
+endif
+
+.PHONY: help build vllm-atom-andy run run-batch verify
+
+.DEFAULT_GOAL := help
+
+help:
+	@echo "vllm-atom-andy Makefile (ATOM + LMCache, Andy Luo blog)"
+	@echo ""
+	@echo "  make build         docker build -t $(IMAGE_NAME)"
+	@echo "                      base: rocm/atom-dev:vllm-v0.19.0-nightly_20260522"
+	@echo "                      (digest-pinned; override ATOM_DEV_DIGEST=sha256:...)"
+	@echo "  make verify        confirm LMCache HIP c_ops backend (.so)"
+	@echo "  make run            docker run -it ... bind-mounts configs/ + scripts/"
+	@echo "                      + LOG (server.txt); DATA = LMCache NVMe tier"
+	@echo "                      default CONTAINER_NAME=$(CONTAINER_NAME)"
+	@echo "  make run-batch      docker run -d (non-interactive)"
+	@echo ""
+	@echo "VAA_LMCACHE_TIER: hbm | cpu (default) | cpu-nvme"
+	@echo "  hbm       ATOM HBM-only (no LMCache connector)"
+	@echo "  cpu       HBM L1 + CPU DRAM L2"
+	@echo "  cpu-nvme  HBM L1 + CPU L2 + NVMe L3 (needs DATA mount)"
+	@echo ""
+	@echo "make run: requires HF_TOKEN or HF_TOKEN_FILE. See README for blog overrides"
+	@echo "  (TP=2, MiniMax-M2.5, GMU=0.78, max context 100K)."
+	@echo ""
+
+run:
+	@$(MAKE) -f "$(CURDIR)/Makefile" _docker_run DOCKER_RUN_ATTACH=-it
+
+run-batch:
+	@$(MAKE) -f "$(CURDIR)/Makefile" _docker_run DOCKER_RUN_ATTACH=-d
+
+_docker_run:
+	@set -e; \
+	HF_TOKEN_FILE_MAKE="$(HF_TOKEN_FILE)"; \
+	if [ -n "$$HF_TOKEN_FILE_MAKE" ]; then export HF_TOKEN_FILE="$$HF_TOKEN_FILE_MAKE"; fi; \
+	command -v docker >/dev/null 2>&1 || { \
+		echo "ERROR: docker not found (install Docker Engine)" >&2; \
+		exit 1; \
+	}; \
+	if [ -z "$$HF_TOKEN" ] && [ -n "$$HF_TOKEN_FILE" ] && [ -r "$$HF_TOKEN_FILE" ]; then \
+		export HF_TOKEN="$$(tr -d '\r\n' < "$$HF_TOKEN_FILE")"; \
+	fi; \
+	if [ -z "$$HF_TOKEN" ]; then \
+		echo "ERROR: set HF_TOKEN or a readable HF_TOKEN_FILE" >&2; \
+		exit 1; \
+	fi; \
+	mkdir -p "$(DATA)" "$(LOG)" "$(HF_HOME)" \
+		"$(HF_HOME)/hub" "$(HF_HOME)/datasets" "$(HF_HOME)/vllm" \
+		"$(HF_HOME)/vllm_config" "$(HF_HOME)/torch" "$(HF_HOME)/torch_inductor"; \
+	docker rm -f "$(CONTAINER_NAME)" >/dev/null 2>&1 || true; \
+	docker run $(DOCKER_RUN_ATTACH) --rm \
+		--name="$(CONTAINER_NAME)" \
+		--hostname="$(CONTAINER_NAME)" \
+		--ipc=host \
+		--network=host \
+		--group-add video \
+		--cap-add=SYS_PTRACE \
+		--security-opt seccomp=unconfined \
+		--device=/dev/kfd \
+		--device=/dev/dri \
+		--env HF_HOME="$(CONTAINER_HF_HOME)" \
+		--env HF_HUB_CACHE="$(CONTAINER_HF_HOME)/hub" \
+		--env HF_DATASETS_CACHE="$(CONTAINER_HF_HOME)/datasets" \
+		--env VLLM_CACHE_ROOT="$(CONTAINER_HF_HOME)/vllm" \
+		--env VLLM_CONFIG_ROOT="$(CONTAINER_HF_HOME)/vllm_config" \
+		--env TORCH_HOME="$(CONTAINER_HF_HOME)/torch" \
+		--env TORCHINDUCTOR_CACHE_DIR="$(CONTAINER_HF_HOME)/torch_inductor" \
+		--env VAA_CONTAINER_DATA_DIR="$(CONTAINER_DATA_DIR)" \
+		--env VAA_SERVER_LOG_DIR="$(CONTAINER_LOG_DIR)" \
+		--env VAA_LMCACHE_TIER="$(VAA_LMCACHE_TIER)" \
+		--env VAA_LMCACHE_LOG_LEVEL="$(VAA_LMCACHE_LOG_LEVEL)" \
+		--env VLLM_SERVER_DEV_MODE="$(VLLM_SERVER_DEV_MODE)" \
+		$$(if [ -n "$(VAA_TENSOR_PARALLEL_SIZE)" ]; then printf '%s' "--env VAA_TENSOR_PARALLEL_SIZE=$(VAA_TENSOR_PARALLEL_SIZE)"; fi) \
+		$$(if [ -n "$(VAA_GPU_MEMORY_UTILIZATION)" ]; then printf '%s' "--env VAA_GPU_MEMORY_UTILIZATION=$(VAA_GPU_MEMORY_UTILIZATION)"; fi) \
+		$$(if [ -n "$(VAA_MAX_MODEL_LEN)" ]; then printf '%s' "--env VAA_MAX_MODEL_LEN=$(VAA_MAX_MODEL_LEN)"; fi) \
+		$$(if [ -n "$(VAA_MAX_NUM_BATCHED_TOKENS)" ]; then printf '%s' "--env VAA_MAX_NUM_BATCHED_TOKENS=$(VAA_MAX_NUM_BATCHED_TOKENS)"; fi) \
+		$$(if [ -n "$(VAA_LMCACHE_MAX_LOCAL_CPU_SIZE)" ]; then printf '%s' "--env VAA_LMCACHE_MAX_LOCAL_CPU_SIZE=$(VAA_LMCACHE_MAX_LOCAL_CPU_SIZE)"; fi) \
+		$$(if [ -n "$(VAA_MODEL_PROFILE)" ]; then printf '%s' "--env VAA_MODEL_PROFILE=$(VAA_MODEL_PROFILE)"; fi) \
+		$$(if [ -n "$(VLLM_MODEL)" ]; then printf '%s' "--env VLLM_MODEL=$(VLLM_MODEL)"; fi) \
+		--env HF_TOKEN="$$HF_TOKEN" \
+		--env ROCR_VISIBLE_DEVICES="$(GPU)" \
+		--env TZ="$(TZ)" \
+		--env PYTORCH_ALLOC_CONF="$${PYTORCH_ALLOC_CONF:-expandable_segments:True}" \
+		-v "$(HF_HOME):$(CONTAINER_HF_HOME)" \
+		-v "$(DATA):$(CONTAINER_DATA_DIR)" \
+		-v "$(LOG):$(CONTAINER_LOG_DIR)" \
+		-v "$(CURDIR)/configs:/app/configs:ro" \
+		-v "$(CURDIR)/scripts:/app/scripts:ro" \
+		-v /boot/config-$$(uname -r):/boot/config-$$(uname -r):ro \
+		$(EXTRA_DOCKER_RUN_FLAGS) \
+		$(IMAGE_NAME) $(ARGS); \
+	if [ "$(DOCKER_RUN_ATTACH)" = "-d" ]; then \
+		echo "Started container $(CONTAINER_NAME)"; \
+	fi
+
+build vllm-atom-andy:
+	@command -v docker >/dev/null 2>&1 || { \
+		echo "ERROR: docker not found (install Docker Engine)" >&2; \
+		exit 1; \
+	}
+	@test -n "$(ROCM_ARCH)" || { \
+		echo "ERROR: ROCM_ARCH is empty (install ROCm / rocm_agent_enumerator," >&2; \
+		echo "       or set e.g. ROCM_ARCH=gfx942 for MI300X)" >&2; \
+		exit 1; \
+	}
+	docker build -f "$(CURDIR)/Dockerfile" -t $(IMAGE_NAME) $(BUILD_ARGS) "$(REPO_ROOT)"
+
+verify:
+	@command -v docker >/dev/null 2>&1 || { \
+		echo "ERROR: docker not found (install Docker Engine)" >&2; \
+		exit 1; \
+	}
+	docker run --rm $(IMAGE_NAME) python3 /app/scripts/verify-lmcache-hip.py

--- a/recipies/vllm-atom-andy/README.md
+++ b/recipies/vllm-atom-andy/README.md
@@ -32,7 +32,7 @@ for HBM L1 + CPU DRAM L2 + optional NVMe L3.
 | **`make build` / `make run` / `make verify`**, mounts, **`VAA_*`** | **`Makefile`** |
 | **`rocm/atom-dev@sha256:…`** (20260522 nightly) + HIP LMCache + **`aiofile`** | **`Dockerfile`** |
 | Defaults (FP8 KV, CUDA graphs, ATOM env, tiers) | **`configs/vllm-atom-andy.yaml`** |
-| Server entrypoint | **`scripts/vllm-server`** |
+| Server entry point | **`scripts/vllm-server`** |
 | HIP backend check (blog Step 3) | **`scripts/verify-lmcache-hip.py`** |
 
 ### Base image

--- a/recipies/vllm-atom-andy/README.md
+++ b/recipies/vllm-atom-andy/README.md
@@ -1,0 +1,167 @@
+<!--
+Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+SPDX-License-Identifier: MIT
+-->
+
+# vllm-atom-andy
+
+ROCm **vLLM** + **ATOM** (AiTer Optimized Model plugin) + **LMCache**
+local CPU / NVMe tiers, following [Andy Luo's ATOM + LMCache MI300X blog][atom-blog].
+Base image **`rocm/atom-dev:vllm-v0.19.0-nightly_20260522`**, pinned by digest in
+**`Dockerfile`** (not **`vllm-latest`**). Work from **`recipies/vllm-atom-andy/`**.
+
+Part of [rocm-aic](../../README.md). Unlike [vllm-lmcache-hipfile](../vllm-lmcache-hipfile)
+(GdsBackend + hipFile) and [vllm-lmcache-nixl](../vllm-lmcache-nixl) (NIXL
+POSIX/AIS), this recipe uses LMCache's **`LMCACHE_LOCAL_*`** environment API
+for HBM L1 + CPU DRAM L2 + optional NVMe L3.
+
+## Contents
+
+- [Where things live](#where-things-live)
+- [Quick start](#quick-start)
+- [LMCache tiers](#lmcache-tiers-vaa_lmcache_tier)
+- [Critical pitfalls](#critical-pitfalls)
+- [Blog reproduction (2× MI300X, MiniMax-M2.5)](#blog-reproduction-2-mi300x-minimax-m25)
+- [kv-cache-tester / trace replay](#kv-cache-tester--trace-replay)
+- [Compare to other recipes](#compare-to-other-recipes)
+
+## Where things live
+
+| What you need | File |
+| --- | --- |
+| **`make build` / `make run` / `make verify`**, mounts, **`VAA_*`** | **`Makefile`** |
+| **`rocm/atom-dev@sha256:…`** (20260522 nightly) + HIP LMCache + **`aiofile`** | **`Dockerfile`** |
+| Defaults (FP8 KV, CUDA graphs, ATOM env, tiers) | **`configs/vllm-atom-andy.yaml`** |
+| Server entrypoint | **`scripts/vllm-server`** |
+| HIP backend check (blog Step 3) | **`scripts/verify-lmcache-hip.py`** |
+
+### Base image
+
+Default **`rocm/atom-dev:vllm-v0.19.0-nightly_20260522`**, referenced by digest
+in **`Dockerfile`** and **`Makefile`** **`ATOM_DEV_DIGEST`**. Override with
+**`make build ATOM_DEV_DIGEST=sha256:…`** after verifying a newer dated nightly on
+Docker Hub.
+
+**Hardware:** ATOM targets **AMD Instinct MI300X (gfx942)**. Radeon GPUs (e.g.
+gfx1201) are not supported by the **`rocm/atom-dev`** stack; use
+[vllm-lmcache-hipfile](../vllm-lmcache-hipfile) on Radeon instead.
+
+## Quick start
+
+```bash
+export ROCM_ARCH=gfx942   # MI300X; required for LMCache HIP build
+make -C recipies/vllm-atom-andy build
+make -C recipies/vllm-atom-andy verify
+export HF_TOKEN=your_hf_token_here
+make -C recipies/vllm-atom-andy run
+```
+
+The **Makefile** bind-mounts **`configs/`** and **`scripts/`** so YAML and
+Python update without **`docker build`**. LMCache NVMe state uses host **`DATA`**
+(default **`/mnt/lmcache-nvme`** → container **`/data`**). Server logs tee to
+host **`LOG`** (default **`recipies/vllm-atom-andy/logs`**, file **`server.txt`**).
+
+Port **`800{GPU}`** matches the first index in **`ROCR_VISIBLE_DEVICES`** (e.g.
+**`8000`** for **`GPU=0`**). Override **`CONTAINER_NAME`**, **`DATA`**, **`LOG`**
+via **`make run`** variables (see **`make help`**).
+
+Prepare the host **`DATA`** path before **`cpu-nvme`**. Prefer stable NVMe
+identity under **`/dev/disk/by-id/`** when formatting or mounting test SSDs;
+do not rely on volatile **`/dev/nvme*n*`** namespace paths in docs or scripts.
+
+## LMCache tiers (`VAA_LMCACHE_TIER`)
+
+| Tier | Env | Behavior |
+| --- | --- | --- |
+| **`hbm`** | (default off LMCache env) | ATOM FP8 prefix cache in HBM only |
+| **`cpu`** | **`LMCACHE_LOCAL_CPU=true`**, 64 GB L2 default | HBM L1 + CPU DRAM L2 |
+| **`cpu-nvme`** | above + **`LMCACHE_LOCAL_DISK=/data/lmcache`** | adds NVMe L3 spill |
+
+Examples:
+
+```bash
+make run VAA_LMCACHE_TIER=hbm
+make run VAA_LMCACHE_TIER=cpu
+make run VAA_LMCACHE_TIER=cpu-nvme DATA=/mnt/nvme/lmcache
+```
+
+### When to use which tier (from blog)
+
+| Scenario | Recommended |
+| --- | --- |
+| Low concurrency, short context (&lt;32K) | **`hbm`** |
+| Moderate concurrency, mixed context | **`cpu`** |
+| High concurrency, long context (100K+), SLO on p95 | **`cpu-nvme`** |
+| Decode-bound (short input, long output) | **`hbm`** — cache won't help decode |
+
+## Critical pitfalls
+
+1. **CUDA graphs** — ATOM defaults to eager mode. This recipe always passes
+   **`--compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE"}'`**. Do not
+   set **`VAA_ENFORCE_EAGER`** (the server rejects it). Without graphs, expect
+   3–5× throughput loss.
+2. **LMCache HIP build** — PyPI **`pip install lmcache`** on ROCm silently falls
+   back to Python **`non_cuda_equivalents`**. Run **`make verify`** after build;
+   **`c_ops`** must be a **`.so`**, not **`.py`**.
+3. **`PYTHONHASHSEED=0`** — required for LMCache cache-key consistency across TP
+   workers (set in the image and server).
+4. **`aiofile`** — required for the NVMe disk tier; installed in the Dockerfile.
+   Without it, disk I/O may block or fail.
+
+## Blog reproduction (2× MI300X, MiniMax-M2.5)
+
+Defaults are **TP=1**, **`openai/gpt-oss-120b`**, GMU **0.90**. To match the blog
+stress arm on **2× MI300X** with **MiniMax-M2.5**:
+
+```bash
+make -C recipies/vllm-atom-andy run \
+  GPU=0,1 \
+  VAA_TENSOR_PARALLEL_SIZE=2 \
+  VLLM_MODEL=/path/to/MiniMax-M2.5 \
+  VAA_MODEL_PROFILE=minimax \
+  VAA_GPU_MEMORY_UTILIZATION=0.78 \
+  VAA_MAX_MODEL_LEN=100000 \
+  VAA_LMCACHE_TIER=cpu-nvme \
+  DATA=/mnt/nvme/lmcache
+```
+
+Mount model weights with **`EXTRA_DOCKER_RUN_FLAGS`**, e.g.
+**`-v /mnt/nvme/models:/work/models`**, and set **`VLLM_MODEL=/work/models/MiniMax-M2.5`**
+if serving from that path.
+
+## kv-cache-tester / trace replay
+
+The blog uses **`trace_replay_tester.py`** from
+[callanjfox/kv-cache-tester][kv-cache-tester] (739 Claude Code traces). This repo
+ships an Ansible role at
+[ansible/roles/kv_cache_tester](../../ansible/roles/kv_cache_tester).
+
+Stress run parameters from the blog (after the server is up on port 8000):
+
+```bash
+ansible-playbook ansible/playbooks/kv-cache-tester.yml \
+  -e kv_cache_tester_api_endpoint=http://127.0.0.1:8000 \
+  -e kv_cache_tester_script=trace_replay_tester.py \
+  -e 'kv_cache_tester_extra_args=["--trace-directory","traces","--start-users","4","--max-users","32","--max-ttft","60.0","--test-duration","1200","--max-context","100000","--warm-prefix-pct","0.5","--timing-strategy","think-only","--recycle","--seed","42"]'
+```
+
+Traces must exist under the kv-cache-tester checkout (**`traces/`**). Clone with
+**`git clone --recursive`** per upstream instructions.
+
+## Compare to other recipes
+
+| Recipe | LMCache backend | Base image |
+| --- | --- | --- |
+| vllm-lmcache-hipfile | GdsBackend → hipFile | vllm/vllm-openai-rocm:v0.19.0 |
+| vllm-lmcache-nixl | NixlStorageBackend → NIXL POSIX/AIS | vllm/vllm-openai-rocm:v0.19.0 |
+| **vllm-atom-andy** | **`LMCACHE_LOCAL_CPU` / `LMCACHE_LOCAL_DISK`** | **rocm/atom-dev** (digest-pinned) |
+
+## Future work
+
+Slurm sbatch integration, GitHub Actions workflows, and Grafana panels are not
+included in v1; use [vllm-lmcache-hipfile](../vllm-lmcache-hipfile) for cluster
+automation patterns.
+
+<!-- References -->
+[atom-blog]: https://andyluo7.github.io/llm/amd/mi300x/vllm/lmcache/performance/2026/05/22/atom-lmcache-kv-cache-offload-mi300x/
+[kv-cache-tester]: https://github.com/callanjfox/kv-cache-tester

--- a/recipies/vllm-atom-andy/configs/vllm-atom-andy.yaml
+++ b/recipies/vllm-atom-andy/configs/vllm-atom-andy.yaml
@@ -1,0 +1,44 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# vllm-atom-andy: ATOM + LMCache local CPU/NVMe tiers (Andy Luo blog defaults).
+
+lmcache:
+  chunk_size: 256
+  max_local_cpu_size_gb: 64
+  disk_subdir: lmcache
+
+vllm_kv_transfer:
+  kv_connector: LMCacheConnectorV1
+  kv_role: kv_both
+
+vllm:
+  host: "0.0.0.0"
+  tensor_parallel_size: 1
+  kv_cache_dtype: fp8
+  model_default: "openai/gpt-oss-120b"
+  max_model_len_default: "32768"
+  max_num_batched_tokens_default: "16384"
+  gpu_memory_utilization_default: "0.90"
+
+atom:
+  aiter_quick_reduce_quantization: INT4
+  enable_qk_norm_rope_cache_quant_fusion: true
+  float32_matmul_precision: high
+
+serve:
+  async_scheduling: true
+  enable_prefix_caching: true
+  compilation_config: '{"cudagraph_mode":"FULL_AND_PIECEWISE"}'
+  disable_uvicorn_access_log: true
+  enable_mfu_metrics: true
+  load_format: auto
+  trust_remote_code: true
+
+model_profiles:
+  minimax:
+    tool_call_parser: minimax_m2
+    reasoning_parser: minimax_m2
+    enable_auto_tool_choice: true
+    trust_remote_code: true

--- a/recipies/vllm-atom-andy/requirements-lmcache-runtime.txt
+++ b/recipies/vllm-atom-andy/requirements-lmcache-runtime.txt
@@ -1,0 +1,18 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# LMCache runtime deps for vllm-atom-andy (local CPU / NVMe tiers).
+# Excludes torch and cufile-python so the atom-dev ROCm venv is not replaced.
+
+aiofile
+aiofiles
+blake3
+msgspec
+numpy<=2.2.6
+psutil
+py-cpuinfo
+pyyaml
+pyzmq>=25.0.0
+safetensors
+sortedcontainers

--- a/recipies/vllm-atom-andy/scripts/verify-lmcache-hip.py
+++ b/recipies/vllm-atom-andy/scripts/verify-lmcache-hip.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+"""Verify LMCache HIP c_ops was built (not Python fallback on ROCm)."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _lmcache_git_sha() -> str | None:
+    git_dir = Path("/app/LMCache")
+    if not (git_dir / ".git").is_dir():
+        return None
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(git_dir), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return out.stdout.strip() or None
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+
+def _find_c_ops_so() -> Path | None:
+    roots = [
+        Path("/app/LMCache"),
+        Path("/opt/venv/lib/python3.12/site-packages/lmcache"),
+    ]
+    for root in roots:
+        if not root.is_dir():
+            continue
+        for path in sorted(root.rglob("c_ops*.so")):
+            if path.is_file():
+                return path
+    return None
+
+
+def _check_rocm_torch() -> str:
+    import torch
+
+    ver = torch.__version__
+    if "rocm" not in ver and not torch.version.hip:
+        raise SystemExit(f"ERROR: expected ROCm torch in atom-dev venv, got {ver}")
+    hip = Path(torch.__file__).resolve().parent / "lib" / "libtorch_hip.so"
+    if not hip.is_file():
+        raise SystemExit(f"ERROR: missing {hip}")
+    return ver
+
+
+def main() -> int:
+    try:
+        torch_ver = _check_rocm_torch()
+    except ImportError as e:
+        print(f"FAIL: cannot import torch ({e})", file=sys.stderr)
+        return 1
+
+    so_path = _find_c_ops_so()
+    if so_path is None:
+        print(
+            "FAIL: no lmcache c_ops*.so found under /app/LMCache or site-packages.\n"
+            "Rebuild with BUILD_WITH_HIP=1 and /opt/venv/bin/pip install -e . --no-deps.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Import may fall back without a GPU; presence of the .so is the build check.
+    try:
+        import lmcache.c_ops as c_ops  # noqa: F401
+    except ImportError:
+        pass
+
+    sha = _lmcache_git_sha()
+    print(f"OK: ROCm torch={torch_ver}")
+    print(f"    LMCache HIP c_ops at {so_path}")
+    if sha:
+        print(f"    LMCache git HEAD: {sha}")
+
+    try:
+        out = subprocess.run(
+            [sys.executable, "-m", "pip", "show", "lmcache"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        for line in out.stdout.splitlines():
+            if line.startswith(("Name:", "Version:", "Location:")):
+                print(f"    {line}")
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        pass
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/recipies/vllm-atom-andy/scripts/vllm-atom-andy-defaults.py
+++ b/recipies/vllm-atom-andy/scripts/vllm-atom-andy-defaults.py
@@ -1,0 +1,24 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+DEFAULT_CONTAINER_DATA_DIR = "/data"
+DEFAULT_CONTAINER_SERVER_LOG_DIR = "/var/log/vllm-atom-andy"
+
+
+def container_data_root() -> Path:
+    """In-container LMCache data root (**`VAA_CONTAINER_DATA_DIR`**)."""
+    v = os.environ.get("VAA_CONTAINER_DATA_DIR", "").strip()
+    return Path(v) if v else Path(DEFAULT_CONTAINER_DATA_DIR)
+
+
+def container_server_log_dir() -> Path:
+    """Directory for **`vllm-server`** tee (**`server.txt`**)."""
+    v = os.environ.get("VAA_SERVER_LOG_DIR", "").strip()
+    return Path(v) if v else Path(DEFAULT_CONTAINER_SERVER_LOG_DIR)

--- a/recipies/vllm-atom-andy/scripts/vllm-server
+++ b/recipies/vllm-atom-andy/scripts/vllm-server
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import threading
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError as e:
+    print("ERROR: PyYAML is required (import yaml).", file=sys.stderr)
+    raise SystemExit(1) from e
+
+import importlib.util
+
+_script_dir = Path(__file__).resolve().parent
+
+
+def _load_defaults_module():
+    path = _script_dir / "vllm-atom-andy-defaults.py"
+    spec = importlib.util.spec_from_file_location("vllm_vaa_defaults", path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load {path}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_defaults = _load_defaults_module()
+container_data_root = _defaults.container_data_root
+container_server_log_dir = _defaults.container_server_log_dir
+_cfg_next_to_script = _script_dir / "configs"
+_CONFIG_DIR = (
+    _cfg_next_to_script
+    if _cfg_next_to_script.is_dir()
+    else _script_dir.parent / "configs"
+)
+_SERVICE_YAML = _CONFIG_DIR / "vllm-atom-andy.yaml"
+
+
+def _truthy(name: str, default: str = "1") -> bool:
+    v = os.environ.get(name, default).strip().lower()
+    return v not in ("0", "false", "no", "off", "")
+
+
+def _lmcache_tier() -> str:
+    return os.environ.get("VAA_LMCACHE_TIER", "cpu").strip().lower()
+
+
+def _chunk_statistics_extra(data_root: Path) -> dict[str, object]:
+    out_dir = str(data_root / "lmcache_chunk_stats")
+    Path(out_dir).mkdir(parents=True, exist_ok=True)
+    return {
+        "chunk_statistics_file_output_dir": out_dir,
+        "chunk_statistics_file_rotation_size": 104857600,
+        "chunk_statistics_file_max_count": 100,
+    }
+
+
+def _apply_chunk_statistics_env(env: dict[str, str], data_root: Path) -> None:
+    if not _truthy("VAA_LMCACHE_ENABLE_CHUNK_STATISTICS", "0"):
+        return
+    env["LMCACHE_ENABLE_CHUNK_STATISTICS"] = "true"
+    env["LMCACHE_CHUNK_STATISTICS_AUTO_START_STATISTICS"] = "true"
+    env["LMCACHE_CHUNK_STATISTICS_STRATEGY"] = os.environ.get(
+        "VAA_LMCACHE_CHUNK_STATISTICS_STRATEGY", "file_hash"
+    ).strip()
+    env.setdefault("PYTHONHASHSEED", "0")
+    prior = env.get("LMCACHE_EXTRA_CONFIG", "").strip()
+    extra: dict[str, object] = {}
+    if prior:
+        try:
+            parsed = json.loads(prior)
+            if isinstance(parsed, dict):
+                extra = parsed
+        except json.JSONDecodeError:
+            pass
+    extra.update(_chunk_statistics_extra(data_root))
+    env["LMCACHE_EXTRA_CONFIG"] = json.dumps(extra, separators=(",", ":"))
+
+
+def _apply_lmcache_log_level(env: dict[str, str]) -> None:
+    v = os.environ.get("VAA_LMCACHE_LOG_LEVEL", "").strip()
+    env["LMCACHE_LOG_LEVEL"] = v if v else "INFO"
+
+
+def _apply_atom_env(env: dict[str, str], atom_cfg: dict[str, Any]) -> None:
+    qr = atom_cfg.get("aiter_quick_reduce_quantization")
+    if isinstance(qr, str) and qr.strip():
+        env["AITER_QUICK_REDUCE_QUANTIZATION"] = qr.strip()
+    if atom_cfg.get("enable_qk_norm_rope_cache_quant_fusion"):
+        env["ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION"] = "1"
+    fmp = atom_cfg.get("float32_matmul_precision")
+    if isinstance(fmp, str) and fmp.strip():
+        env["VLLM_FLOAT32_MATMUL_PRECISION"] = fmp.strip()
+
+
+def _apply_lmcache_tier_env(
+    env: dict[str, str],
+    tier: str,
+    lmc_cfg: dict[str, Any],
+    data_root: Path,
+) -> bool:
+    """Return True when LMCache connector should be enabled."""
+    if tier in ("hbm", "hbm-only", "none", "off"):
+        for k in (
+            "LMCACHE_LOCAL_CPU",
+            "LMCACHE_LOCAL_DISK",
+            "LMCACHE_MAX_LOCAL_CPU_SIZE",
+            "LMCACHE_CHUNK_SIZE",
+        ):
+            env.pop(k, None)
+        return False
+
+    if tier not in ("cpu", "cpu-nvme", "cpu_nvme", "cpu+disk"):
+        print(
+            f"ERROR: VAA_LMCACHE_TIER must be hbm, cpu, or cpu-nvme (got {tier!r})",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+    chunk = lmc_cfg.get("chunk_size", 256)
+    max_cpu = lmc_cfg.get("max_local_cpu_size_gb", 64)
+    override_cpu = os.environ.get("VAA_LMCACHE_MAX_LOCAL_CPU_SIZE", "").strip()
+    if override_cpu:
+        max_cpu = override_cpu
+
+    env["LMCACHE_LOCAL_CPU"] = "true"
+    env["LMCACHE_CHUNK_SIZE"] = str(int(chunk))
+    env["LMCACHE_MAX_LOCAL_CPU_SIZE"] = str(max_cpu)
+    env.setdefault("PYTHONHASHSEED", "0")
+
+    if tier in ("cpu-nvme", "cpu_nvme", "cpu+disk"):
+        subdir = lmc_cfg.get("disk_subdir", "lmcache")
+        if not isinstance(subdir, str) or not subdir.strip():
+            subdir = "lmcache"
+        disk_path = (data_root / subdir).resolve()
+        disk_path.mkdir(parents=True, exist_ok=True)
+        env["LMCACHE_LOCAL_DISK"] = str(disk_path)
+
+    return True
+
+
+def _model_profile(svc: dict[str, Any], model: str) -> dict[str, Any]:
+    explicit = os.environ.get("VAA_MODEL_PROFILE", "").strip().lower()
+    if explicit:
+        profiles = svc.get("model_profiles")
+        if isinstance(profiles, dict) and explicit in profiles:
+            prof = profiles[explicit]
+            return prof if isinstance(prof, dict) else {}
+    if "minimax" in model.lower():
+        profiles = svc.get("model_profiles")
+        if isinstance(profiles, dict):
+            prof = profiles.get("minimax")
+            return prof if isinstance(prof, dict) else {}
+    return {}
+
+
+def _enable_mfu_metrics(prof: dict[str, Any]) -> bool:
+    v = os.environ.get("VAA_ENABLE_MFU_METRICS", "").strip().lower()
+    if v in ("0", "false", "no", "off"):
+        return False
+    if v in ("1", "true", "yes", "on"):
+        return True
+    return bool(prof.get("enable_mfu_metrics", True))
+
+
+def _tee_thread(stream: Any, log_f: Any) -> None:
+    for line in iter(stream.readline, b""):
+        if not line:
+            break
+        log_f.write(line)
+        log_f.flush()
+        try:
+            sys.stdout.buffer.write(line)
+            sys.stdout.buffer.flush()
+        except BrokenPipeError:
+            break
+
+
+def _first_gpu_index(rocr: str) -> str:
+    port = rocr.split(",", 1)[0].strip()
+    if not port.isdigit():
+        print(
+            "error: first GPU index in ROCR_VISIBLE_DEVICES must be a "
+            f"non-negative integer (got: {rocr})",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    if "," in rocr:
+        print(
+            f"vllm-atom-andy: using first index {port} from "
+            f"ROCR_VISIBLE_DEVICES={rocr} for ports",
+            file=sys.stderr,
+        )
+    return port
+
+
+def main() -> int:
+    eager = os.environ.get("VAA_ENFORCE_EAGER", "").strip().lower()
+    if eager in ("1", "true", "yes", "on"):
+        print(
+            "ERROR: VAA_ENFORCE_EAGER is not supported with ATOM; "
+            "CUDA graphs are required (--compilation-config cudagraph_mode).",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not os.environ.get("ROCR_VISIBLE_DEVICES", "").strip():
+        print("Error: ROCR_VISIBLE_DEVICES not set", file=sys.stderr)
+        return 1
+
+    if not _SERVICE_YAML.is_file():
+        print(f"ERROR: missing {_SERVICE_YAML}", file=sys.stderr)
+        return 1
+
+    svc = yaml.safe_load(_SERVICE_YAML.read_text(encoding="utf-8"))
+    vcfg = svc["vllm"]
+    prof = svc.get("serve")
+    if not isinstance(prof, dict):
+        print("ERROR: vllm-atom-andy.yaml must define serve (mapping)", file=sys.stderr)
+        return 1
+
+    atom_cfg = svc.get("atom")
+    if not isinstance(atom_cfg, dict):
+        atom_cfg = {}
+
+    lmc_cfg = svc.get("lmcache")
+    if not isinstance(lmc_cfg, dict):
+        lmc_cfg = {}
+
+    data_root = container_data_root()
+    data_root.mkdir(parents=True, exist_ok=True)
+
+    rocr = os.environ.get("ROCR_VISIBLE_DEVICES", "0").strip() or "0"
+    gpu_idx = _first_gpu_index(rocr)
+    vllm_port = int(f"800{gpu_idx}")
+
+    env = os.environ.copy()
+    env["PYTHONHASHSEED"] = "0"
+    _apply_atom_env(env, atom_cfg)
+    _apply_lmcache_log_level(env)
+    _apply_chunk_statistics_env(env, data_root)
+
+    torch_lib = "/opt/venv/lib/python3.12/site-packages/torch/lib"
+    rocm_lib = "/opt/rocm/lib"
+    prev_ld = env.get("LD_LIBRARY_PATH", "")
+    parts = [torch_lib, rocm_lib] + [p for p in prev_ld.split(":") if p]
+    env["LD_LIBRARY_PATH"] = ":".join(dict.fromkeys(parts))
+
+    tier = _lmcache_tier()
+    use_lmcache = _apply_lmcache_tier_env(env, tier, lmc_cfg, data_root)
+
+    if _truthy("VLLM_SERVER_DEV_MODE", "1"):
+        env["VLLM_SERVER_DEV_MODE"] = "1"
+    else:
+        env.pop("VLLM_SERVER_DEV_MODE", None)
+
+    model = os.environ.get("VLLM_MODEL", "").strip() or str(vcfg["model_default"])
+    model_prof = _model_profile(svc, model)
+
+    tp_override = os.environ.get("VAA_TENSOR_PARALLEL_SIZE", "").strip()
+    if tp_override:
+        tp_size = int(tp_override)
+    else:
+        tp_size = int(vcfg["tensor_parallel_size"])
+
+    gpu_mem = (
+        os.environ.get("VAA_GPU_MEMORY_UTILIZATION", "").strip()
+        or os.environ.get("VLLM_GPU_MEMORY_UTILIZATION", "").strip()
+        or str(vcfg["gpu_memory_utilization_default"])
+    )
+    max_len = (
+        os.environ.get("VAA_MAX_MODEL_LEN", "").strip()
+        or str(vcfg["max_model_len_default"])
+    )
+    max_batched = (
+        os.environ.get("VAA_MAX_NUM_BATCHED_TOKENS", "").strip()
+        or str(vcfg["max_num_batched_tokens_default"])
+    )
+
+    kv_dtype = str(vcfg.get("kv_cache_dtype", "fp8"))
+
+    cmd: list[str] = [
+        "/opt/venv/bin/vllm",
+        "serve",
+        model,
+        "--host",
+        str(vcfg["host"]),
+        "--port",
+        str(vllm_port),
+        "--max-model-len",
+        max_len,
+        "--tensor-parallel-size",
+        str(tp_size),
+        "--gpu-memory-utilization",
+        gpu_mem,
+        "--kv-cache-dtype",
+        kv_dtype,
+        "--max-num-batched-tokens",
+        max_batched,
+    ]
+
+    if prof.get("enable_prefix_caching", True):
+        cmd.append("--enable-prefix-caching")
+    if prof.get("async_scheduling", True):
+        cmd.append("--async-scheduling")
+
+    comp_cfg = prof.get("compilation_config")
+    if isinstance(comp_cfg, str) and comp_cfg.strip():
+        cmd.extend(["--compilation-config", comp_cfg.strip()])
+
+    if use_lmcache:
+        kv_obj = svc.get("vllm_kv_transfer")
+        if not isinstance(kv_obj, dict):
+            print(
+                "ERROR: vllm-atom-andy.yaml must define vllm_kv_transfer",
+                file=sys.stderr,
+            )
+            return 1
+        kv_raw = json.dumps(kv_obj, separators=(",", ":"))
+        cmd.extend(["--kv-transfer-config", kv_raw])
+
+    lf = prof.get("load_format")
+    if isinstance(lf, str) and lf and lf != "auto":
+        cmd.extend(["--load-format", lf])
+
+    if model_prof.get("trust_remote_code") or prof.get("trust_remote_code"):
+        cmd.append("--trust-remote-code")
+    if model_prof.get("enable_auto_tool_choice"):
+        cmd.append("--enable-auto-tool-choice")
+    tcp = model_prof.get("tool_call_parser")
+    if isinstance(tcp, str) and tcp.strip():
+        cmd.extend(["--tool-call-parser", tcp.strip()])
+    rp = model_prof.get("reasoning_parser")
+    if isinstance(rp, str) and rp.strip():
+        cmd.extend(["--reasoning-parser", rp.strip()])
+
+    if _enable_mfu_metrics(prof):
+        cmd.append("--enable-mfu-metrics")
+    if prof.get("disable_uvicorn_access_log", True):
+        cmd.append("--disable-uvicorn-access-log")
+
+    log_root = container_server_log_dir()
+    log_root.mkdir(parents=True, exist_ok=True)
+    log_path = log_root / "server.txt"
+    log_f = log_path.open("ab", buffering=0)
+    listen = str(vcfg["host"])
+    print(
+        f"vllm-atom-andy VAA_LMCACHE_TIER={tier} lmcache={'on' if use_lmcache else 'off'} "
+        f"http://{listen}:{vllm_port}/v1 log={log_path}",
+        flush=True,
+    )
+    proc = subprocess.Popen(
+        cmd,
+        env=env,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+    assert proc.stdout is not None
+    tee = threading.Thread(
+        target=_tee_thread,
+        args=(proc.stdout, log_f),
+        daemon=True,
+    )
+    tee.start()
+    rc = proc.wait()
+    tee.join(timeout=30)
+    proc.stdout.close()
+    log_f.close()
+    return int(rc)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Introduce a Docker/Makefile recipe that extends digest-pinned rocm/atom-dev with HIP-built LMCache (no-deps install to preserve ROCm PyTorch), local CPU/NVMe tier env vars, and Andy Luo blog defaults. Document usage, kv-cache-tester repro, and link from the repo README.
