### PR TITLE
Align Ansible with recipies layout and add Prometheus remote write.

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ rocm-aic/
 ```
 ## Documentation
 
-- **[Ansible runbook](ansible/README.md)** — playbooks, recipes, monitoring
+- **[Ansible guide](ansible/README.md)** — playbooks, recipes, monitoring
 - **[LLM-D Deployments](recipies/llm-d/README.md)** — Kubernetes llm-d guide
 - **[Tiered Prefix Cache](recipies/llm-d/tiered-prefix-cache/README.md)** — KV cache offloading
 - **[Inference Scheduling](recipies/llm-d/inference-scheduling/README.md)** — Smart routing

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ need only `openai` unless you use the full tool stack.
 | amdgpu-dkms repack tool | [tools/amdgpu-dkms][t-dkms] | [README][t-dkms-readme] |
 | WEKA FS PoC | [vendors/weka][v-weka] | [README][v-weka-readme] |
 | Dell vLLM + LMCache + hipFile | [vendors/dell/vllm-lmcache-hipfile][v-dell] | [README][v-dell-readme] |
-| Ansible discovery / provision | [ansible][ansible-dir] | [site.yml][site-yml] |
+| Ansible discovery / provision | [ansible][ansible-dir] | [README][ansible-readme] |
 
 ## Benchmarks
 
@@ -102,54 +102,51 @@ This repository provides production-ready deployment automation for LLM inferenc
 
 #### LLM-D Based Deployments
 
-**[Tiered Prefix Cache](deployments/llm-d/tiered-prefix-cache/)** - KV cache offloading
+**[Tiered Prefix Cache](recipies/llm-d/tiered-prefix-cache/)** - KV cache offloading
 - Offload GPU HBM cache to CPU RAM
 - Two connector variants: offloading-connector, lmcache-connector
 - Intelligent prefix cache-aware routing
 - Method: Kustomize + Helm
 
-**[Inference Scheduling](deployments/llm-d/inference-scheduling/)** - Intelligent routing
+**[Inference Scheduling](recipies/llm-d/inference-scheduling/)** - Intelligent routing
 - vLLM replicas with smart load balancing
 - Prefix cache-aware request routing
 - Reduced tail latency and increased throughput
 - Method: Helmfile (3 charts)
 
-**[Benchmarking](deployments/llm-d/benchmarks/)** - Benchmarking framework
+**[Benchmarking](recipies/llm-d/benchmarks/)** - Benchmarking framework
 - Declarative benchmark sweep configurations
 - Result post-processing and plotting
 
-**[Monitoring](deployments/llm-d/monitoring/)** - Grafana dashboard management
+**[Monitoring](recipies/llm-d/monitoring/)** - Grafana dashboard management
 - Load llm-d default dashboards (6 dashboards)
 - Load rocm-icms custom dashboards
 - Automatic Grafana discovery
 
-See [deployments/README.md](deployments/README.md) for details.
+See [recipies/llm-d/README.md](recipies/llm-d/README.md) for details.
 
 ## Repository Structure
 
 ```
-rocm-icms/
-├── justfile                    # Root automation (setup, verification)
-├── submodules/
-│   └── llm-d/                  # LLM-D project (submodule)
-├── deployments/
-│   ├── common/                 # Shared utilities (all deployments)
-│   ├── llm-d/                  # LLM-D based deployments
-│   │   ├── benchmarks/
-│   │   ├── monitoring/
-│   │   ├── tiered-prefix-cache/
-│   │   └── inference-scheduling/
-│   └── custom/                 # Custom deployments (add your own)
-├── scripts/                    # Utilities
+rocm-aic/
+├── ansible/                    # Discovery, provisioning, monitoring
+├── benchmarks/                 # TTFT and prefill benchmarks
+├── grafana/                    # Dashboard JSON (import or deploy.sh)
+├── recipies/                   # Docker vLLM recipes and llm-d K8s deploys
+│   ├── common/                 # Shared NIXL scripts, rocm-aic-exporter
+│   ├── llm-d/                  # LLM-D Kubernetes deployments
+│   ├── rocm-inference-stack/   # Full inference stack Docker image
+│   ├── vllm-lmcache-hipfile/
+│   └── vllm-lmcache-nixl/
 ├── tools/                      # Build and development tools
 └── vendors/                    # Vendor-specific configurations
 ```
 ## Documentation
 
-- **[Deployments Overview](deployments/README.md)** - Architecture and organization
-- **[LLM-D Deployments](deployments/llm-d/README.md)** - LLM-D guide deployments
-- **[Tiered Prefix Cache Guide](deployments/llm-d/tiered-prefix-cache/README.md)** - KV cache offloading
-- **[Inference Scheduling Guide](deployments/llm-d/inference-scheduling/README.md)** - Smart routing
+- **[Ansible runbook](ansible/README.md)** — playbooks, recipes, monitoring
+- **[LLM-D Deployments](recipies/llm-d/README.md)** — Kubernetes llm-d guide
+- **[Tiered Prefix Cache](recipies/llm-d/tiered-prefix-cache/README.md)** — KV cache offloading
+- **[Inference Scheduling](recipies/llm-d/inference-scheduling/README.md)** — Smart routing
 
 ## References
 
@@ -177,6 +174,7 @@ rocm-icms/
 [v-dell]: vendors/dell/vllm-lmcache-hipfile/
 [v-dell-readme]: vendors/dell/vllm-lmcache-hipfile/README.md
 [ansible-dir]: ansible/
+[ansible-readme]: ansible/README.md
 [playbooks-dir]: ansible/playbooks/
 [discover-yml]: ansible/playbooks/discover.yml
 [site-yml]: ansible/site.yml

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -28,11 +28,11 @@ export ANSIBLE_REMOTE_USER=<lab-user>   # matches inventory/hosts.yml
 | Exporters only | `ansible-playbook site.yml --tags rocm_aic_exporter` |
 | Inference image | `ansible-playbook site.yml --tags inference-container` |
 | Monitoring | `ansible-playbook site.yml --tags monitoring` |
-| NVMe-oF | `ansible-playbook site.yml --tags nvmeof` |
+| NVMe over Fabrics | `ansible-playbook site.yml --tags nvmeof` |
 | NFS migration | `ansible-playbook site.yml --tags nfs-rdma` |
 
 The NFS play is tagged `never` in `site.yml`; run it explicitly with
-`--tags nfs-rdma` when migrating from NVMe-oF to NFS over RDMA.
+`--tags nfs-rdma` when migrating from NVMe over Fabrics to NFS over RDMA.
 
 List all tags: `ansible-playbook site.yml --list-tags`.
 
@@ -151,7 +151,7 @@ ansible-playbook site.yml --tags monitoring \
   -e monitoring_prometheus_remote_write_url=https://mimir.example:9009/api/v1/push
 ```
 
-See `roles/monitoring_stack/defaults/main.yml` for auth and TLS variables.
+See `roles/monitoring_stack/defaults/main.yml` for authentication and transport security variables.
 The remote-write **receiver** (`--web.enable-remote-write-receiver`) is
 opt-in (`monitoring_prometheus_enable_remote_write_receiver: true`).
 

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,0 +1,160 @@
+<!--
+Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+SPDX-License-Identifier: MIT
+-->
+
+# Ansible — cluster discovery, provisioning, and monitoring
+
+Run playbooks from this directory. Inventory and group variables live under
+`inventory/`; local roles under `roles/`. Galaxy collection
+[sbates130272.batesste][galaxy] supplies user, RDMA, ROCm, and exporter
+roles used by `host_setup`.
+
+## Prerequisites
+
+```bash
+cd ansible
+ansible-galaxy collection install -r requirements.yml
+export ANSIBLE_REMOTE_USER=<lab-user>   # matches inventory/hosts.yml
+```
+
+## Playbook entry points
+
+| Goal | Command |
+|------|---------|
+| Full flow | `ansible-playbook site.yml` |
+| Discovery only | `ansible-playbook playbooks/discover.yml` |
+| Host provisioning | `ansible-playbook site.yml --tags provision` |
+| Exporters only | `ansible-playbook site.yml --tags rocm_aic_exporter` |
+| Inference image | `ansible-playbook site.yml --tags inference-container` |
+| Monitoring | `ansible-playbook site.yml --tags monitoring` |
+| NVMe-oF | `ansible-playbook site.yml --tags nvmeof` |
+| NFS migration | `ansible-playbook site.yml --tags nfs-rdma` |
+
+The NFS play is tagged `never` in `site.yml`; run it explicitly with
+`--tags nfs-rdma` when migrating from NVMe-oF to NFS over RDMA.
+
+List all tags: `ansible-playbook site.yml --list-tags`.
+
+## Variable surfaces
+
+- `inventory/group_vars/<group>.yml` — primary lab tuning
+- `roles/*/defaults/main.yml` — role defaults (override in inventory)
+- CLI `-e key=value` — one-off overrides (secrets, endpoints)
+
+Discovery reports: `playbooks/reports/` (per-host JSON) and
+`reports/` (RDMA cross-host summaries).
+
+## Recipes — build and run
+
+Ansible does **not** deploy vLLM Docker recipes. Build and run them on GPU
+nodes manually; use Ansible for host exporters and the central monitoring
+stack.
+
+### vLLM + LMCache + NIXL (`recipies/vllm-lmcache-nixl`)
+
+Build context is the **repository root**. Containers use **`--network=host`**
+(vLLM `/metrics` on host port **8000**).
+
+```bash
+export ROCM_ARCH=gfx942          # or gfx1201 on Radeon
+make -C recipies/vllm-lmcache-nixl build
+export HF_TOKEN=...              # or HF_TOKEN_FILE=/path/to/token
+mkdir -p /mnt/lmcache-nvme recipies/vllm-lmcache-nixl/logs
+make -C recipies/vllm-lmcache-nixl run \
+  VLN_LMCACHE_IO=nixl-posix \
+  GPU=0 DATA=/mnt/lmcache-nvme
+```
+
+AIS mode: `VLN_LMCACHE_IO=ais VLH_HIPFILE_STATS_LEVEL=1`.
+
+Slurm from repo root: `./run-slurm-nixl.sh`.
+
+See [recipies/vllm-lmcache-nixl/README.md](../recipies/vllm-lmcache-nixl/README.md).
+
+### vLLM + LMCache + hipFile (`recipies/vllm-lmcache-hipfile`)
+
+Same pattern; default IO backend is hipfile:
+
+```bash
+export ROCM_ARCH=gfx942
+make -C recipies/vllm-lmcache-hipfile build
+export HF_TOKEN=...
+mkdir -p /mnt/lmcache-nvme recipies/vllm-lmcache-hipfile/logs
+make -C recipies/vllm-lmcache-hipfile run \
+  VLH_LMCACHE_IO=hipfile \
+  GPU=0 DATA=/mnt/lmcache-nvme
+```
+
+Slurm: `./run-slurm.sh`.
+
+### Ansible coupling after a recipe is running
+
+1. `host_setup_rocm_aic_exporter_ais_stats_container` must match the
+   container name (`CONTAINER_NAME`, default `vllm-lmcache-nixl-gpu0`).
+2. `host_setup_rocm_aic_exporter_vlh_host_data_root` must match the `DATA=`
+   mount (default `/mnt/lmcache-nvme`).
+3. Re-apply the textfile exporter:
+   `ansible-playbook site.yml --tags rocm_aic_exporter`.
+4. Optional vLLM/LMCache scrape jobs on the monitoring server — set in
+   `inventory/group_vars/monitoring_server.yml`:
+   `monitoring_scrape_vllm_enabled: true` and/or
+   `monitoring_scrape_lmcache_enabled: true`, then
+   `ansible-playbook site.yml --tags monitoring`.
+
+### ROCm inference stack image (`recipies/rocm-inference-stack`)
+
+Manual build:
+
+```bash
+cd recipies/rocm-inference-stack
+DOCKER_BUILDKIT=1 docker buildx build -f Dockerfile -t rocm-inference-stack:latest .
+```
+
+Ansible build and deploy to `gpu_nodes`:
+
+```bash
+cd ansible
+ansible-playbook playbooks/inference-image.yml --tags inference-image-build
+ansible-playbook playbooks/inference-image.yml --tags inference-image-deploy
+```
+
+Default build context: `recipies/rocm-inference-stack` (see
+`inference_container_context_path` in `group_vars/gpu_nodes.yml`).
+
+### llm-d Kubernetes (`recipies/llm-d`)
+
+Not managed by Ansible. One-time setup and tiered-prefix-cache deploy:
+
+```bash
+cd recipies/llm-d/setup && ./prereqs.sh -y && just llm-d-setup
+cd ../tiered-prefix-cache && just setup && just port-forward-start
+```
+
+Optional: federate in-cluster Prometheus into the lab server via
+`monitoring_llmd_prometheus_federate_*` in `monitoring_server.yml`.
+
+### Benchmark data (optional)
+
+```bash
+make -C recipies/vllm-lmcache-nixl data-all BOOK_DATA_ROOT=/path/to/gutenberg
+```
+
+## Monitoring — Prometheus remote write
+
+The `monitoring_stack` role pushes metrics to an external endpoint when
+`monitoring_prometheus_remote_write_url` is set. Configure in
+`inventory/group_vars/monitoring_server.yml` or via `-e`:
+
+```bash
+ansible-playbook site.yml --tags monitoring \
+  -e monitoring_prometheus_remote_write_url=https://mimir.example:9009/api/v1/push
+```
+
+See `roles/monitoring_stack/defaults/main.yml` for auth and TLS variables.
+The remote-write **receiver** (`--web.enable-remote-write-receiver`) is
+opt-in (`monitoring_prometheus_enable_remote_write_receiver: true`).
+
+Grafana cluster summary sync from the repo root: `./deploy.sh apply`.
+
+[galaxy]: https://galaxy.ansible.com/ui/repo/published/sbates130272/batesste/

--- a/ansible/inventory/group_vars/gpu_nodes.yml
+++ b/ansible/inventory/group_vars/gpu_nodes.yml
@@ -86,6 +86,8 @@ extra_packages:
   - prometheus-node-exporter
 
 # --- Optional: ROCm inference container (playbooks/inference-image.yml) ---
+# Default build context: recipies/rocm-inference-stack (override if needed):
+# inference_container_context_path: "{{ playbook_dir }}/../../recipies/rocm-inference-stack"
 # inference_nixl_git_url: https://github.com/andyluo7/nixl.git
 # inference_nixl_git_ref: f72aad2cf4da0dff5d710dfcaa8666defa114d78  # amd-support + AIS overlay
 # inference_llm_d_git_sha: "" # optional llm-d commit after branch checkout

--- a/ansible/inventory/group_vars/monitoring_server.yml
+++ b/ansible/inventory/group_vars/monitoring_server.yml
@@ -17,9 +17,18 @@ monitoring_grafana_require_admin_password: false
 # monitoring_grafana_dashboard_node_exporter_id: "1860"
 # monitoring_grafana_dashboard_amd_gpu_id: "23434"
 
-# Accept Prometheus remote write at POST /api/v1/write (web.enable-remote-write-
-# receiver). Appended via prometheus.service.d drop-in (monitoring_stack).
-monitoring_prometheus_enable_remote_write_receiver: true
+# Push metrics to an external Prometheus-compatible endpoint (Grafana Cloud,
+# Mimir, etc.). Set secrets with vault or `-e`.
+# monitoring_prometheus_remote_write_url: "https://prometheus-prod-XX.grafana.net/api/prom/push"
+# monitoring_prometheus_remote_write_basic_auth_username: "123456"
+# monitoring_prometheus_remote_write_basic_auth_password: "{{ vault_grafana_cloud_token }}"
+
+# Opt-in vLLM/LMCache scrape jobs (Docker recipes use --network=host :8000).
+# monitoring_scrape_vllm_enabled: true
+# monitoring_scrape_lmcache_enabled: true
+
+# Optional: accept remote write at POST /api/v1/write on this server (advanced).
+# monitoring_prometheus_enable_remote_write_receiver: true
 
 # Optional: federate metrics from an llm-d / in-cluster Prometheus into this
 # server's Prometheus TSDB.

--- a/ansible/inventory/hosts.yml
+++ b/ansible/inventory/hosts.yml
@@ -10,6 +10,10 @@ all:
         ansible_user: "{{ lookup('env', 'ANSIBLE_REMOTE_USER')
           | default('stebates', true) }}"
       hosts:
+        # Dev / bench box; SSH from any control node (no ansible_connection:
+        # local). Override ansible_host if cluster nodes reach it on another IP.
+        snoc-thinkstation:
+          ansible_host: 10.0.0.131
         g04u07:
           ansible_host: 10.245.130.131
         g04u13:

--- a/ansible/playbooks/monitoring.yml
+++ b/ansible/playbooks/monitoring.yml
@@ -20,8 +20,9 @@
 # Grafana: cluster summary dashboard UID rocm-aic-cluster (recording rules
 # rocm_icms:nvme:key / rocm_icms:rdma:key; textfile rocm_icms_software_version).
 #
-# Prometheus on monitoring_server: scrape-only config in prometheus.yml; remote
-# write receiver enabled via /etc/default/prometheus (POST /api/v1/write).
+# Prometheus on monitoring_server: scrape config in prometheus.yml; optional
+# outbound remote_write when monitoring_prometheus_remote_write_url is set.
+# Remote-write receiver is opt-in (monitoring_prometheus_enable_remote_write_receiver).
 
 - name: Install monitoring stack on monitoring server
   hosts: monitoring_server

--- a/ansible/roles/inference_container/defaults/main.yml
+++ b/ansible/roles/inference_container/defaults/main.yml
@@ -12,7 +12,8 @@ inference_container_image: >-
 # After build: tarball on the Ansible controller (localhost play)
 inference_container_tarball: /tmp/rocm-inference-stack.tar
 
-# Path to Dockerfile directory (repo: containers/rocm-inference-stack)
+# Path to Dockerfile directory (repo: recipies/rocm-inference-stack).
+# Empty uses playbook_dir/../../recipies/rocm-inference-stack (see build.yml).
 inference_container_context_path: ""
 
 # Git URLs / refs (NIXL default: public ROCm/nixl over HTTPS; no BuildKit SSH).

--- a/ansible/roles/inference_container/tasks/build.yml
+++ b/ansible/roles/inference_container/tasks/build.yml
@@ -10,7 +10,7 @@
         inference_container_context_path
         if (inference_container_context_path | length) > 0
         else (playbook_dir | dirname | dirname)
-        ~ '/containers/rocm-inference-stack'
+        ~ '/recipies/rocm-inference-stack'
       }}
 
 - name: Check Dockerfile exists

--- a/ansible/roles/monitoring_stack/defaults/main.yml
+++ b/ansible/roles/monitoring_stack/defaults/main.yml
@@ -32,9 +32,24 @@ monitoring_grafana_dashboard_amd_gpu_id: "23434"
 
 monitoring_grafana_provision_cluster_summary_dashboard: true
 
-# Prometheus: remote-write receiver via systemd drop-in (preserves package
-# /etc/default/prometheus ARGS). Enables POST /api/v1/write on the server.
-monitoring_prometheus_enable_remote_write_receiver: true
+# Outbound remote_write. Empty url = disabled (local TSDB only).
+monitoring_prometheus_remote_write_url: ""
+monitoring_prometheus_remote_write_basic_auth_username: ""
+monitoring_prometheus_remote_write_basic_auth_password: ""
+monitoring_prometheus_remote_write_bearer_token: ""
+monitoring_prometheus_remote_write_tls_ca_file: ""
+monitoring_prometheus_remote_write_insecure_skip_verify: false
+
+# Opt-in scrape jobs for vLLM/LMCache (host-network Docker recipes on :8000).
+monitoring_scrape_vllm_enabled: false
+monitoring_scrape_vllm_port: 8000
+monitoring_scrape_lmcache_enabled: false
+monitoring_scrape_lmcache_port: 8000
+monitoring_scrape_lmcache_metrics_path: /metrics
+
+# Remote-write receiver (POST /api/v1/write). Off by default; enable for
+# agents that push into this server's TSDB.
+monitoring_prometheus_enable_remote_write_receiver: false
 # Extra flags appended in systemd drop-in ExecStart when args_override is empty.
 monitoring_prometheus_extra_args: []
 # Non-empty string replaces /etc/default/prometheus ARGS entirely (advanced).

--- a/ansible/roles/monitoring_stack/tasks/prometheus.yml
+++ b/ansible/roles/monitoring_stack/tasks/prometheus.yml
@@ -3,6 +3,26 @@
 # SPDX-License-Identifier: MIT
 
 ---
+- name: Validate remote write URL when configured
+  ansible.builtin.assert:
+    that:
+      - monitoring_prometheus_remote_write_url is match('^https?://')
+    fail_msg: >-
+      monitoring_prometheus_remote_write_url must start with http:// or
+      https:// when set.
+  when: monitoring_prometheus_remote_write_url | default('') | length > 0
+
+- name: Warn when remote write URL lacks credentials
+  ansible.builtin.debug:
+    msg: >-
+      monitoring_prometheus_remote_write_url is set but neither basic_auth
+      nor bearer_token is configured; push may fail for authenticated
+      endpoints (e.g. Grafana Cloud).
+  when:
+    - monitoring_prometheus_remote_write_url | default('') | length > 0
+    - monitoring_prometheus_remote_write_basic_auth_username | default('') | length == 0
+    - monitoring_prometheus_remote_write_bearer_token | default('') | length == 0
+
 - name: Ensure Prometheus systemd drop-in directory exists
   ansible.builtin.file:
     path: /etc/systemd/system/prometheus.service.d

--- a/ansible/roles/monitoring_stack/templates/prometheus.yml.j2
+++ b/ansible/roles/monitoring_stack/templates/prometheus.yml.j2
@@ -11,6 +11,26 @@ global:
     cluster: rocm-icms
     replica: "{{ inventory_hostname }}"
 
+{% if monitoring_prometheus_remote_write_url | default('') | length > 0 %}
+remote_write:
+  - url: "{{ monitoring_prometheus_remote_write_url }}"
+{% if monitoring_prometheus_remote_write_basic_auth_username | default('') | length > 0 %}
+    basic_auth:
+      username: "{{ monitoring_prometheus_remote_write_basic_auth_username }}"
+      password: "{{ monitoring_prometheus_remote_write_basic_auth_password }}"
+{% elif monitoring_prometheus_remote_write_bearer_token | default('') | length > 0 %}
+    authorization:
+      credentials: "{{ monitoring_prometheus_remote_write_bearer_token }}"
+{% endif %}
+{% if monitoring_prometheus_remote_write_tls_ca_file | default('') | length > 0 %}
+    tls_config:
+      ca_file: "{{ monitoring_prometheus_remote_write_tls_ca_file }}"
+{% elif monitoring_prometheus_remote_write_insecure_skip_verify | default(false) | bool %}
+    tls_config:
+      insecure_skip_verify: true
+{% endif %}
+{% endif %}
+
 rule_files:
   - /etc/prometheus/rules/rocm_icms.yml
 
@@ -61,6 +81,30 @@ scrape_configs:
           instance: "{{ host }}"
           hostname: "{{ host }}"
 {% endfor %}
+
+{% if monitoring_scrape_vllm_enabled | default(false) | bool %}
+  - job_name: vllm-exporter
+    metrics_path: /metrics
+    static_configs:
+{% for host in groups['gpu_nodes'] %}
+      - targets:
+          - "{{ hostvars[host].ansible_host }}:{{ monitoring_scrape_vllm_port | default(8000) }}"
+        labels:
+          instance: "{{ hostvars[host].ansible_host }}:{{ monitoring_scrape_vllm_port | default(8000) }}"
+{% endfor %}
+{% endif %}
+
+{% if monitoring_scrape_lmcache_enabled | default(false) | bool %}
+  - job_name: lmcache-exporter
+    metrics_path: "{{ monitoring_scrape_lmcache_metrics_path | default('/metrics') }}"
+    static_configs:
+{% for host in groups['gpu_nodes'] %}
+      - targets:
+          - "{{ hostvars[host].ansible_host }}:{{ monitoring_scrape_lmcache_port | default(8000) }}"
+        labels:
+          instance: "{{ hostvars[host].ansible_host }}:{{ monitoring_scrape_lmcache_port | default(8000) }}"
+{% endfor %}
+{% endif %}
 {% endif %}
 
 {% if monitoring_llmd_prometheus_federate_enabled | default(false) | bool %}

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -197,7 +197,7 @@ Related material in this repository
 * **Performance notes** for shared-namespace NVMe-oF on the lab fabric are in
   ``performance.rst`` in this directory.
 * **ROCm inference stack** container (vLLM, LMCache, hipFile checkout, llm-d
-  source for charts): ``containers/rocm-inference-stack/README.md``.
+  source for charts): ``recipies/rocm-inference-stack/README.md``.
 * **LMCache TTFT benchmark** and AIS-oriented configs: ``benchmarks/ttft-lmcache/``.
 * **Ansible** playbooks for NVMe-oF target and initiator roles:
   ``ansible/playbooks/nvme-of.yml`` and inventory under ``ansible/inventory/``.

--- a/grafana/README.md
+++ b/grafana/README.md
@@ -15,8 +15,11 @@ and `rocm_aic_*` textfile metrics from
 [`rocm-aic-exporter.py`](../recipies/common/scripts/rocm-aic-exporter.py).
 
 Expects Prometheus scrape jobs named `node_exporter`, `nvme_exporter`,
-`vllm-exporter`, `lmcache-exporter`, and `amd_metrics_exporter` (as
-provisioned by the Ansible `monitoring_stack` role).
+`amd_metrics_exporter`, and (when enabled in inventory) `vllm-exporter` and
+`lmcache-exporter` from the Ansible `monitoring_stack` role. Set
+`monitoring_scrape_vllm_enabled` and/or `monitoring_scrape_lmcache_enabled`
+in `ansible/inventory/group_vars/monitoring_server.yml`, then run
+`ansible-playbook site.yml --tags monitoring`.
 
 ### Local vs NFS AIC storage
 


### PR DESCRIPTION
Point inference_container builds at recipies/rocm-inference-stack, add an ansible/README runbook for playbooks and recipe workflows, and fix stale deployments/ and containers/ documentation paths.

Extend monitoring_stack with outbound remote_write (URL, auth, TLS), optional vllm-exporter and lmcache-exporter scrape jobs, and disable the remote-write receiver by default.
