### PR TITLE
Add vLLM AMD Grafana dashboard and dashboard lint/apply tooling.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,3 +41,11 @@ jobs:
           yamllint -c .yamllint \
             $(find . -name '*.yml' -o -name '*.yaml' \
               | grep -v '.git/')
+
+  grafana:
+    name: Grafana dashboards
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Normalize and lint dashboard JSON
+        run: make grafana-check

--- a/.github/workflows/vllm-lmcache-hipfile-config.yml
+++ b/.github/workflows/vllm-lmcache-hipfile-config.yml
@@ -56,23 +56,9 @@ jobs:
           ' "${MANIFEST}"
 
       - name: Validate Grafana dashboard JSON
-        env:
-          DASH: ${{ github.workspace }}/grafana/rocm-aic-dashboard.json
         run: |
           set -euo pipefail
-          jq -e '
-            (type == "object")
-            and (.kind == "Dashboard")
-            and (
-              ((.spec.elements // {} | keys | length) >= 1)
-              or ((.panels // [] | length) >= 1)
-            )
-            and (
-              ([.spec.elements[]? | select(.kind == "Panel")] | length) >= 1
-              or ((.panels // [] | length) >= 1)
-            )
-            and (([.. | strings? | select(test("rocm_aic_"))] | length) >= 1)
-          ' "${DASH}"
+          python3 grafana/scripts/lint-dashboards.py --check
 
       - name: Check Grafana dashboard normalization
         run: |

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ BENCH_DIR := $(REPO_ROOT)/benchmarks/llm-prefill-benchmark
 BOOK_DATA_ROOT ?= $(REPO_ROOT)/data/gutenberg
 
 .PHONY: help data data-all gutenberg-data gutenberg-data-all \
-	grafana-normalize grafana-check
+	grafana-apply grafana-lint grafana-normalize grafana-check
 
 .DEFAULT_GOAL := help
 
@@ -17,8 +17,10 @@ help:
 	@echo ""
 	@echo "  make data              download one Gutenberg book -> data/gutenberg/"
 	@echo "  make data-all          build full Gutenberg library -> data/gutenberg/"
+	@echo "  make grafana-apply     apply dashboard query/style improvements"
+	@echo "  make grafana-lint      lint grafana/*.json dashboard candidates"
 	@echo "  make grafana-normalize strip volatile fields from grafana/*.json"
-	@echo "  make grafana-check     CI: assert dashboards are normalized"
+	@echo "  make grafana-check     CI: normalize + lint all dashboard JSON"
 	@echo ""
 	@echo "Overrides: BOOK_DATA_ROOT, BOOK_SLUG, BOOK_PG_ID, DATA_ALL_LIMIT, ..."
 
@@ -28,8 +30,13 @@ data gutenberg-data:
 data-all gutenberg-data-all:
 	@$(MAKE) -C "$(BENCH_DIR)" data-all BOOK_DATA_ROOT="$(BOOK_DATA_ROOT)"
 
+grafana-apply:
+	@python3 "$(REPO_ROOT)/grafana/scripts/apply-dashboard-improvements.py"
+
+grafana-lint:
+	@python3 "$(REPO_ROOT)/grafana/scripts/lint-dashboards.py" --check
+
 grafana-normalize:
 	@python3 "$(REPO_ROOT)/grafana/scripts/normalize-dashboard.py"
 
-grafana-check:
-	@python3 "$(REPO_ROOT)/grafana/scripts/normalize-dashboard.py" --check
+grafana-check: grafana-normalize grafana-lint

--- a/grafana/README.md
+++ b/grafana/README.md
@@ -108,7 +108,8 @@ CI runs `make grafana-check` (same script with `--check`) on pull requests
 that touch `grafana/**`.
 
 After editing in the Grafana UI, export or API-pull the dashboard, then
-normalize before commit. Assign a new UID only once:
+`make grafana-apply` (optional query/style fixes), `make grafana-normalize`,
+and `make grafana-lint` before commit. Assign a new UID only once:
 
 ```bash
 python3 grafana/scripts/normalize-dashboard.py --ensure-uid

--- a/grafana/rocm-aic-dashboard.json
+++ b/grafana/rocm-aic-dashboard.json
@@ -6,8 +6,8 @@
         "namespace": "default",
         "uid": "7f2af756-9968-44cd-8f7a-cd8be435dd28",
         "annotations": {
-            "rocm-aic.git.normalizedAt": "2026-05-29T05:18:45Z",
-            "rocm-aic.git.revision": "1633d5cd94d1e8dac62c893acabef509654691e7",
+            "rocm-aic.git.normalizedAt": "2026-06-03T21:29:36Z",
+            "rocm-aic.git.revision": "10fb4bad735ae03824943ad21ddb760b5c6094ea",
             "rocm-aic.git.author": "sbates@raithlin.com"
         }
     },
@@ -161,11 +161,11 @@
                                         "insertNulls": false,
                                         "lineInterpolation": "linear",
                                         "lineWidth": 1,
-                                        "pointSize": 1,
+                                        "pointSize": 0,
                                         "scaleDistribution": {
                                             "type": "linear"
                                         },
-                                        "showPoints": "auto",
+                                        "showPoints": "never",
                                         "showValues": false,
                                         "spanNulls": false,
                                         "stacking": {
@@ -307,11 +307,11 @@
                                         "insertNulls": false,
                                         "lineInterpolation": "linear",
                                         "lineWidth": 1,
-                                        "pointSize": 1,
+                                        "pointSize": 0,
                                         "scaleDistribution": {
                                             "type": "linear"
                                         },
-                                        "showPoints": "auto",
+                                        "showPoints": "never",
                                         "showValues": false,
                                         "spanNulls": false,
                                         "stacking": {
@@ -436,7 +436,7 @@
                                         "scaleDistribution": {
                                             "type": "linear"
                                         },
-                                        "showPoints": "auto",
+                                        "showPoints": "never",
                                         "showValues": false,
                                         "spanNulls": false,
                                         "stacking": {
@@ -581,7 +581,7 @@
                                         "scaleDistribution": {
                                             "type": "linear"
                                         },
-                                        "showPoints": "auto",
+                                        "showPoints": "never",
                                         "showValues": false,
                                         "spanNulls": false,
                                         "stacking": {
@@ -722,7 +722,7 @@
                                         "scaleDistribution": {
                                             "type": "linear"
                                         },
-                                        "showPoints": "auto",
+                                        "showPoints": "never",
                                         "showValues": false,
                                         "spanNulls": false,
                                         "stacking": {
@@ -860,9 +860,7 @@
                                     ],
                                     "displayMode": "table",
                                     "placement": "bottom",
-                                    "showLegend": true,
-                                    "sortBy": "Name",
-                                    "sortDesc": true
+                                    "showLegend": true
                                 },
                                 "tooltip": {
                                     "hideZeros": false,
@@ -909,7 +907,7 @@
                                         "scaleDistribution": {
                                             "type": "linear"
                                         },
-                                        "showPoints": "auto",
+                                        "showPoints": "never",
                                         "showValues": false,
                                         "spanNulls": false,
                                         "stacking": {
@@ -1030,7 +1028,7 @@
                                         "scaleDistribution": {
                                             "type": "linear"
                                         },
-                                        "showPoints": "auto",
+                                        "showPoints": "never",
                                         "showValues": false,
                                         "spanNulls": false,
                                         "stacking": {
@@ -1151,7 +1149,7 @@
                                         "scaleDistribution": {
                                             "type": "linear"
                                         },
-                                        "showPoints": "auto",
+                                        "showPoints": "never",
                                         "showValues": false,
                                         "spanNulls": false,
                                         "stacking": {
@@ -1292,7 +1290,7 @@
                                         "scaleDistribution": {
                                             "type": "linear"
                                         },
-                                        "showPoints": "auto",
+                                        "showPoints": "never",
                                         "showValues": false,
                                         "spanNulls": false,
                                         "stacking": {
@@ -1435,7 +1433,7 @@
                                         "scaleDistribution": {
                                             "type": "linear"
                                         },
-                                        "showPoints": "auto",
+                                        "showPoints": "never",
                                         "showValues": false,
                                         "spanNulls": false,
                                         "stacking": {
@@ -1556,7 +1554,7 @@
                                         "scaleDistribution": {
                                             "type": "linear"
                                         },
-                                        "showPoints": "auto",
+                                        "showPoints": "never",
                                         "showValues": false,
                                         "spanNulls": false,
                                         "stacking": {
@@ -1674,7 +1672,7 @@
                                         "insertNulls": false,
                                         "lineInterpolation": "smooth",
                                         "lineWidth": 1,
-                                        "pointSize": 5,
+                                        "pointSize": 0,
                                         "scaleDistribution": {
                                             "type": "linear"
                                         },
@@ -1799,7 +1797,7 @@
                                         "scaleDistribution": {
                                             "type": "linear"
                                         },
-                                        "showPoints": "auto",
+                                        "showPoints": "never",
                                         "showValues": false,
                                         "spanNulls": false,
                                         "stacking": {
@@ -1937,11 +1935,11 @@
                                         "insertNulls": false,
                                         "lineInterpolation": "linear",
                                         "lineWidth": 1,
-                                        "pointSize": 5,
+                                        "pointSize": 0,
                                         "scaleDistribution": {
                                             "type": "linear"
                                         },
-                                        "showPoints": "auto",
+                                        "showPoints": "never",
                                         "showValues": false,
                                         "spanNulls": false,
                                         "stacking": {
@@ -2037,9 +2035,7 @@
                                     ],
                                     "displayMode": "table",
                                     "placement": "bottom",
-                                    "showLegend": true,
-                                    "sortBy": "Name",
-                                    "sortDesc": true
+                                    "showLegend": true
                                 },
                                 "tooltip": {
                                     "hideZeros": false,
@@ -2086,7 +2082,7 @@
                                         "scaleDistribution": {
                                             "type": "linear"
                                         },
-                                        "showPoints": "auto",
+                                        "showPoints": "never",
                                         "showValues": false,
                                         "spanNulls": false,
                                         "stacking": {
@@ -2406,7 +2402,7 @@
                                         "insertNulls": false,
                                         "lineInterpolation": "smooth",
                                         "lineWidth": 1,
-                                        "pointSize": 5,
+                                        "pointSize": 0,
                                         "scaleDistribution": {
                                             "type": "linear"
                                         },
@@ -2767,7 +2763,7 @@
                 "spec": {
                     "id": 59,
                     "title": "AIC KV Cache Footprint",
-                    "description": "On-disk LMCache chunk bytes and used NIXL pool slots/bytes (0-byte slots excluded).",
+                    "description": "On-disk LMCache chunk and NIXL static pool size over time.",
                     "links": [],
                     "data": {
                         "kind": "QueryGroup",
@@ -2807,32 +2803,11 @@
                                             "spec": {
                                                 "editorMode": "code",
                                                 "expr": "sum(rocm_aic_nixl_pool_bytes_total{instance=~\"$host\"})",
-                                                "legendFormat": "NIXL pool bytes (used)",
+                                                "legendFormat": "NIXL pool bytes",
                                                 "range": true
                                             }
                                         },
                                         "refId": "B",
-                                        "hidden": false
-                                    }
-                                },
-                                {
-                                    "kind": "PanelQuery",
-                                    "spec": {
-                                        "query": {
-                                            "kind": "DataQuery",
-                                            "group": "prometheus",
-                                            "version": "v0",
-                                            "datasource": {
-                                                "name": "${datasource}"
-                                            },
-                                            "spec": {
-                                                "editorMode": "code",
-                                                "expr": "sum(rocm_aic_nixl_pool_slots_used{instance=~\"$host\"})",
-                                                "legendFormat": "NIXL pool slots used",
-                                                "range": true
-                                            }
-                                        },
-                                        "refId": "C",
                                         "hidden": false
                                     }
                                 }
@@ -2919,20 +2894,7 @@
                                         }
                                     }
                                 },
-                                "overrides": [
-                                    {
-                                        "matcher": {
-                                            "id": "byName",
-                                            "options": "NIXL pool slots used"
-                                        },
-                                        "properties": [
-                                            {
-                                                "id": "unit",
-                                                "value": "short"
-                                            }
-                                        ]
-                                    }
-                                ]
+                                "overrides": []
                             }
                         }
                     }
@@ -3931,7 +3893,10 @@
                     "pluginId": "prometheus",
                     "refresh": "onDashboardLoad",
                     "regex": "",
-                    "current": {},
+                    "current": {
+                        "text": "",
+                        "value": ""
+                    },
                     "options": [],
                     "multi": false,
                     "includeAll": false,
@@ -4000,14 +3965,14 @@
                         },
                         "spec": {
                             "qryType": 1,
-                            "query": "label_values(up{job=~\"vllm-exporter|vllm\"}, instance)",
+                            "query": "label_values(up{job=~\"vllm-exporter|vllm\",instance!~\"localhost(:.*)?\"}, instance)",
                             "refId": "PrometheusVariableQueryEditor-VariableQuery"
                         }
                     },
                     "regex": "",
                     "regexApplyTo": "value",
                     "sort": "alphabeticalAsc",
-                    "definition": "label_values(up{job=~\"vllm-exporter|vllm\"}, instance)",
+                    "definition": "label_values(up{job=~\"vllm-exporter|vllm\",instance!~\"localhost(:.*)?\"}, instance)",
                     "options": [],
                     "multi": true,
                     "includeAll": true,

--- a/grafana/scripts/apply-dashboard-improvements.py
+++ b/grafana/scripts/apply-dashboard-improvements.py
@@ -3,17 +3,225 @@
 #
 # SPDX-License-Identifier: MIT
 #
-"""Apply reviewed improvements to grafana/rocm-aic-dashboard.json."""
+"""Apply reviewed improvements to Grafana dashboard JSON in grafana/."""
 
 from __future__ import annotations
 
 import copy
 import json
+import math
+import re
+import sys
 from pathlib import Path
 from typing import Any
 
+_SCRIPT_DIR = Path(__file__).resolve().parent
+if str(_SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPT_DIR))
+
+from dashboard_v2_wire import (  # noqa: E402
+    fix_dashboard_v2_wire_format,
+    variable_dict,
+    variable_spec,
+)
+
 REPO = Path(__file__).resolve().parents[2]
-DASH_PATH = REPO / "grafana" / "rocm-aic-dashboard.json"
+ROCM_AIC_DASH_PATH = REPO / "grafana" / "rocm-aic-dashboard.json"
+VLLM_AMD_DASH_PATH = REPO / "grafana" / "vllm-dashboard-amd.json"
+
+LEGEND_TABLE = {
+    "calcs": ["min", "mean", "max", "lastNotNull"],
+    "displayMode": "table",
+    "placement": "bottom",
+    "showLegend": True,
+}
+
+EMPTY_VAR_CURRENT: dict[str, str] = {"text": "", "value": ""}
+
+VLLM_AMD_INSTANCE_VAR = "instance"
+VLLM_AMD_MODEL_VAR = "model"
+VLLM_AMD_JOB_REGEX = "vllm-exporter|vllm"
+# vLLM >= ~0.10 renamed TPOT histogram; older exports used time_per_output_token_seconds.
+VLLM_ITL_METRIC_LEGACY = "time_per_output_token_seconds"
+VLLM_ITL_METRIC = "inter_token_latency_seconds"
+# vLLM unified GPU/CPU block cache gauges into kv_cache_usage_perc.
+VLLM_GPU_CACHE_LEGACY = "gpu_cache_usage_perc"
+VLLM_KV_CACHE_METRIC = "kv_cache_usage_perc"
+
+VLLM_AMD_INSTANCE_LOCALHOST_FILTER = 'instance!~"localhost(:.*)?"'
+VLLM_AMD_INSTANCE_QUERY = (
+    f'label_values(up{{job=~"{VLLM_AMD_JOB_REGEX}",'
+    f"{VLLM_AMD_INSTANCE_LOCALHOST_FILTER}}}, instance)"
+)
+VLLM_AMD_MODEL_QUERY = (
+    f'label_values(vllm:{VLLM_KV_CACHE_METRIC}{{job=~"{VLLM_AMD_JOB_REGEX}",'
+    f'instance=~"$instance"}}, model_name)'
+)
+VLLM_AMD_ACTIVE_MODELS_PANEL_ID = 17
+VLLM_AMD_ACTIVE_MODELS_ELEMENT = "panel-17"
+VLLM_AMD_ACTIVE_MODELS_KV_EXPR = (
+    f"vllm:{VLLM_KV_CACHE_METRIC}{{job=~\"{VLLM_AMD_JOB_REGEX}\","
+    f'instance=~"$instance",model_name=~"$model"}}'
+)
+VLLM_AMD_ACTIVE_MODELS_RUNNING_EXPR = (
+    f'vllm:num_requests_running{{job=~"{VLLM_AMD_JOB_REGEX}",'
+    f'instance=~"$instance",model_name=~"$model"}}'
+)
+
+VLLM_DASHBOARD_TITLE = "AMD vLLM Inference Dashboard"
+VLLM_DASHBOARD_DESCRIPTION = (
+    "Prometheus metrics for vLLM inference: latency, throughput, scheduler "
+    "state, and KV-cache utilization."
+)
+VLLM_DASHBOARD_TIME_FROM = "now-24h"
+VLLM_LAYOUT_HEIGHT_SCALE = 1.5
+
+VLLM_PERCENTILE_LEGEND = {
+    "A": "P99",
+    "B": "P95",
+    "C": "P90",
+    "D": "P50",
+    "E": "Mean",
+}
+
+# Grid rows: element name, x, y, width, height (height before scale).
+_VLLM_GRID_BASE: list[tuple[str, int, int, int, int]] = [
+    ("panel-17", 0, 0, 24, 7),
+    ("panel-9", 0, 7, 12, 8),
+    ("panel-8", 12, 7, 12, 8),
+    ("panel-10", 0, 15, 12, 8),
+    ("panel-3", 12, 15, 12, 8),
+    ("panel-5", 0, 23, 12, 8),
+    ("panel-4", 12, 23, 12, 8),
+    ("panel-12", 0, 31, 12, 8),
+    ("panel-13", 12, 31, 12, 8),
+    ("panel-11", 0, 39, 12, 8),
+    ("panel-14", 12, 39, 12, 8),
+    ("panel-15", 0, 47, 12, 8),
+    ("panel-16", 12, 47, 12, 8),
+]
+
+# Panel id -> title, description, optional legendFormats by refId.
+VLLM_PANEL_METADATA: dict[int, dict[str, Any]] = {
+    3: {
+        "title": "Scheduler State",
+        "description": (
+            "Count of requests in running, waiting, and swapped scheduler "
+            "states (vllm:num_requests_*)."
+        ),
+        "legendFormats": {
+            "A": "Running",
+            "B": "Swapped",
+            "C": "Waiting",
+        },
+    },
+    4: {
+        "title": "KV Cache Utilization",
+        "description": (
+            "Share of KV-cache blocks in use, 0–1 scale "
+            f"(vllm:{VLLM_KV_CACHE_METRIC})."
+        ),
+        "legendFormats": {"A": "KV cache"},
+        "hideQueryRefs": {"B"},
+        "hideLegend": True,
+    },
+    5: {
+        "title": "TTFT Latency",
+        "description": (
+            "Time to first output token: P50, P90, P95, P99, and mean "
+            "(vllm:time_to_first_token_seconds)."
+        ),
+        "legendFormats": dict(VLLM_PERCENTILE_LEGEND),
+    },
+    8: {
+        "title": "Token Throughput",
+        "description": (
+            "Prompt and generation token processing rates per second "
+            "(vllm:prompt_tokens_total, vllm:generation_tokens_total)."
+        ),
+        "legendFormats": {
+            "A": "Prompt tok/s",
+            "B": "Generation tok/s",
+        },
+    },
+    9: {
+        "title": "E2E Request Latency",
+        "description": (
+            "End-to-end request latency: P50, P90, P95, P99, and mean "
+            "(vllm:e2e_request_latency_seconds)."
+        ),
+        "legendFormats": dict(VLLM_PERCENTILE_LEGEND),
+    },
+    10: {
+        "title": "ITL Latency",
+        "description": (
+            "Inter-token latency during decode: P50, P90, P95, P99, and mean "
+            f"(vllm:{VLLM_ITL_METRIC})."
+        ),
+        "legendFormats": dict(VLLM_PERCENTILE_LEGEND),
+    },
+    11: {
+        "title": "Request Finish Reasons",
+        "description": (
+            "Completed requests by finish reason, such as EOS or max "
+            "sequence length (vllm:request_success_total)."
+        ),
+        "legendFormats": {"A": "{{finished_reason}}"},
+        "alwaysShowLegend": True,
+    },
+    12: {
+        "title": "Prompt Length Distribution",
+        "description": (
+            "Heatmap of input prompt token counts per request "
+            "(vllm:request_prompt_tokens_bucket)."
+        ),
+    },
+    13: {
+        "title": "Generation Length Distribution",
+        "description": (
+            "Heatmap of output token counts per request "
+            "(vllm:request_generation_tokens_bucket)."
+        ),
+    },
+    14: {
+        "title": "Request Queue Time",
+        "description": (
+            "Time requests spend waiting in the scheduler queue before "
+            "execution (vllm:request_queue_time_seconds)."
+        ),
+        "legendFormats": {"A": "Queue time"},
+        "hideLegend": True,
+    },
+    15: {
+        "title": "Prefill and Decode Time",
+        "description": (
+            "Aggregate time spent in prefill and decode phases "
+            "(vllm:request_prefill_time_seconds, "
+            "vllm:request_decode_time_seconds)."
+        ),
+        "legendFormats": {"A": "Prefill", "B": "Decode"},
+    },
+    16: {
+        "title": "Max Generation Tokens",
+        "description": (
+            "Maximum generation tokens reserved per sequence group "
+            "(vllm:request_max_num_generation_tokens)."
+        ),
+        "legendFormats": {"A": "Max tokens"},
+        "hideLegend": True,
+    },
+    17: {
+        "title": "Active Models",
+        "description": (
+            "KV-cache use and in-flight requests per model/engine over time "
+            "(vllm:kv_cache_usage_perc, vllm:num_requests_running)."
+        ),
+        "legendFormats": {
+            "A": "{{model_name}} · KV cache (engine {{engine}})",
+            "B": "{{model_name}} · running (engine {{engine}})",
+        },
+    },
+}
 
 HIT_RATIO_EXPR = (
     "sum(rate(vllm:external_prefix_cache_hits_total{"
@@ -35,7 +243,7 @@ HOST_QUERY = (
     'label_values(up{job=~"node_exporter|node|amd_metrics_exporter|amd_exporter"}, '
     "instance)"
 )
-VLLM_INSTANCE_QUERY = 'label_values(up{job=~"vllm-exporter|vllm"}, instance)'
+VLLM_INSTANCE_QUERY = VLLM_AMD_INSTANCE_QUERY
 RDMA_DEVICE_QUERY = (
     'label_values(rdma_port_rcv_data_total{instance=~"$host"}, device)'
 )
@@ -192,6 +400,55 @@ def make_stat_panel(
     }
 
 
+def make_table_panel(
+    panel_id: int,
+    title: str,
+    description: str,
+    queries: list[dict[str, Any]],
+    *,
+    unit: str = "none",
+    transformations: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    defaults: dict[str, Any] = {
+        "thresholds": copy.deepcopy(THRESHOLD_GREEN_ONLY),
+        "color": {"mode": "thresholds"},
+        "custom": {
+            "align": "auto",
+            "cellOptions": {"type": "auto"},
+            "footer": {"reducers": []},
+            "inspect": False,
+        },
+    }
+    if unit != "none":
+        defaults["unit"] = unit
+    return {
+        "kind": "Panel",
+        "spec": {
+            "id": panel_id,
+            "title": title,
+            "description": description,
+            "links": [],
+            "data": {
+                "kind": "QueryGroup",
+                "spec": {
+                    "queries": queries,
+                    "transformations": transformations or [],
+                    "queryOptions": {},
+                },
+            },
+            "vizConfig": {
+                "kind": "VizConfig",
+                "group": "table",
+                "version": "13.0.1",
+                "spec": {
+                    "options": {"cellHeight": "sm", "showHeader": True},
+                    "fieldConfig": {"defaults": defaults, "overrides": []},
+                },
+            },
+        },
+    }
+
+
 def make_timeseries_panel(
     panel_id: int,
     title: str,
@@ -299,9 +556,7 @@ def optional_constant_var(
     *,
     hide: str = "dontHide",
 ) -> dict[str, Any]:
-    return {
-        "kind": "ConstantVariable",
-        "spec": {
+    return variable_dict("ConstantVariable", {
             "name": name,
             "current": {"text": NFS_MOUNT_DEFAULT, "value": NFS_MOUNT_DEFAULT},
             "label": label,
@@ -315,8 +570,7 @@ def optional_constant_var(
             "multi": False,
             "includeAll": False,
             "allowCustomValue": True,
-        },
-    }
+        })
 
 
 def query_var(
@@ -359,7 +613,371 @@ def query_var(
     }
     if include_all:
         spec["allValue"] = ".+"
-    return {"kind": "QueryVariable", "spec": spec}
+    return variable_dict("QueryVariable", spec)
+
+
+def iter_panel_specs(dash: dict[str, Any]):
+    """Yield panel spec dicts from a Grafana v2 dashboard."""
+    for elem in dash.get("spec", {}).get("elements", {}).values():
+        if elem.get("kind") == "Panel":
+            yield elem["spec"]
+
+
+def iter_prom_query_specs(dash: dict[str, Any]):
+    """Yield Prometheus query spec dicts (panel queries and variable queries)."""
+    for panel in iter_panel_specs(dash):
+        queries = panel.get("data", {}).get("spec", {}).get("queries", [])
+        for q in queries:
+            qspec = q.get("spec", {}).get("query", {}).get("spec", {})
+            if isinstance(qspec, dict) and "expr" in qspec:
+                yield qspec
+    for var in dash.get("spec", {}).get("variables", []):
+        q = variable_spec(var).get("query", {})
+        if isinstance(q, dict) and q.get("group") == "prometheus":
+            qspec = q.get("spec", {})
+            if isinstance(qspec, dict) and "query" in qspec:
+                yield qspec
+
+
+def apply_timeseries_styling_to_dashboard(dash: dict[str, Any]) -> None:
+    """Table legends and 0-width points on all timeseries panels."""
+    for panel in iter_panel_specs(dash):
+        viz = panel.get("vizConfig", {})
+        if viz.get("group") != "timeseries":
+            continue
+        viz_spec = viz.setdefault("spec", {})
+        options = viz_spec.setdefault("options", {})
+        options["legend"] = copy.deepcopy(LEGEND_TABLE)
+        defaults = viz_spec.setdefault("fieldConfig", {}).setdefault("defaults", {})
+        custom = defaults.setdefault("custom", {})
+        custom["pointSize"] = 0
+        custom["showPoints"] = "never"
+
+
+def _scale_vllm_panel_height(base_height: int) -> int:
+    return max(1, math.ceil(base_height * VLLM_LAYOUT_HEIGHT_SCALE))
+
+
+def rebuild_vllm_layout(dash: dict[str, Any]) -> None:
+    """Place vLLM panels on a non-overlapping grid with scaled row heights."""
+    layout_items: list[dict[str, Any]] = []
+    y = 0
+    idx = 0
+    while idx < len(_VLLM_GRID_BASE):
+        base_y = _VLLM_GRID_BASE[idx][2]
+        row: list[tuple[str, int, int, int, int]] = []
+        while idx < len(_VLLM_GRID_BASE) and _VLLM_GRID_BASE[idx][2] == base_y:
+            row.append(_VLLM_GRID_BASE[idx])
+            idx += 1
+        row_height = _scale_vllm_panel_height(row[0][4])
+        for name, x, _, width, _ in row:
+            layout_items.append(
+                {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                        "x": x,
+                        "y": y,
+                        "width": width,
+                        "height": row_height,
+                        "element": {
+                            "kind": "ElementReference",
+                            "name": name,
+                        },
+                    },
+                }
+            )
+        y += row_height
+    dash.setdefault("spec", {}).setdefault("layout", {}).setdefault("spec", {})[
+        "items"
+    ] = layout_items
+
+
+def _visible_query_count(panel: dict[str, Any]) -> int:
+    queries = panel.get("data", {}).get("spec", {}).get("queries", [])
+    return sum(1 for q in queries if not q.get("spec", {}).get("hidden", False))
+
+
+def apply_vllm_legend_styling(dash: dict[str, Any]) -> None:
+    """Hide legends on single-series panels; table calcs elsewhere."""
+    for panel in iter_panel_specs(dash):
+        viz = panel.get("vizConfig", {})
+        if viz.get("group") != "timeseries":
+            continue
+        options = viz.setdefault("spec", {}).setdefault("options", {})
+        meta = VLLM_PANEL_METADATA.get(panel.get("id"), {})
+        force_hide = meta.get("hideLegend", False)
+        force_show = meta.get("alwaysShowLegend", False)
+        visible = _visible_query_count(panel)
+        legend = copy.deepcopy(LEGEND_TABLE)
+        if force_hide:
+            legend["showLegend"] = False
+        elif force_show:
+            legend["showLegend"] = True
+        else:
+            legend["showLegend"] = visible > 1
+        options["legend"] = legend
+
+
+def apply_vllm_time_settings(dash: dict[str, Any]) -> None:
+    """Default dashboard time range for vLLM."""
+    time_settings = dash.setdefault("spec", {}).setdefault("timeSettings", {})
+    time_settings["from"] = VLLM_DASHBOARD_TIME_FROM
+    time_settings.setdefault("to", "now")
+
+
+def _strip_vllm_model_name_filter(expr: str) -> str:
+    """Remove model_name dashboard variable selectors from PromQL."""
+    patterns = (
+        r',model_name=~"\$model_name"',
+        r'model_name=~"\$model_name",',
+        r',model_name="\$model_name"',
+        r'model_name="\$model_name",',
+    )
+    for pat in patterns:
+        expr = re.sub(pat, "", expr)
+    return expr
+
+
+def fix_vllm_prom_expr(expr: str) -> str:
+    """Scope vLLM metrics to job + scrape instance; map legacy ITL metric names."""
+    if "vllm:" not in expr:
+        return expr
+    if VLLM_ITL_METRIC_LEGACY in expr:
+        expr = expr.replace(
+            f"vllm:{VLLM_ITL_METRIC_LEGACY}",
+            f"vllm:{VLLM_ITL_METRIC}",
+        )
+    if VLLM_GPU_CACHE_LEGACY in expr:
+        expr = expr.replace(
+            f"vllm:{VLLM_GPU_CACHE_LEGACY}",
+            f"vllm:{VLLM_KV_CACHE_METRIC}",
+        )
+    # Repair double-open-brace from a prior apply-script bug.
+    expr = re.sub(r"(vllm:[^\{]+)\{\{", r"\1{", expr)
+    expr = re.sub(
+        r'server_name="\$instance"',
+        f'{VLLM_AMD_INSTANCE_VAR}=~"${VLLM_AMD_INSTANCE_VAR}"',
+        expr,
+    )
+    expr = re.sub(
+        rf'{VLLM_AMD_INSTANCE_VAR}="\${VLLM_AMD_INSTANCE_VAR}"',
+        f'{VLLM_AMD_INSTANCE_VAR}=~"${VLLM_AMD_INSTANCE_VAR}"',
+        expr,
+    )
+    job_sel = f'job=~"{VLLM_AMD_JOB_REGEX}"'
+    instance_sel = f'{VLLM_AMD_INSTANCE_VAR}=~"${VLLM_AMD_INSTANCE_VAR}"'
+    model_sel = f'model_name=~"${VLLM_AMD_MODEL_VAR}"'
+
+    def add_vllm_selector_labels(match: re.Match[str]) -> str:
+        prefix, labels = match.group(1), match.group(2)
+        insert = ""
+        if job_sel not in labels:
+            insert += f"{job_sel},"
+        if instance_sel not in labels:
+            insert += f"{instance_sel},"
+        if model_sel not in labels:
+            insert += f"{model_sel},"
+        return f"{prefix}{insert}{labels}}}"
+
+    return re.sub(r"(vllm:[^\{]+\{)([^}]*)\}", add_vllm_selector_labels, expr)
+
+
+def fix_vllm_panel_metadata(dash: dict[str, Any]) -> None:
+    """Panel titles, descriptions, and legend labels for the vLLM dashboard."""
+    spec = dash.setdefault("spec", {})
+    spec["title"] = VLLM_DASHBOARD_TITLE
+    spec["description"] = VLLM_DASHBOARD_DESCRIPTION
+
+    for panel in iter_panel_specs(dash):
+        pid = panel.get("id")
+        meta = VLLM_PANEL_METADATA.get(pid)
+        if not meta:
+            continue
+        panel["title"] = meta["title"]
+        panel["description"] = meta["description"]
+        queries = panel.get("data", {}).get("spec", {}).get("queries", [])
+        legend_formats = meta.get("legendFormats", {})
+        hide_refs = meta.get("hideQueryRefs", set())
+        for q in queries:
+            qspec = q.get("spec", {})
+            ref = qspec.get("refId")
+            if ref in hide_refs:
+                qspec["hidden"] = True
+            if ref in legend_formats:
+                qspec.get("query", {}).get("spec", {})["legendFormat"] = (
+                    legend_formats[ref]
+                )
+
+
+def fix_vllm_datasource_refs(obj: Any) -> None:
+    """Rename legacy DS_PROMETHEUS variable references to datasource."""
+    if isinstance(obj, dict):
+        for key, val in list(obj.items()):
+            if key == "name" and val == "DS_PROMETHEUS":
+                obj[key] = "datasource"
+            elif isinstance(val, str):
+                if "${DS_PROMETHEUS}" in val:
+                    obj[key] = val.replace("${DS_PROMETHEUS}", "${datasource}")
+            else:
+                fix_vllm_datasource_refs(val)
+    elif isinstance(obj, list):
+        for item in obj:
+            fix_vllm_datasource_refs(item)
+
+
+def fix_vllm_variables(variables: list[dict[str, Any]]) -> None:
+    """Datasource (hidden), vLLM instance, and instance-scoped model selector."""
+    drop = {"model_name", "model_name_var"}
+    variables[:] = [
+        v for v in variables if variable_spec(v).get("name") not in drop
+    ]
+    for var in variables:
+        spec = variable_spec(var)
+        name = spec.get("name")
+        if name in ("DS_PROMETHEUS", "datasource"):
+            spec["name"] = "datasource"
+            spec["hide"] = "hideVariable"
+            spec["label"] = "Data source"
+            spec["current"] = copy.deepcopy(EMPTY_VAR_CURRENT)
+            spec["options"] = []
+        if name == VLLM_AMD_INSTANCE_VAR:
+            spec["label"] = "vLLM Instance"
+            spec["description"] = (
+                "Prometheus instance label on vLLM exporter scrape targets "
+                "(host:port from job vllm-exporter; localhost excluded)."
+            )
+            spec["current"] = copy.deepcopy(EMPTY_VAR_CURRENT)
+            spec["allowCustomValue"] = False
+        q = spec.get("query", {})
+        if isinstance(q, dict) and q.get("group") == "prometheus":
+            q.setdefault("datasource", {})["name"] = "${datasource}"
+            if name == VLLM_AMD_INSTANCE_VAR:
+                qspec = q.setdefault("spec", {})
+                qspec["query"] = VLLM_AMD_INSTANCE_QUERY
+                spec["definition"] = VLLM_AMD_INSTANCE_QUERY
+
+    model_var = query_var(
+        VLLM_AMD_MODEL_VAR,
+        "LLM Model",
+        VLLM_AMD_MODEL_QUERY,
+        "Model name on the selected vLLM instance (from vllm:kv_cache_usage_perc).",
+        include_all=True,
+        sort="disabled",
+    )
+    variable_spec(model_var)["refresh"] = "onTimeRangeChanged"
+    variable_spec(model_var)["multi"] = False
+
+    model_idx = next(
+        (
+            i
+            for i, v in enumerate(variables)
+            if variable_spec(v).get("name") == VLLM_AMD_MODEL_VAR
+        ),
+        None,
+    )
+    inst_idx = next(
+        (
+            i
+            for i, v in enumerate(variables)
+            if variable_spec(v).get("name") == VLLM_AMD_INSTANCE_VAR
+        ),
+        None,
+    )
+    if model_idx is None:
+        insert_at = (inst_idx + 1) if inst_idx is not None else len(variables)
+        variables.insert(insert_at, model_var)
+    else:
+        variables[model_idx] = model_var
+
+
+def make_active_models_panel(
+    panel_id: int,
+    title: str,
+    description: str,
+) -> dict[str, Any]:
+    """Time series: KV-cache % (left) and running requests (right) per model."""
+    panel = make_timeseries_panel(
+        panel_id,
+        title,
+        description,
+        [
+            panel_query(
+                "A",
+                VLLM_AMD_ACTIVE_MODELS_KV_EXPR,
+                legend="{{model_name}} · KV cache (engine {{engine}})",
+            ),
+            panel_query(
+                "B",
+                VLLM_AMD_ACTIVE_MODELS_RUNNING_EXPR,
+                legend="{{model_name}} · running (engine {{engine}})",
+            ),
+        ],
+        unit="short",
+        tooltip_multi=True,
+        fill_opacity=0,
+    )
+    viz = panel["spec"]["vizConfig"]["spec"]
+    viz["fieldConfig"]["defaults"] = {
+        "unit": "short",
+        "min": 0,
+        "thresholds": copy.deepcopy(THRESHOLD_GREEN_ONLY),
+        "color": {"mode": "palette-classic"},
+        "custom": viz["fieldConfig"]["defaults"]["custom"],
+    }
+    viz["fieldConfig"]["overrides"] = [
+        {
+            "matcher": {"id": "byRegexp", "options": "KV cache"},
+            "properties": [
+                {"id": "unit", "value": "percentunit"},
+                {"id": "min", "value": 0},
+                {"id": "max", "value": 1},
+                {"id": "custom.axisPlacement", "value": "left"},
+            ],
+        },
+        {
+            "matcher": {"id": "byRegexp", "options": "running"},
+            "properties": [
+                {"id": "unit", "value": "short"},
+                {"id": "decimals", "value": 0},
+                {"id": "custom.axisPlacement", "value": "right"},
+            ],
+        },
+    ]
+    return panel
+
+
+def ensure_vllm_active_models_panel(dash: dict[str, Any]) -> None:
+    """Top-of-dashboard time series for loaded models on the selected instance."""
+    spec = dash.setdefault("spec", {})
+    elements = spec.setdefault("elements", {})
+
+    meta = VLLM_PANEL_METADATA[VLLM_AMD_ACTIVE_MODELS_PANEL_ID]
+    elements[VLLM_AMD_ACTIVE_MODELS_ELEMENT] = make_active_models_panel(
+        VLLM_AMD_ACTIVE_MODELS_PANEL_ID,
+        meta["title"],
+        meta["description"],
+    )
+
+
+def fix_vllm_prom_queries(dash: dict[str, Any]) -> None:
+    for qspec in iter_prom_query_specs(dash):
+        if "expr" in qspec:
+            qspec["expr"] = fix_vllm_prom_expr(qspec["expr"])
+
+
+def apply_vllm_dashboard_improvements(dash: dict[str, Any]) -> None:
+    """vLLM AMD dashboard: instance/$instance filters and timeseries styling."""
+    fix_vllm_datasource_refs(dash)
+    spec = dash.setdefault("spec", {})
+    fix_vllm_variables(spec.get("variables", []))
+    ensure_vllm_active_models_panel(dash)
+    fix_vllm_prom_queries(dash)
+    fix_vllm_panel_metadata(dash)
+    apply_timeseries_styling_to_dashboard(dash)
+    apply_vllm_legend_styling(dash)
+    rebuild_vllm_layout(dash)
+    apply_vllm_time_settings(dash)
+    fix_dashboard_v2_wire_format(dash)
 
 
 def panel_by_id(elements: dict[str, Any], panel_id: int) -> dict[str, Any] | None:
@@ -412,7 +1030,7 @@ def fix_variables(variables: list[dict[str, Any]]) -> None:
     """Patch legacy variable entries (rebuild_variables replaces the full list)."""
     all_current = {"text": "All", "value": "$__all"}
     for var in variables:
-        spec = var.get("spec", {})
+        spec = variable_spec(var)
         name = spec.get("name")
         if name == "datasource":
             spec["current"] = {}
@@ -438,14 +1056,14 @@ def fix_variables(variables: list[dict[str, Any]]) -> None:
 
 def rebuild_variables() -> list[dict[str, Any]]:
     return [
-        {
-            "kind": "DatasourceVariable",
-            "spec": {
+        variable_dict(
+            "DatasourceVariable",
+            {
                 "name": "datasource",
                 "pluginId": "prometheus",
                 "refresh": "onDashboardLoad",
                 "regex": "",
-                "current": {},
+                "current": copy.deepcopy(EMPTY_VAR_CURRENT),
                 "options": [],
                 "multi": False,
                 "includeAll": False,
@@ -454,7 +1072,7 @@ def rebuild_variables() -> list[dict[str, Any]]:
                 "skipUrlSync": False,
                 "allowCustomValue": True,
             },
-        },
+        ),
         query_var(
             "host",
             "Host",
@@ -941,13 +1559,27 @@ def apply_improvements(dash: dict[str, Any]) -> None:
     normalize_host_variable_refs(dash)
     fix_host_metric_exprs(dash)
     spec["variables"] = rebuild_variables()
+    fix_dashboard_v2_wire_format(dash)
 
 
 def main() -> None:
-    dash = json.loads(DASH_PATH.read_text(encoding="utf-8"))
-    apply_improvements(dash)
-    DASH_PATH.write_text(json.dumps(dash, indent=4, ensure_ascii=False) + "\n", encoding="utf-8")
-    print(f"Updated {DASH_PATH}")
+    aic = json.loads(ROCM_AIC_DASH_PATH.read_text(encoding="utf-8"))
+    apply_improvements(aic)
+    apply_timeseries_styling_to_dashboard(aic)
+    ROCM_AIC_DASH_PATH.write_text(
+        json.dumps(aic, indent=4, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    print(f"Updated {ROCM_AIC_DASH_PATH}")
+
+    if VLLM_AMD_DASH_PATH.is_file():
+        vllm = json.loads(VLLM_AMD_DASH_PATH.read_text(encoding="utf-8"))
+        apply_vllm_dashboard_improvements(vllm)
+        VLLM_AMD_DASH_PATH.write_text(
+            json.dumps(vllm, indent=4, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+        print(f"Updated {VLLM_AMD_DASH_PATH}")
 
 
 if __name__ == "__main__":

--- a/grafana/scripts/dashboard_v2_wire.py
+++ b/grafana/scripts/dashboard_v2_wire.py
@@ -1,0 +1,106 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+"""Grafana dashboard v2 schema helpers for variables and transformations."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def is_wrapped_variable(var: dict[str, Any]) -> bool:
+    """True when a variable uses mistaken *VariableKind union-key wrappers."""
+    return any(k.endswith("VariableKind") for k in var)
+
+
+def variable_inner(var: dict[str, Any]) -> dict[str, Any]:
+    """Return {kind, spec} for a dashboard variable in any on-disk format."""
+    if is_wrapped_variable(var):
+        for key, inner in var.items():
+            if key.endswith("VariableKind") and isinstance(inner, dict):
+                return inner
+        return {}
+    return var
+
+
+def variable_spec(var: dict[str, Any]) -> dict[str, Any]:
+    inner = variable_inner(var)
+    spec = inner.get("spec")
+    return spec if isinstance(spec, dict) else {}
+
+
+def variable_dict(kind: str, spec: dict[str, Any]) -> dict[str, Any]:
+    """Grafana v2 variable entry: {kind, spec} at the array element root."""
+    return {"kind": kind, "spec": spec}
+
+
+def fix_variables_wire_format(variables: list[dict[str, Any]]) -> None:
+    """Normalize variables to flat {kind, spec} (unwrap mistaken union wrappers)."""
+    for i, var in enumerate(variables):
+        inner = variable_inner(var)
+        kind = inner.get("kind")
+        spec = inner.get("spec")
+        if isinstance(kind, str) and isinstance(spec, dict):
+            variables[i] = variable_dict(kind, spec)
+
+
+def is_v2beta1_transformation(t: dict[str, Any]) -> bool:
+    spec = t.get("spec")
+    return (
+        isinstance(t.get("kind"), str)
+        and t.get("kind") != "Transformation"
+        and isinstance(spec, dict)
+        and isinstance(spec.get("id"), str)
+    )
+
+
+def transformation_dict(trans_id: str, options: dict[str, Any]) -> dict[str, Any]:
+    """Grafana v2beta1 TransformationKind: kind is the transformer id."""
+    return {
+        "kind": trans_id,
+        "spec": {
+            "id": trans_id,
+            "options": options,
+        },
+    }
+
+
+def fix_transformations_wire_format(dash: dict[str, Any]) -> None:
+    """Normalize panel transformations to v2beta1 TransformationKind."""
+    elements = dash.get("spec", {}).get("elements", {})
+    if not isinstance(elements, dict):
+        return
+    for elem in elements.values():
+        if elem.get("kind") != "Panel":
+            continue
+        qspec = elem.get("spec", {}).get("data", {}).get("spec", {})
+        if not isinstance(qspec, dict):
+            continue
+        transforms = qspec.get("transformations")
+        if not isinstance(transforms, list):
+            continue
+        fixed: list[dict[str, Any]] = []
+        for t in transforms:
+            if is_v2beta1_transformation(t):
+                fixed.append(t)
+            elif t.get("kind") == "Transformation" and isinstance(t.get("group"), str):
+                fixed.append(
+                    transformation_dict(t["group"], t.get("spec", {}).get("options") or {})
+                )
+            elif isinstance(t.get("id"), str):
+                fixed.append(transformation_dict(t["id"], t.get("options") or {}))
+            else:
+                fixed.append(t)
+        qspec["transformations"] = fixed
+
+
+def fix_dashboard_v2_wire_format(dash: dict[str, Any]) -> None:
+    """Apply v2 schema fixes for variables and transformations."""
+    spec = dash.get("spec")
+    if not isinstance(spec, dict):
+        return
+    variables = spec.get("variables")
+    if isinstance(variables, list):
+        fix_variables_wire_format(variables)
+    fix_transformations_wire_format(dash)

--- a/grafana/scripts/lint-dashboards.py
+++ b/grafana/scripts/lint-dashboards.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+"""Lint Grafana dashboard JSON under grafana/.
+
+Checks structure expected by Grafana v2 dashboard schema, git normalization
+rules, and project conventions (datasource variable shape, PromQL selectors).
+
+Usage:
+  lint-dashboards.py [--check] [FILE ...]
+
+Default: all grafana/*.json dashboard candidates.
+Exit 0 when clean; exit 1 when --check and any file would change or has errors.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+def _load_wire_module():
+    path = _SCRIPT_DIR / "dashboard_v2_wire.py"
+    spec = importlib.util.spec_from_file_location("dashboard_v2_wire", path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load {path}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_wire = _load_wire_module()
+variable_spec = _wire.variable_spec
+is_wrapped_variable = _wire.is_wrapped_variable
+is_v2beta1_transformation = _wire.is_v2beta1_transformation
+
+
+def _load_normalize_module():
+    path = _SCRIPT_DIR / "normalize-dashboard.py"
+    spec = importlib.util.spec_from_file_location("normalize_dashboard", path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load {path}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_norm = _load_normalize_module()
+detect_format = _norm.detect_format
+is_normalized = _norm.is_normalized
+volatile_metadata_errors = _norm.volatile_metadata_errors
+default_dashboard_paths = _norm.default_dashboard_paths
+
+VALID_VARIABLE_HIDE = frozenset(
+    {"dontHide", "hideLabel", "hideVariable", "inControlsMenu"}
+)
+VALID_VARIABLE_REFRESH = frozenset(
+    {"never", "onDashboardLoad", "onTimeRangeChanged", "onVariableChange"}
+)
+EMPTY_VARIABLE_CURRENT = {"text": "", "value": ""}
+
+# Legacy import name; prefer ${datasource} in panel queries.
+LEGACY_DATASOURCE_VAR = "DS_PROMETHEUS"
+
+
+def repo_root() -> Path:
+    return _SCRIPT_DIR.parents[1]
+
+
+def dashboard_candidates() -> list[Path]:
+    root = repo_root() / "grafana"
+    return sorted(p for p in root.glob("*.json") if p.is_file())
+
+
+def iter_objects(obj: Any):
+    if isinstance(obj, dict):
+        yield obj
+        for v in obj.values():
+            yield from iter_objects(v)
+    elif isinstance(obj, list):
+        for item in obj:
+            yield from iter_objects(item)
+
+
+def variable_names(dash: dict[str, Any]) -> set[str]:
+    names: set[str] = set()
+    for var in dash.get("spec", {}).get("variables", []):
+        name = variable_spec(var).get("name")
+        if isinstance(name, str) and name:
+            names.add(name)
+    return names
+
+
+def panel_count_v2(dash: dict[str, Any]) -> int:
+    return sum(
+        1
+        for elem in dash.get("spec", {}).get("elements", {}).values()
+        if elem.get("kind") == "Panel"
+    )
+
+
+def lint_variable(var: dict[str, Any], path: Path) -> list[str]:
+    errors: list[str] = []
+    if is_wrapped_variable(var):
+        wrapper = next(k for k in var if k.endswith("VariableKind"))
+        errors.append(
+            f"{path}: variable {wrapper!r} uses union-key wrapper; "
+            f'use flat {{"kind": "...", "spec": {{...}}}} instead'
+        )
+        return errors
+
+    kind = var.get("kind")
+    spec = var.get("spec")
+    if not isinstance(spec, dict):
+        return [f"{path}: variable missing spec"]
+
+    name = spec.get("name", "")
+    prefix = f"{path}: variable {name!r}"
+
+    hide = spec.get("hide")
+    if hide is not None and hide not in VALID_VARIABLE_HIDE:
+        errors.append(f"{prefix}: invalid hide {hide!r}")
+
+    refresh = spec.get("refresh")
+    if refresh is not None and refresh not in VALID_VARIABLE_REFRESH:
+        errors.append(f"{prefix}: invalid refresh {refresh!r}")
+
+    current = spec.get("current")
+    if current is None:
+        errors.append(f"{prefix}: missing current (use {{\"text\": \"\", \"value\": \"\"}})")
+    elif not isinstance(current, dict):
+        errors.append(f"{prefix}: current must be an object")
+    elif "text" not in current or "value" not in current:
+        errors.append(
+            f"{prefix}: current must include text and value keys "
+            f"(got {sorted(current.keys())})"
+        )
+
+    if kind == "DatasourceVariable":
+        if name == LEGACY_DATASOURCE_VAR:
+            errors.append(
+                f"{prefix}: rename to 'datasource' and use ${{datasource}} in queries"
+            )
+        if not spec.get("pluginId"):
+            errors.append(f"{prefix}: DatasourceVariable requires pluginId")
+
+    if kind == "QueryVariable":
+        q = spec.get("query")
+        if not isinstance(q, dict) or q.get("group") != "prometheus":
+            errors.append(f"{prefix}: QueryVariable requires prometheus query")
+        else:
+            ds = q.get("datasource", {})
+            ds_name = ds.get("name") if isinstance(ds, dict) else None
+            if ds_name == f"${{{LEGACY_DATASOURCE_VAR}}}":
+                errors.append(f"{prefix}: use datasource ${'{datasource}'} not DS_PROMETHEUS")
+
+    return errors
+
+
+def lint_prom_expr(expr: str, path: Path, *, ctx: str) -> list[str]:
+    errors: list[str] = []
+    if "${DS_PROMETHEUS}" in expr or '"${DS_PROMETHEUS}"' in expr:
+        errors.append(f"{path}: {ctx} uses legacy ${{DS_PROMETHEUS}}; use ${{datasource}}")
+    vllm_amd = path.name.startswith("vllm-")
+    if vllm_amd and "vllm:" in expr and "job=~" not in expr and 'job="' not in expr:
+        errors.append(
+            f"{path}: {ctx} vLLM query missing job filter "
+            f'(expected job=~"vllm-exporter|vllm")'
+        )
+    if vllm_amd and re.search(r'server_name="\$instance"', expr):
+        errors.append(
+            f"{path}: {ctx} uses server_name=\"$instance\"; "
+            f"vLLM metrics should use instance=~\"$instance\""
+        )
+    return errors
+
+
+def lint_dashboard(path: Path, dash: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    errors.extend(f"{path}: {msg}" for msg in volatile_metadata_errors(dash))
+
+    fmt = detect_format(dash)
+    if fmt == "unknown":
+        return errors + [f"{path}: unrecognized dashboard format"]
+
+    if fmt == "v2":
+        if dash.get("apiVersion") != "dashboard.grafana.app/v2":
+            errors.append(f"{path}: apiVersion must be dashboard.grafana.app/v2")
+        if dash.get("kind") != "Dashboard":
+            errors.append(f"{path}: kind must be Dashboard")
+        if panel_count_v2(dash) < 1:
+            errors.append(f"{path}: expected at least one Panel in spec.elements")
+
+        names = variable_names(dash)
+        if "datasource" not in names and LEGACY_DATASOURCE_VAR not in names:
+            errors.append(f"{path}: missing datasource variable")
+
+        for var in dash.get("spec", {}).get("variables", []):
+            errors.extend(lint_variable(var, path))
+
+        for elem in dash.get("spec", {}).get("elements", {}).values():
+            if elem.get("kind") != "Panel":
+                continue
+            transforms = (
+                elem.get("spec", {})
+                .get("data", {})
+                .get("spec", {})
+                .get("transformations", [])
+            )
+            if not isinstance(transforms, list):
+                continue
+            for i, t in enumerate(transforms):
+                if not isinstance(t, dict) or not t:
+                    continue
+                if t.get("kind") == "Transformation":
+                    errors.append(
+                        f"{path}: transformation[{i}] uses Transformation wrapper; "
+                        f'use {{"kind": "<id>", "spec": {{"id": "<id>", "options": ...}}}}'
+                    )
+                elif "id" in t and "options" in t and "spec" not in t:
+                    errors.append(
+                        f"{path}: transformation[{i}] uses top-level id/options; "
+                        f'use {{"kind": "<id>", "spec": {{"id": "<id>", "options": ...}}}}'
+                    )
+                elif not is_v2beta1_transformation(t):
+                    errors.append(
+                        f"{path}: transformation[{i}] must be v2beta1 "
+                        f"TransformationKind (kind + spec.id + spec.options)"
+                    )
+
+        for obj in iter_objects(dash.get("spec", {})):
+            if not isinstance(obj, dict):
+                continue
+            ds = obj.get("datasource")
+            if isinstance(ds, dict):
+                ds_name = ds.get("name")
+                if ds_name == f"${{{LEGACY_DATASOURCE_VAR}}}":
+                    errors.append(
+                        f"{path}: panel/query uses legacy ${{DS_PROMETHEUS}} datasource"
+                    )
+                if isinstance(ds_name, str) and ds_name.startswith("${") and ds_name.endswith("}"):
+                    ref = ds_name[2:-1]
+                    if ref not in names and ref != "datasource":
+                        errors.append(
+                            f"{path}: datasource reference ${{{ref}}} "
+                            f"has no matching variable"
+                        )
+            spec = obj.get("spec")
+            if isinstance(spec, dict) and isinstance(spec.get("expr"), str):
+                errors.extend(
+                    lint_prom_expr(spec["expr"], path, ctx="PromQL expr")
+                )
+
+    if not is_normalized(dash):
+        errors.append(f"{path}: not normalized (run make grafana-normalize)")
+
+    return errors
+
+
+def process_file(path: Path, *, check: bool) -> int:
+    if not path.is_file():
+        print(f"lint-dashboards: not found: {path}", file=sys.stderr)
+        return 1
+
+    try:
+        dash = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        print(f"lint-dashboards: invalid JSON in {path}: {exc}", file=sys.stderr)
+        return 1
+
+    errors = lint_dashboard(path, dash)
+    if errors:
+        for msg in errors:
+            print(f"lint-dashboards: {msg}", file=sys.stderr)
+        if check:
+            print("lint-dashboards: fix errors above and re-run", file=sys.stderr)
+        return 1
+
+    print(f"lint-dashboards: OK {path}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Lint Grafana dashboard JSON.")
+    parser.add_argument(
+        "files",
+        nargs="*",
+        type=Path,
+        help="Dashboard JSON file(s) (default: grafana/*.json)",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit 1 when lint fails (for CI)",
+    )
+    args = parser.parse_args()
+
+    paths = [p.resolve() for p in (args.files or dashboard_candidates())]
+    if not paths:
+        print("lint-dashboards: no dashboard candidates found", file=sys.stderr)
+        return 1
+
+    rc = 0
+    for path in paths:
+        if process_file(path, check=args.check) != 0:
+            rc = 1
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/grafana/scripts/normalize-dashboard.py
+++ b/grafana/scripts/normalize-dashboard.py
@@ -16,7 +16,7 @@ Usage:
   normalize-dashboard.py [--check] [FILE ...]
   normalize-dashboard.py --ensure-uid [FILE ...]
 
-Default FILE: grafana/rocm-aic-dashboard.json relative to repo root.
+Default FILE: grafana/rocm-aic-dashboard.json and grafana/vllm-dashboard-amd.json.
 """
 
 from __future__ import annotations
@@ -31,7 +31,16 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-DEFAULT_DASH = "grafana/rocm-aic-dashboard.json"
+_SCRIPT_DIR = Path(__file__).resolve().parent
+if str(_SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPT_DIR))
+
+from dashboard_v2_wire import fix_dashboard_v2_wire_format  # noqa: E402
+
+DEFAULT_DASHBOARDS = (
+    "grafana/rocm-aic-dashboard.json",
+    "grafana/vllm-dashboard-amd.json",
+)
 
 # Grafana UI / API metadata not useful in git (v2).
 GRAFANA_APP_ANNOTATION_PREFIX = "grafana.app/"
@@ -50,8 +59,13 @@ def repo_root() -> Path:
     return script.parents[2]
 
 
+def default_dashboard_paths() -> list[Path]:
+    root = repo_root()
+    return [root / name for name in DEFAULT_DASHBOARDS]
+
+
 def default_dashboard_path() -> Path:
-    return repo_root() / DEFAULT_DASH
+    return default_dashboard_paths()[0]
 
 
 def git_revision() -> str:
@@ -135,6 +149,7 @@ def normalize_v2(dash: dict[str, Any], *, add_git_provenance: bool) -> dict[str,
             new_meta["annotations"] = existing
 
     out["metadata"] = new_meta
+    fix_dashboard_v2_wire_format(out)
     return out
 
 
@@ -301,7 +316,7 @@ def main() -> int:
         "files",
         nargs="*",
         type=Path,
-        help=f"Dashboard JSON file(s) (default: {DEFAULT_DASH})",
+        help=f"Dashboard JSON file(s) (default: {' '.join(DEFAULT_DASHBOARDS)})",
     )
     parser.add_argument(
         "--check",
@@ -320,7 +335,7 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    paths = args.files or [default_dashboard_path()]
+    paths = args.files or default_dashboard_paths()
     rc = 0
     for path in paths:
         path = path.resolve()

--- a/grafana/vllm-dashboard-amd.json
+++ b/grafana/vllm-dashboard-amd.json
@@ -1,0 +1,2458 @@
+{
+    "apiVersion": "dashboard.grafana.app/v2",
+    "kind": "Dashboard",
+    "metadata": {
+        "name": "b281712d-8bff-41ef-9f3f-71ad43c05e9b",
+        "namespace": "default",
+        "uid": "d8c0b394-daaf-44d0-bca2-6b649b527fc8",
+        "annotations": {
+            "rocm-aic.git.normalizedAt": "2026-06-03T21:29:36Z",
+            "rocm-aic.git.revision": "10fb4bad735ae03824943ad21ddb760b5c6094ea",
+            "rocm-aic.git.author": "sbates@raithlin.com"
+        }
+    },
+    "spec": {
+        "annotations": [
+            {
+                "kind": "AnnotationQuery",
+                "spec": {
+                    "query": {
+                        "kind": "DataQuery",
+                        "group": "grafana",
+                        "version": "v0",
+                        "datasource": {
+                            "name": "-- Grafana --"
+                        },
+                        "spec": {
+                            "limit": 100,
+                            "matchAny": false,
+                            "tags": [],
+                            "type": "dashboard"
+                        }
+                    },
+                    "enable": true,
+                    "hide": true,
+                    "iconColor": "rgba(0, 211, 255, 1)",
+                    "name": "Annotations & Alerts",
+                    "builtIn": true
+                }
+            }
+        ],
+        "cursorSync": "Off",
+        "description": "Prometheus metrics for vLLM inference: latency, throughput, scheduler state, and KV-cache utilization.",
+        "editable": true,
+        "elements": {
+            "panel-10": {
+                "kind": "Panel",
+                "spec": {
+                    "id": 10,
+                    "title": "ITL Latency",
+                    "description": "Inter-token latency during decode: P50, P90, P95, P99, and mean (vllm:inter_token_latency_seconds).",
+                    "links": [],
+                    "data": {
+                        "kind": "QueryGroup",
+                        "spec": {
+                            "queries": [
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "${datasource}"
+                                            },
+                                            "spec": {
+                                                "disableTextWrap": false,
+                                                "editorMode": "code",
+                                                "expr": "histogram_quantile(0.99, sum by(le) (rate(vllm:inter_token_latency_seconds_bucket{model_name=~\"$model\",job=~\"vllm-exporter|vllm\",instance=~\"$instance\"}[$__rate_interval])))",
+                                                "fullMetaSearch": false,
+                                                "includeNullMetadata": false,
+                                                "instant": false,
+                                                "legendFormat": "P99",
+                                                "range": true,
+                                                "useBackend": false
+                                            }
+                                        },
+                                        "refId": "A",
+                                        "hidden": false
+                                    }
+                                },
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "${datasource}"
+                                            },
+                                            "spec": {
+                                                "disableTextWrap": false,
+                                                "editorMode": "builder",
+                                                "expr": "histogram_quantile(0.95, sum by(le) (rate(vllm:inter_token_latency_seconds_bucket{model_name=~\"$model\",job=~\"vllm-exporter|vllm\",instance=~\"$instance\"}[$__rate_interval])))",
+                                                "fullMetaSearch": false,
+                                                "includeNullMetadata": false,
+                                                "instant": false,
+                                                "legendFormat": "P95",
+                                                "range": true,
+                                                "useBackend": false
+                                            }
+                                        },
+                                        "refId": "B",
+                                        "hidden": false
+                                    }
+                                },
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "${datasource}"
+                                            },
+                                            "spec": {
+                                                "disableTextWrap": false,
+                                                "editorMode": "builder",
+                                                "expr": "histogram_quantile(0.9, sum by(le) (rate(vllm:inter_token_latency_seconds_bucket{model_name=~\"$model\",job=~\"vllm-exporter|vllm\",instance=~\"$instance\"}[$__rate_interval])))",
+                                                "fullMetaSearch": false,
+                                                "includeNullMetadata": false,
+                                                "instant": false,
+                                                "legendFormat": "P90",
+                                                "range": true,
+                                                "useBackend": false
+                                            }
+                                        },
+                                        "refId": "C",
+                                        "hidden": false
+                                    }
+                                },
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "${datasource}"
+                                            },
+                                            "spec": {
+                                                "disableTextWrap": false,
+                                                "editorMode": "builder",
+                                                "expr": "histogram_quantile(0.5, sum by(le) (rate(vllm:inter_token_latency_seconds_bucket{model_name=~\"$model\",job=~\"vllm-exporter|vllm\",instance=~\"$instance\"}[$__rate_interval])))",
+                                                "fullMetaSearch": false,
+                                                "includeNullMetadata": false,
+                                                "instant": false,
+                                                "legendFormat": "P50",
+                                                "range": true,
+                                                "useBackend": false
+                                            }
+                                        },
+                                        "refId": "D",
+                                        "hidden": false
+                                    }
+                                },
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "${datasource}"
+                                            },
+                                            "spec": {
+                                                "editorMode": "code",
+                                                "expr": "rate(vllm:inter_token_latency_seconds_sum{model_name=~\"$model\",job=~\"vllm-exporter|vllm\",instance=~\"$instance\"}[$__rate_interval])\n/\nrate(vllm:inter_token_latency_seconds_count{model_name=~\"$model\",job=~\"vllm-exporter|vllm\",instance=~\"$instance\"}[$__rate_interval])",
+                                                "instant": false,
+                                                "legendFormat": "Mean",
+                                                "range": true
+                                            }
+                                        },
+                                        "refId": "E",
+                                        "hidden": false
+                                    }
+                                }
+                            ],
+                            "transformations": [],
+                            "queryOptions": {}
+                        }
+                    },
+                    "vizConfig": {
+                        "kind": "VizConfig",
+                        "group": "timeseries",
+                        "version": "13.0.1+security-01",
+                        "spec": {
+                            "options": {
+                                "annotations": {
+                                    "clustering": -1,
+                                    "multiLane": false
+                                },
+                                "legend": {
+                                    "calcs": [
+                                        "min",
+                                        "mean",
+                                        "max",
+                                        "lastNotNull"
+                                    ],
+                                    "displayMode": "table",
+                                    "placement": "bottom",
+                                    "showLegend": true
+                                },
+                                "tooltip": {
+                                    "hideZeros": false,
+                                    "mode": "single",
+                                    "sort": "none"
+                                }
+                            },
+                            "fieldConfig": {
+                                "defaults": {
+                                    "unit": "s",
+                                    "thresholds": {
+                                        "mode": "absolute",
+                                        "steps": [
+                                            {
+                                                "value": 0,
+                                                "color": "green"
+                                            },
+                                            {
+                                                "value": 80,
+                                                "color": "red"
+                                            }
+                                        ]
+                                    },
+                                    "color": {
+                                        "mode": "palette-classic"
+                                    },
+                                    "custom": {
+                                        "axisBorderShow": false,
+                                        "axisCenteredZero": false,
+                                        "axisColorMode": "text",
+                                        "axisLabel": "",
+                                        "axisPlacement": "auto",
+                                        "barAlignment": 0,
+                                        "barWidthFactor": 0.6,
+                                        "drawStyle": "line",
+                                        "fillOpacity": 0,
+                                        "gradientMode": "none",
+                                        "hideFrom": {
+                                            "legend": false,
+                                            "tooltip": false,
+                                            "viz": false
+                                        },
+                                        "insertNulls": false,
+                                        "lineInterpolation": "linear",
+                                        "lineWidth": 1,
+                                        "pointSize": 0,
+                                        "scaleDistribution": {
+                                            "type": "linear"
+                                        },
+                                        "showPoints": "never",
+                                        "showValues": false,
+                                        "spanNulls": false,
+                                        "stacking": {
+                                            "group": "A",
+                                            "mode": "none"
+                                        },
+                                        "thresholdsStyle": {
+                                            "mode": "off"
+                                        }
+                                    }
+                                },
+                                "overrides": []
+                            }
+                        }
+                    }
+                }
+            },
+            "panel-11": {
+                "kind": "Panel",
+                "spec": {
+                    "id": 11,
+                    "title": "Request Finish Reasons",
+                    "description": "Completed requests by finish reason, such as EOS or max sequence length (vllm:request_success_total).",
+                    "links": [],
+                    "data": {
+                        "kind": "QueryGroup",
+                        "spec": {
+                            "queries": [
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "${datasource}"
+                                            },
+                                            "spec": {
+                                                "disableTextWrap": false,
+                                                "editorMode": "builder",
+                                                "expr": "sum by(finished_reason) (increase(vllm:request_success_total{model_name=~\"$model\",job=~\"vllm-exporter|vllm\",instance=~\"$instance\"}[$__rate_interval]))",
+                                                "fullMetaSearch": false,
+                                                "includeNullMetadata": true,
+                                                "instant": false,
+                                                "interval": "",
+                                                "legendFormat": "{{finished_reason}}",
+                                                "range": true,
+                                                "useBackend": false
+                                            }
+                                        },
+                                        "refId": "A",
+                                        "hidden": false
+                                    }
+                                }
+                            ],
+                            "transformations": [],
+                            "queryOptions": {}
+                        }
+                    },
+                    "vizConfig": {
+                        "kind": "VizConfig",
+                        "group": "timeseries",
+                        "version": "13.0.1+security-01",
+                        "spec": {
+                            "options": {
+                                "annotations": {
+                                    "clustering": -1,
+                                    "multiLane": false
+                                },
+                                "legend": {
+                                    "calcs": [
+                                        "min",
+                                        "mean",
+                                        "max",
+                                        "lastNotNull"
+                                    ],
+                                    "displayMode": "table",
+                                    "placement": "bottom",
+                                    "showLegend": true
+                                },
+                                "tooltip": {
+                                    "hideZeros": false,
+                                    "mode": "single",
+                                    "sort": "none"
+                                }
+                            },
+                            "fieldConfig": {
+                                "defaults": {
+                                    "thresholds": {
+                                        "mode": "absolute",
+                                        "steps": [
+                                            {
+                                                "value": 0,
+                                                "color": "green"
+                                            },
+                                            {
+                                                "value": 80,
+                                                "color": "red"
+                                            }
+                                        ]
+                                    },
+                                    "color": {
+                                        "mode": "palette-classic"
+                                    },
+                                    "custom": {
+                                        "axisBorderShow": false,
+                                        "axisCenteredZero": false,
+                                        "axisColorMode": "text",
+                                        "axisLabel": "",
+                                        "axisPlacement": "auto",
+                                        "barAlignment": 0,
+                                        "barWidthFactor": 0.6,
+                                        "drawStyle": "line",
+                                        "fillOpacity": 0,
+                                        "gradientMode": "none",
+                                        "hideFrom": {
+                                            "legend": false,
+                                            "tooltip": false,
+                                            "viz": false
+                                        },
+                                        "insertNulls": false,
+                                        "lineInterpolation": "linear",
+                                        "lineWidth": 1,
+                                        "pointSize": 0,
+                                        "scaleDistribution": {
+                                            "type": "linear"
+                                        },
+                                        "showPoints": "never",
+                                        "showValues": false,
+                                        "spanNulls": false,
+                                        "stacking": {
+                                            "group": "A",
+                                            "mode": "none"
+                                        },
+                                        "thresholdsStyle": {
+                                            "mode": "off"
+                                        }
+                                    }
+                                },
+                                "overrides": []
+                            }
+                        }
+                    }
+                }
+            },
+            "panel-12": {
+                "kind": "Panel",
+                "spec": {
+                    "id": 12,
+                    "title": "Prompt Length Distribution",
+                    "description": "Heatmap of input prompt token counts per request (vllm:request_prompt_tokens_bucket).",
+                    "links": [],
+                    "data": {
+                        "kind": "QueryGroup",
+                        "spec": {
+                            "queries": [
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "${datasource}"
+                                            },
+                                            "spec": {
+                                                "disableTextWrap": false,
+                                                "editorMode": "builder",
+                                                "expr": "sum by(le) (increase(vllm:request_prompt_tokens_bucket{model_name=~\"$model\",job=~\"vllm-exporter|vllm\",instance=~\"$instance\"}[$__rate_interval]))",
+                                                "format": "heatmap",
+                                                "fullMetaSearch": false,
+                                                "includeNullMetadata": true,
+                                                "instant": false,
+                                                "legendFormat": "{{le}}",
+                                                "range": true,
+                                                "useBackend": false
+                                            }
+                                        },
+                                        "refId": "A",
+                                        "hidden": false
+                                    }
+                                }
+                            ],
+                            "transformations": [],
+                            "queryOptions": {}
+                        }
+                    },
+                    "vizConfig": {
+                        "kind": "VizConfig",
+                        "group": "heatmap",
+                        "version": "13.0.1+security-01",
+                        "spec": {
+                            "options": {
+                                "annotations": {
+                                    "clustering": -1,
+                                    "multiLane": false
+                                },
+                                "calculate": false,
+                                "cellGap": 1,
+                                "cellValues": {
+                                    "unit": "none"
+                                },
+                                "color": {
+                                    "exponent": 0.5,
+                                    "fill": "dark-orange",
+                                    "min": 0,
+                                    "mode": "scheme",
+                                    "reverse": false,
+                                    "scale": "exponential",
+                                    "scheme": "Spectral",
+                                    "steps": 64
+                                },
+                                "exemplars": {
+                                    "color": "rgba(255,0,255,0.7)"
+                                },
+                                "filterValues": {
+                                    "le": 1e-09
+                                },
+                                "legend": {
+                                    "show": true
+                                },
+                                "rowsFrame": {
+                                    "layout": "auto",
+                                    "value": "Request count"
+                                },
+                                "tooltip": {
+                                    "mode": "single",
+                                    "showColorScale": false,
+                                    "yHistogram": true
+                                },
+                                "yAxis": {
+                                    "axisLabel": "Prompt Length",
+                                    "axisPlacement": "left",
+                                    "reverse": false,
+                                    "unit": "none"
+                                }
+                            },
+                            "fieldConfig": {
+                                "defaults": {
+                                    "custom": {
+                                        "hideFrom": {
+                                            "legend": false,
+                                            "tooltip": false,
+                                            "viz": false
+                                        },
+                                        "scaleDistribution": {
+                                            "type": "linear"
+                                        }
+                                    }
+                                },
+                                "overrides": []
+                            }
+                        }
+                    }
+                }
+            },
+            "panel-13": {
+                "kind": "Panel",
+                "spec": {
+                    "id": 13,
+                    "title": "Generation Length Distribution",
+                    "description": "Heatmap of output token counts per request (vllm:request_generation_tokens_bucket).",
+                    "links": [],
+                    "data": {
+                        "kind": "QueryGroup",
+                        "spec": {
+                            "queries": [
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "${datasource}"
+                                            },
+                                            "spec": {
+                                                "disableTextWrap": false,
+                                                "editorMode": "builder",
+                                                "expr": "sum by(le) (increase(vllm:request_generation_tokens_bucket{model_name=~\"$model\",job=~\"vllm-exporter|vllm\",instance=~\"$instance\"}[$__rate_interval]))",
+                                                "format": "heatmap",
+                                                "fullMetaSearch": false,
+                                                "includeNullMetadata": true,
+                                                "instant": false,
+                                                "legendFormat": "{{le}}",
+                                                "range": true,
+                                                "useBackend": false
+                                            }
+                                        },
+                                        "refId": "A",
+                                        "hidden": false
+                                    }
+                                }
+                            ],
+                            "transformations": [],
+                            "queryOptions": {}
+                        }
+                    },
+                    "vizConfig": {
+                        "kind": "VizConfig",
+                        "group": "heatmap",
+                        "version": "13.0.1+security-01",
+                        "spec": {
+                            "options": {
+                                "annotations": {
+                                    "clustering": -1,
+                                    "multiLane": false
+                                },
+                                "calculate": false,
+                                "cellGap": 1,
+                                "cellValues": {
+                                    "unit": "none"
+                                },
+                                "color": {
+                                    "exponent": 0.5,
+                                    "fill": "dark-orange",
+                                    "min": 0,
+                                    "mode": "scheme",
+                                    "reverse": false,
+                                    "scale": "exponential",
+                                    "scheme": "Spectral",
+                                    "steps": 64
+                                },
+                                "exemplars": {
+                                    "color": "rgba(255,0,255,0.7)"
+                                },
+                                "filterValues": {
+                                    "le": 1e-09
+                                },
+                                "legend": {
+                                    "show": true
+                                },
+                                "rowsFrame": {
+                                    "layout": "auto",
+                                    "value": "Request count"
+                                },
+                                "tooltip": {
+                                    "mode": "single",
+                                    "showColorScale": false,
+                                    "yHistogram": true
+                                },
+                                "yAxis": {
+                                    "axisLabel": "Generation Length",
+                                    "axisPlacement": "left",
+                                    "reverse": false,
+                                    "unit": "none"
+                                }
+                            },
+                            "fieldConfig": {
+                                "defaults": {
+                                    "custom": {
+                                        "hideFrom": {
+                                            "legend": false,
+                                            "tooltip": false,
+                                            "viz": false
+                                        },
+                                        "scaleDistribution": {
+                                            "type": "linear"
+                                        }
+                                    }
+                                },
+                                "overrides": []
+                            }
+                        }
+                    }
+                }
+            },
+            "panel-14": {
+                "kind": "Panel",
+                "spec": {
+                    "id": 14,
+                    "title": "Request Queue Time",
+                    "description": "Time requests spend waiting in the scheduler queue before execution (vllm:request_queue_time_seconds).",
+                    "links": [],
+                    "data": {
+                        "kind": "QueryGroup",
+                        "spec": {
+                            "queries": [
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "${datasource}"
+                                            },
+                                            "spec": {
+                                                "disableTextWrap": false,
+                                                "editorMode": "code",
+                                                "expr": "rate(vllm:request_queue_time_seconds_sum{model_name=~\"$model\",job=~\"vllm-exporter|vllm\",instance=~\"$instance\"}[$__rate_interval])",
+                                                "fullMetaSearch": false,
+                                                "includeNullMetadata": true,
+                                                "instant": false,
+                                                "legendFormat": "Queue time",
+                                                "range": true,
+                                                "useBackend": false
+                                            }
+                                        },
+                                        "refId": "A",
+                                        "hidden": false
+                                    }
+                                }
+                            ],
+                            "transformations": [],
+                            "queryOptions": {}
+                        }
+                    },
+                    "vizConfig": {
+                        "kind": "VizConfig",
+                        "group": "timeseries",
+                        "version": "13.0.1+security-01",
+                        "spec": {
+                            "options": {
+                                "annotations": {
+                                    "clustering": -1,
+                                    "multiLane": false
+                                },
+                                "legend": {
+                                    "calcs": [
+                                        "min",
+                                        "mean",
+                                        "max",
+                                        "lastNotNull"
+                                    ],
+                                    "displayMode": "table",
+                                    "placement": "bottom",
+                                    "showLegend": false
+                                },
+                                "tooltip": {
+                                    "hideZeros": false,
+                                    "mode": "single",
+                                    "sort": "none"
+                                }
+                            },
+                            "fieldConfig": {
+                                "defaults": {
+                                    "thresholds": {
+                                        "mode": "absolute",
+                                        "steps": [
+                                            {
+                                                "value": 0,
+                                                "color": "green"
+                                            },
+                                            {
+                                                "value": 80,
+                                                "color": "red"
+                                            }
+                                        ]
+                                    },
+                                    "color": {
+                                        "mode": "palette-classic"
+                                    },
+                                    "custom": {
+                                        "axisBorderShow": false,
+                                        "axisCenteredZero": false,
+                                        "axisColorMode": "text",
+                                        "axisLabel": "seconds",
+                                        "axisPlacement": "auto",
+                                        "barAlignment": 0,
+                                        "barWidthFactor": 0.6,
+                                        "drawStyle": "line",
+                                        "fillOpacity": 0,
+                                        "gradientMode": "none",
+                                        "hideFrom": {
+                                            "legend": false,
+                                            "tooltip": false,
+                                            "viz": false
+                                        },
+                                        "insertNulls": false,
+                                        "lineInterpolation": "linear",
+                                        "lineWidth": 1,
+                                        "pointSize": 0,
+                                        "scaleDistribution": {
+                                            "type": "linear"
+                                        },
+                                        "showPoints": "never",
+                                        "showValues": false,
+                                        "spanNulls": false,
+                                        "stacking": {
+                                            "group": "A",
+                                            "mode": "none"
+                                        },
+                                        "thresholdsStyle": {
+                                            "mode": "off"
+                                        }
+                                    }
+                                },
+                                "overrides": []
+                            }
+                        }
+                    }
+                }
+            },
+            "panel-15": {
+                "kind": "Panel",
+                "spec": {
+                    "id": 15,
+                    "title": "Prefill and Decode Time",
+                    "description": "Aggregate time spent in prefill and decode phases (vllm:request_prefill_time_seconds, vllm:request_decode_time_seconds).",
+                    "links": [],
+                    "data": {
+                        "kind": "QueryGroup",
+                        "spec": {
+                            "queries": [
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "${datasource}"
+                                            },
+                                            "spec": {
+                                                "disableTextWrap": false,
+                                                "editorMode": "code",
+                                                "expr": "rate(vllm:request_prefill_time_seconds_sum{model_name=~\"$model\",job=~\"vllm-exporter|vllm\",instance=~\"$instance\"}[$__rate_interval])",
+                                                "fullMetaSearch": false,
+                                                "includeNullMetadata": true,
+                                                "instant": false,
+                                                "legendFormat": "Prefill",
+                                                "range": true,
+                                                "useBackend": false
+                                            }
+                                        },
+                                        "refId": "A",
+                                        "hidden": false
+                                    }
+                                },
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "${datasource}"
+                                            },
+                                            "spec": {
+                                                "editorMode": "code",
+                                                "expr": "rate(vllm:request_decode_time_seconds_sum{model_name=~\"$model\",job=~\"vllm-exporter|vllm\",instance=~\"$instance\"}[$__rate_interval])",
+                                                "instant": false,
+                                                "legendFormat": "Decode",
+                                                "range": true
+                                            }
+                                        },
+                                        "refId": "B",
+                                        "hidden": false
+                                    }
+                                }
+                            ],
+                            "transformations": [],
+                            "queryOptions": {}
+                        }
+                    },
+                    "vizConfig": {
+                        "kind": "VizConfig",
+                        "group": "timeseries",
+                        "version": "13.0.1+security-01",
+                        "spec": {
+                            "options": {
+                                "annotations": {
+                                    "clustering": -1,
+                                    "multiLane": false
+                                },
+                                "legend": {
+                                    "calcs": [
+                                        "min",
+                                        "mean",
+                                        "max",
+                                        "lastNotNull"
+                                    ],
+                                    "displayMode": "table",
+                                    "placement": "bottom",
+                                    "showLegend": true
+                                },
+                                "tooltip": {
+                                    "hideZeros": false,
+                                    "mode": "single",
+                                    "sort": "none"
+                                }
+                            },
+                            "fieldConfig": {
+                                "defaults": {
+                                    "thresholds": {
+                                        "mode": "absolute",
+                                        "steps": [
+                                            {
+                                                "value": 0,
+                                                "color": "green"
+                                            },
+                                            {
+                                                "value": 80,
+                                                "color": "red"
+                                            }
+                                        ]
+                                    },
+                                    "color": {
+                                        "mode": "palette-classic"
+                                    },
+                                    "custom": {
+                                        "axisBorderShow": false,
+                                        "axisCenteredZero": false,
+                                        "axisColorMode": "text",
+                                        "axisLabel": "",
+                                        "axisPlacement": "auto",
+                                        "barAlignment": 0,
+                                        "barWidthFactor": 0.6,
+                                        "drawStyle": "line",
+                                        "fillOpacity": 0,
+                                        "gradientMode": "none",
+                                        "hideFrom": {
+                                            "legend": false,
+                                            "tooltip": false,
+                                            "viz": false
+                                        },
+                                        "insertNulls": false,
+                                        "lineInterpolation": "linear",
+                                        "lineWidth": 1,
+                                        "pointSize": 0,
+                                        "scaleDistribution": {
+                                            "type": "linear"
+                                        },
+                                        "showPoints": "never",
+                                        "showValues": false,
+                                        "spanNulls": false,
+                                        "stacking": {
+                                            "group": "A",
+                                            "mode": "none"
+                                        },
+                                        "thresholdsStyle": {
+                                            "mode": "off"
+                                        }
+                                    }
+                                },
+                                "overrides": []
+                            }
+                        }
+                    }
+                }
+            },
+            "panel-16": {
+                "kind": "Panel",
+                "spec": {
+                    "id": 16,
+                    "title": "Max Generation Tokens",
+                    "description": "Maximum generation tokens reserved per sequence group (vllm:request_max_num_generation_tokens).",
+                    "links": [],
+                    "data": {
+                        "kind": "QueryGroup",
+                        "spec": {
+                            "queries": [
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "${datasource}"
+                                            },
+                                            "spec": {
+                                                "disableTextWrap": false,
+                                                "editorMode": "code",
+                                                "expr": "rate(vllm:request_max_num_generation_tokens_sum{model_name=~\"$model\",job=~\"vllm-exporter|vllm\",instance=~\"$instance\"}[$__rate_interval])",
+                                                "fullMetaSearch": false,
+                                                "includeNullMetadata": true,
+                                                "instant": false,
+                                                "legendFormat": "Max tokens",
+                                                "range": true,
+                                                "useBackend": false
+                                            }
+                                        },
+                                        "refId": "A",
+                                        "hidden": false
+                                    }
+                                }
+                            ],
+                            "transformations": [],
+                            "queryOptions": {}
+                        }
+                    },
+                    "vizConfig": {
+                        "kind": "VizConfig",
+                        "group": "timeseries",
+                        "version": "13.0.1+security-01",
+                        "spec": {
+                            "options": {
+                                "annotations": {
+                                    "clustering": -1,
+                                    "multiLane": false
+                                },
+                                "legend": {
+                                    "calcs": [
+                                        "min",
+                                        "mean",
+                                        "max",
+                                        "lastNotNull"
+                                    ],
+                                    "displayMode": "table",
+                                    "placement": "bottom",
+                                    "showLegend": false
+                                },
+                                "tooltip": {
+                                    "hideZeros": false,
+                                    "mode": "single",
+                                    "sort": "none"
+                                }
+                            },
+                            "fieldConfig": {
+                                "defaults": {
+                                    "thresholds": {
+                                        "mode": "absolute",
+                                        "steps": [
+                                            {
+                                                "value": 0,
+                                                "color": "green"
+                                            },
+                                            {
+                                                "value": 80,
+                                                "color": "red"
+                                            }
+                                        ]
+                                    },
+                                    "color": {
+                                        "mode": "palette-classic"
+                                    },
+                                    "custom": {
+                                        "axisBorderShow": false,
+                                        "axisCenteredZero": false,
+                                        "axisColorMode": "text",
+                                        "axisLabel": "",
+                                        "axisPlacement": "auto",
+                                        "barAlignment": 0,
+                                        "barWidthFactor": 0.6,
+                                        "drawStyle": "line",
+                                        "fillOpacity": 0,
+                                        "gradientMode": "none",
+                                        "hideFrom": {
+                                            "legend": false,
+                                            "tooltip": false,
+                                            "viz": false
+                                        },
+                                        "insertNulls": false,
+                                        "lineInterpolation": "linear",
+                                        "lineWidth": 1,
+                                        "pointSize": 0,
+                                        "scaleDistribution": {
+                                            "type": "linear"
+                                        },
+                                        "showPoints": "never",
+                                        "showValues": false,
+                                        "spanNulls": false,
+                                        "stacking": {
+                                            "group": "A",
+                                            "mode": "none"
+                                        },
+                                        "thresholdsStyle": {
+                                            "mode": "off"
+                                        }
+                                    }
+                                },
+                                "overrides": []
+                            }
+                        }
+                    }
+                }
+            },
+            "panel-3": {
+                "kind": "Panel",
+                "spec": {
+                    "id": 3,
+                    "title": "Scheduler State",
+                    "description": "Count of requests in running, waiting, and swapped scheduler states (vllm:num_requests_*).",
+                    "links": [],
+                    "data": {
+                        "kind": "QueryGroup",
+                        "spec": {
+                            "queries": [
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "${datasource}"
+                                            },
+                                            "spec": {
+                                                "disableTextWrap": false,
+                                                "editorMode": "builder",
+                                                "expr": "vllm:num_requests_running{model_name=~\"$model\",job=~\"vllm-exporter|vllm\",instance=~\"$instance\"}",
+                                                "fullMetaSearch": false,
+                                                "includeNullMetadata": true,
+                                                "instant": false,
+                                                "legendFormat": "Running",
+                                                "range": true,
+                                                "useBackend": false
+                                            }
+                                        },
+                                        "refId": "A",
+                                        "hidden": false
+                                    }
+                                },
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "${datasource}"
+                                            },
+                                            "spec": {
+                                                "disableTextWrap": false,
+                                                "editorMode": "builder",
+                                                "expr": "vllm:num_requests_swapped{model_name=~\"$model\",job=~\"vllm-exporter|vllm\",instance=~\"$instance\"}",
+                                                "fullMetaSearch": false,
+                                                "includeNullMetadata": true,
+                                                "instant": false,
+                                                "legendFormat": "Swapped",
+                                                "range": true,
+                                                "useBackend": false
+                                            }
+                                        },
+                                        "refId": "B",
+                                        "hidden": false
+                                    }
+                                },
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "${datasource}"
+                                            },
+                                            "spec": {
+                                                "disableTextWrap": false,
+                                                "editorMode": "builder",
+                                                "expr": "vllm:num_requests_waiting{model_name=~\"$model\",job=~\"vllm-exporter|vllm\",instance=~\"$instance\"}",
+                                                "fullMetaSearch": false,
+                                                "includeNullMetadata": true,
+                                                "instant": false,
+                                                "legendFormat": "Waiting",
+                                                "range": true,
+                                                "useBackend": false
+                                            }
+                                        },
+                                        "refId": "C",
+                                        "hidden": false
+                                    }
+                                }
+                            ],
+                            "transformations": [],
+                            "queryOptions": {}
+                        }
+                    },
+                    "vizConfig": {
+                        "kind": "VizConfig",
+                        "group": "timeseries",
+                        "version": "13.0.1+security-01",
+                        "spec": {
+                            "options": {
+                                "annotations": {
+                                    "clustering": -1,
+                                    "multiLane": false
+                                },
+                                "legend": {
+                                    "calcs": [
+                                        "min",
+                                        "mean",
+                                        "max",
+                                        "lastNotNull"
+                                    ],
+                                    "displayMode": "table",
+                                    "placement": "bottom",
+                                    "showLegend": true
+                                },
+                                "tooltip": {
+                                    "hideZeros": false,
+                                    "mode": "single",
+                                    "sort": "none"
+                                }
+                            },
+                            "fieldConfig": {
+                                "defaults": {
+                                    "unit": "none",
+                                    "thresholds": {
+                                        "mode": "absolute",
+                                        "steps": [
+                                            {
+                                                "value": 0,
+                                                "color": "green"
+                                            },
+                                            {
+                                                "value": 80,
+                                                "color": "red"
+                                            }
+                                        ]
+                                    },
+                                    "color": {
+                                        "mode": "palette-classic"
+                                    },
+                                    "custom": {
+                                        "axisBorderShow": false,
+                                        "axisCenteredZero": false,
+                                        "axisColorMode": "text",
+                                        "axisLabel": "",
+                                        "axisPlacement": "auto",
+                                        "barAlignment": 0,
+                                        "barWidthFactor": 0.6,
+                                        "drawStyle": "line",
+                                        "fillOpacity": 0,
+                                        "gradientMode": "none",
+                                        "hideFrom": {
+                                            "legend": false,
+                                            "tooltip": false,
+                                            "viz": false
+                                        },
+                                        "insertNulls": false,
+                                        "lineInterpolation": "linear",
+                                        "lineWidth": 1,
+                                        "pointSize": 0,
+                                        "scaleDistribution": {
+                                            "type": "linear"
+                                        },
+                                        "showPoints": "never",
+                                        "showValues": false,
+                                        "spanNulls": false,
+                                        "stacking": {
+                                            "group": "A",
+                                            "mode": "none"
+                                        },
+                                        "thresholdsStyle": {
+                                            "mode": "off"
+                                        }
+                                    }
+                                },
+                                "overrides": []
+                            }
+                        }
+                    }
+                }
+            },
+            "panel-4": {
+                "kind": "Panel",
+                "spec": {
+                    "id": 4,
+                    "title": "KV Cache Utilization",
+                    "description": "Share of KV-cache blocks in use, 0–1 scale (vllm:kv_cache_usage_perc).",
+                    "links": [],
+                    "data": {
+                        "kind": "QueryGroup",
+                        "spec": {
+                            "queries": [
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "${datasource}"
+                                            },
+                                            "spec": {
+                                                "editorMode": "code",
+                                                "expr": "vllm:kv_cache_usage_perc{model_name=~\"$model\",job=~\"vllm-exporter|vllm\",instance=~\"$instance\"}",
+                                                "instant": false,
+                                                "legendFormat": "KV cache",
+                                                "range": true
+                                            }
+                                        },
+                                        "refId": "A",
+                                        "hidden": false
+                                    }
+                                },
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "${datasource}"
+                                            },
+                                            "spec": {
+                                                "editorMode": "code",
+                                                "expr": "vllm:cpu_cache_usage_perc{model_name=~\"$model\",job=~\"vllm-exporter|vllm\",instance=~\"$instance\"}",
+                                                "instant": false,
+                                                "legendFormat": "CPU Cache Usage",
+                                                "range": true
+                                            }
+                                        },
+                                        "refId": "B",
+                                        "hidden": true
+                                    }
+                                }
+                            ],
+                            "transformations": [],
+                            "queryOptions": {}
+                        }
+                    },
+                    "vizConfig": {
+                        "kind": "VizConfig",
+                        "group": "timeseries",
+                        "version": "13.0.1+security-01",
+                        "spec": {
+                            "options": {
+                                "annotations": {
+                                    "clustering": -1,
+                                    "multiLane": false
+                                },
+                                "legend": {
+                                    "calcs": [
+                                        "min",
+                                        "mean",
+                                        "max",
+                                        "lastNotNull"
+                                    ],
+                                    "displayMode": "table",
+                                    "placement": "bottom",
+                                    "showLegend": false
+                                },
+                                "tooltip": {
+                                    "hideZeros": false,
+                                    "mode": "single",
+                                    "sort": "none"
+                                }
+                            },
+                            "fieldConfig": {
+                                "defaults": {
+                                    "unit": "percentunit",
+                                    "thresholds": {
+                                        "mode": "absolute",
+                                        "steps": [
+                                            {
+                                                "value": 0,
+                                                "color": "green"
+                                            },
+                                            {
+                                                "value": 80,
+                                                "color": "red"
+                                            }
+                                        ]
+                                    },
+                                    "color": {
+                                        "mode": "palette-classic"
+                                    },
+                                    "custom": {
+                                        "axisBorderShow": false,
+                                        "axisCenteredZero": false,
+                                        "axisColorMode": "text",
+                                        "axisLabel": "",
+                                        "axisPlacement": "auto",
+                                        "barAlignment": 0,
+                                        "barWidthFactor": 0.6,
+                                        "drawStyle": "line",
+                                        "fillOpacity": 0,
+                                        "gradientMode": "none",
+                                        "hideFrom": {
+                                            "legend": false,
+                                            "tooltip": false,
+                                            "viz": false
+                                        },
+                                        "insertNulls": false,
+                                        "lineInterpolation": "linear",
+                                        "lineWidth": 1,
+                                        "pointSize": 0,
+                                        "scaleDistribution": {
+                                            "type": "linear"
+                                        },
+                                        "showPoints": "never",
+                                        "showValues": false,
+                                        "spanNulls": false,
+                                        "stacking": {
+                                            "group": "A",
+                                            "mode": "none"
+                                        },
+                                        "thresholdsStyle": {
+                                            "mode": "off"
+                                        }
+                                    }
+                                },
+                                "overrides": []
+                            }
+                        }
+                    }
+                }
+            },
+            "panel-5": {
+                "kind": "Panel",
+                "spec": {
+                    "id": 5,
+                    "title": "TTFT Latency",
+                    "description": "Time to first output token: P50, P90, P95, P99, and mean (vllm:time_to_first_token_seconds).",
+                    "links": [],
+                    "data": {
+                        "kind": "QueryGroup",
+                        "spec": {
+                            "queries": [
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "${datasource}"
+                                            },
+                                            "spec": {
+                                                "disableTextWrap": false,
+                                                "editorMode": "builder",
+                                                "expr": "histogram_quantile(0.99, sum by(le) (rate(vllm:time_to_first_token_seconds_bucket{model_name=~\"$model\",job=~\"vllm-exporter|vllm\",instance=~\"$instance\"}[$__rate_interval])))",
+                                                "fullMetaSearch": false,
+                                                "includeNullMetadata": false,
+                                                "instant": false,
+                                                "legendFormat": "P99",
+                                                "range": true,
+                                                "useBackend": false
+                                            }
+                                        },
+                                        "refId": "A",
+                                        "hidden": false
+                                    }
+                                },
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "${datasource}"
+                                            },
+                                            "spec": {
+                                                "disableTextWrap": false,
+                                                "editorMode": "builder",
+                                                "expr": "histogram_quantile(0.95, sum by(le) (rate(vllm:time_to_first_token_seconds_bucket{model_name=~\"$model\",job=~\"vllm-exporter|vllm\",instance=~\"$instance\"}[$__rate_interval])))",
+                                                "fullMetaSearch": false,
+                                                "includeNullMetadata": false,
+                                                "instant": false,
+                                                "legendFormat": "P95",
+                                                "range": true,
+                                                "useBackend": false
+                                            }
+                                        },
+                                        "refId": "B",
+                                        "hidden": false
+                                    }
+                                },
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "${datasource}"
+                                            },
+                                            "spec": {
+                                                "disableTextWrap": false,
+                                                "editorMode": "builder",
+                                                "expr": "histogram_quantile(0.9, sum by(le) (rate(vllm:time_to_first_token_seconds_bucket{model_name=~\"$model\",job=~\"vllm-exporter|vllm\",instance=~\"$instance\"}[$__rate_interval])))",
+                                                "fullMetaSearch": false,
+                                                "includeNullMetadata": false,
+                                                "instant": false,
+                                                "legendFormat": "P90",
+                                                "range": true,
+                                                "useBackend": false
+                                            }
+                                        },
+                                        "refId": "C",
+                                        "hidden": false
+                                    }
+                                },
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "${datasource}"
+                                            },
+                                            "spec": {
+                                                "disableTextWrap": false,
+                                                "editorMode": "builder",
+                                                "expr": "histogram_quantile(0.5, sum by(le) (rate(vllm:time_to_first_token_seconds_bucket{model_name=~\"$model\",job=~\"vllm-exporter|vllm\",instance=~\"$instance\"}[$__rate_interval])))",
+                                                "fullMetaSearch": false,
+                                                "includeNullMetadata": false,
+                                                "instant": false,
+                                                "legendFormat": "P50",
+                                                "range": true,
+                                                "useBackend": false
+                                            }
+                                        },
+                                        "refId": "D",
+                                        "hidden": false
+                                    }
+                                },
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "${datasource}"
+                                            },
+                                            "spec": {
+                                                "editorMode": "code",
+                                                "expr": "rate(vllm:time_to_first_token_seconds_sum{model_name=~\"$model\",job=~\"vllm-exporter|vllm\",instance=~\"$instance\"}[$__rate_interval])\n/\nrate(vllm:time_to_first_token_seconds_count{model_name=~\"$model\",job=~\"vllm-exporter|vllm\",instance=~\"$instance\"}[$__rate_interval])",
+                                                "instant": false,
+                                                "legendFormat": "Mean",
+                                                "range": true
+                                            }
+                                        },
+                                        "refId": "E",
+                                        "hidden": false
+                                    }
+                                }
+                            ],
+                            "transformations": [],
+                            "queryOptions": {}
+                        }
+                    },
+                    "vizConfig": {
+                        "kind": "VizConfig",
+                        "group": "timeseries",
+                        "version": "13.0.1+security-01",
+                        "spec": {
+                            "options": {
+                                "annotations": {
+                                    "clustering": -1,
+                                    "multiLane": false
+                                },
+                                "legend": {
+                                    "calcs": [
+                                        "min",
+                                        "mean",
+                                        "max",
+                                        "lastNotNull"
+                                    ],
+                                    "displayMode": "table",
+                                    "placement": "bottom",
+                                    "showLegend": true
+                                },
+                                "tooltip": {
+                                    "hideZeros": false,
+                                    "mode": "single",
+                                    "sort": "none"
+                                }
+                            },
+                            "fieldConfig": {
+                                "defaults": {
+                                    "unit": "s",
+                                    "thresholds": {
+                                        "mode": "absolute",
+                                        "steps": [
+                                            {
+                                                "value": 0,
+                                                "color": "green"
+                                            },
+                                            {
+                                                "value": 80,
+                                                "color": "red"
+                                            }
+                                        ]
+                                    },
+                                    "color": {
+                                        "mode": "palette-classic"
+                                    },
+                                    "custom": {
+                                        "axisBorderShow": false,
+                                        "axisCenteredZero": false,
+                                        "axisColorMode": "text",
+                                        "axisLabel": "",
+                                        "axisPlacement": "auto",
+                                        "barAlignment": 0,
+                                        "barWidthFactor": 0.6,
+                                        "drawStyle": "line",
+                                        "fillOpacity": 0,
+                                        "gradientMode": "none",
+                                        "hideFrom": {
+                                            "legend": false,
+                                            "tooltip": false,
+                                            "viz": false
+                                        },
+                                        "insertNulls": false,
+                                        "lineInterpolation": "linear",
+                                        "lineWidth": 1,
+                                        "pointSize": 0,
+                                        "scaleDistribution": {
+                                            "type": "linear"
+                                        },
+                                        "showPoints": "never",
+                                        "showValues": false,
+                                        "spanNulls": false,
+                                        "stacking": {
+                                            "group": "A",
+                                            "mode": "none"
+                                        },
+                                        "thresholdsStyle": {
+                                            "mode": "off"
+                                        }
+                                    }
+                                },
+                                "overrides": []
+                            }
+                        }
+                    }
+                }
+            },
+            "panel-8": {
+                "kind": "Panel",
+                "spec": {
+                    "id": 8,
+                    "title": "Token Throughput",
+                    "description": "Prompt and generation token processing rates per second (vllm:prompt_tokens_total, vllm:generation_tokens_total).",
+                    "links": [],
+                    "data": {
+                        "kind": "QueryGroup",
+                        "spec": {
+                            "queries": [
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "${datasource}"
+                                            },
+                                            "spec": {
+                                                "disableTextWrap": false,
+                                                "editorMode": "builder",
+                                                "expr": "rate(vllm:prompt_tokens_total{model_name=~\"$model\",job=~\"vllm-exporter|vllm\",instance=~\"$instance\"}[$__rate_interval])",
+                                                "fullMetaSearch": false,
+                                                "includeNullMetadata": false,
+                                                "instant": false,
+                                                "legendFormat": "Prompt tok/s",
+                                                "range": true,
+                                                "useBackend": false
+                                            }
+                                        },
+                                        "refId": "A",
+                                        "hidden": false
+                                    }
+                                },
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "${datasource}"
+                                            },
+                                            "spec": {
+                                                "disableTextWrap": false,
+                                                "editorMode": "builder",
+                                                "expr": "rate(vllm:generation_tokens_total{model_name=~\"$model\",job=~\"vllm-exporter|vllm\",instance=~\"$instance\"}[$__rate_interval])",
+                                                "fullMetaSearch": false,
+                                                "includeNullMetadata": false,
+                                                "instant": false,
+                                                "legendFormat": "Generation tok/s",
+                                                "range": true,
+                                                "useBackend": false
+                                            }
+                                        },
+                                        "refId": "B",
+                                        "hidden": false
+                                    }
+                                }
+                            ],
+                            "transformations": [],
+                            "queryOptions": {}
+                        }
+                    },
+                    "vizConfig": {
+                        "kind": "VizConfig",
+                        "group": "timeseries",
+                        "version": "13.0.1+security-01",
+                        "spec": {
+                            "options": {
+                                "annotations": {
+                                    "clustering": -1,
+                                    "multiLane": false
+                                },
+                                "legend": {
+                                    "calcs": [
+                                        "min",
+                                        "mean",
+                                        "max",
+                                        "lastNotNull"
+                                    ],
+                                    "displayMode": "table",
+                                    "placement": "bottom",
+                                    "showLegend": true
+                                },
+                                "tooltip": {
+                                    "hideZeros": false,
+                                    "mode": "single",
+                                    "sort": "none"
+                                }
+                            },
+                            "fieldConfig": {
+                                "defaults": {
+                                    "thresholds": {
+                                        "mode": "absolute",
+                                        "steps": [
+                                            {
+                                                "value": 0,
+                                                "color": "green"
+                                            },
+                                            {
+                                                "value": 80,
+                                                "color": "red"
+                                            }
+                                        ]
+                                    },
+                                    "color": {
+                                        "mode": "palette-classic"
+                                    },
+                                    "custom": {
+                                        "axisBorderShow": false,
+                                        "axisCenteredZero": false,
+                                        "axisColorMode": "text",
+                                        "axisLabel": "",
+                                        "axisPlacement": "auto",
+                                        "barAlignment": 0,
+                                        "barWidthFactor": 0.6,
+                                        "drawStyle": "line",
+                                        "fillOpacity": 0,
+                                        "gradientMode": "none",
+                                        "hideFrom": {
+                                            "legend": false,
+                                            "tooltip": false,
+                                            "viz": false
+                                        },
+                                        "insertNulls": false,
+                                        "lineInterpolation": "linear",
+                                        "lineWidth": 1,
+                                        "pointSize": 0,
+                                        "scaleDistribution": {
+                                            "type": "linear"
+                                        },
+                                        "showPoints": "never",
+                                        "showValues": false,
+                                        "spanNulls": false,
+                                        "stacking": {
+                                            "group": "A",
+                                            "mode": "none"
+                                        },
+                                        "thresholdsStyle": {
+                                            "mode": "off"
+                                        }
+                                    }
+                                },
+                                "overrides": []
+                            }
+                        }
+                    }
+                }
+            },
+            "panel-9": {
+                "kind": "Panel",
+                "spec": {
+                    "id": 9,
+                    "title": "E2E Request Latency",
+                    "description": "End-to-end request latency: P50, P90, P95, P99, and mean (vllm:e2e_request_latency_seconds).",
+                    "links": [],
+                    "data": {
+                        "kind": "QueryGroup",
+                        "spec": {
+                            "queries": [
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "${datasource}"
+                                            },
+                                            "spec": {
+                                                "disableTextWrap": false,
+                                                "editorMode": "code",
+                                                "expr": "histogram_quantile(0.99, sum by(le) (rate(vllm:e2e_request_latency_seconds_bucket{model_name=~\"$model\",job=~\"vllm-exporter|vllm\",instance=~\"$instance\"}[$__rate_interval])))",
+                                                "fullMetaSearch": false,
+                                                "includeNullMetadata": false,
+                                                "instant": false,
+                                                "legendFormat": "P99",
+                                                "range": true,
+                                                "useBackend": false
+                                            }
+                                        },
+                                        "refId": "A",
+                                        "hidden": false
+                                    }
+                                },
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "${datasource}"
+                                            },
+                                            "spec": {
+                                                "disableTextWrap": false,
+                                                "editorMode": "code",
+                                                "expr": "histogram_quantile(0.95, sum by(le) (rate(vllm:e2e_request_latency_seconds_bucket{model_name=~\"$model\",job=~\"vllm-exporter|vllm\",instance=~\"$instance\"}[$__rate_interval])))",
+                                                "fullMetaSearch": false,
+                                                "includeNullMetadata": false,
+                                                "instant": false,
+                                                "legendFormat": "P95",
+                                                "range": true,
+                                                "useBackend": false
+                                            }
+                                        },
+                                        "refId": "B",
+                                        "hidden": false
+                                    }
+                                },
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "${datasource}"
+                                            },
+                                            "spec": {
+                                                "disableTextWrap": false,
+                                                "editorMode": "code",
+                                                "expr": "histogram_quantile(0.9, sum by(le) (rate(vllm:e2e_request_latency_seconds_bucket{model_name=~\"$model\",job=~\"vllm-exporter|vllm\",instance=~\"$instance\"}[$__rate_interval])))",
+                                                "fullMetaSearch": false,
+                                                "includeNullMetadata": false,
+                                                "instant": false,
+                                                "legendFormat": "P90",
+                                                "range": true,
+                                                "useBackend": false
+                                            }
+                                        },
+                                        "refId": "C",
+                                        "hidden": false
+                                    }
+                                },
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "${datasource}"
+                                            },
+                                            "spec": {
+                                                "disableTextWrap": false,
+                                                "editorMode": "code",
+                                                "expr": "histogram_quantile(0.5, sum by(le) (rate(vllm:e2e_request_latency_seconds_bucket{model_name=~\"$model\",job=~\"vllm-exporter|vllm\",instance=~\"$instance\"}[$__rate_interval])))",
+                                                "fullMetaSearch": false,
+                                                "includeNullMetadata": false,
+                                                "instant": false,
+                                                "legendFormat": "P50",
+                                                "range": true,
+                                                "useBackend": false
+                                            }
+                                        },
+                                        "refId": "D",
+                                        "hidden": false
+                                    }
+                                },
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "${datasource}"
+                                            },
+                                            "spec": {
+                                                "editorMode": "code",
+                                                "expr": "rate(vllm:e2e_request_latency_seconds_sum{model_name=~\"$model\",job=~\"vllm-exporter|vllm\",instance=~\"$instance\"}[$__rate_interval])\n/\nrate(vllm:e2e_request_latency_seconds_count{model_name=~\"$model\",job=~\"vllm-exporter|vllm\",instance=~\"$instance\"}[$__rate_interval])",
+                                                "instant": false,
+                                                "legendFormat": "Mean",
+                                                "range": true
+                                            }
+                                        },
+                                        "refId": "E",
+                                        "hidden": false
+                                    }
+                                }
+                            ],
+                            "transformations": [],
+                            "queryOptions": {}
+                        }
+                    },
+                    "vizConfig": {
+                        "kind": "VizConfig",
+                        "group": "timeseries",
+                        "version": "13.0.1+security-01",
+                        "spec": {
+                            "options": {
+                                "annotations": {
+                                    "clustering": -1,
+                                    "multiLane": false
+                                },
+                                "legend": {
+                                    "calcs": [
+                                        "min",
+                                        "mean",
+                                        "max",
+                                        "lastNotNull"
+                                    ],
+                                    "displayMode": "table",
+                                    "placement": "bottom",
+                                    "showLegend": true
+                                },
+                                "tooltip": {
+                                    "hideZeros": false,
+                                    "mode": "single",
+                                    "sort": "none"
+                                }
+                            },
+                            "fieldConfig": {
+                                "defaults": {
+                                    "unit": "s",
+                                    "thresholds": {
+                                        "mode": "absolute",
+                                        "steps": [
+                                            {
+                                                "value": 0,
+                                                "color": "green"
+                                            },
+                                            {
+                                                "value": 80,
+                                                "color": "red"
+                                            }
+                                        ]
+                                    },
+                                    "color": {
+                                        "mode": "palette-classic"
+                                    },
+                                    "custom": {
+                                        "axisBorderShow": false,
+                                        "axisCenteredZero": false,
+                                        "axisColorMode": "text",
+                                        "axisLabel": "",
+                                        "axisPlacement": "auto",
+                                        "barAlignment": 0,
+                                        "barWidthFactor": 0.6,
+                                        "drawStyle": "line",
+                                        "fillOpacity": 0,
+                                        "gradientMode": "none",
+                                        "hideFrom": {
+                                            "legend": false,
+                                            "tooltip": false,
+                                            "viz": false
+                                        },
+                                        "insertNulls": false,
+                                        "lineInterpolation": "linear",
+                                        "lineWidth": 1,
+                                        "pointSize": 0,
+                                        "scaleDistribution": {
+                                            "type": "linear"
+                                        },
+                                        "showPoints": "never",
+                                        "showValues": false,
+                                        "spanNulls": false,
+                                        "stacking": {
+                                            "group": "A",
+                                            "mode": "none"
+                                        },
+                                        "thresholdsStyle": {
+                                            "mode": "off"
+                                        }
+                                    }
+                                },
+                                "overrides": []
+                            }
+                        }
+                    }
+                }
+            },
+            "panel-17": {
+                "kind": "Panel",
+                "spec": {
+                    "id": 17,
+                    "title": "Active Models",
+                    "description": "KV-cache use and in-flight requests per model/engine over time (vllm:kv_cache_usage_perc, vllm:num_requests_running).",
+                    "links": [],
+                    "data": {
+                        "kind": "QueryGroup",
+                        "spec": {
+                            "queries": [
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "${datasource}"
+                                            },
+                                            "spec": {
+                                                "editorMode": "code",
+                                                "expr": "vllm:kv_cache_usage_perc{job=~\"vllm-exporter|vllm\",instance=~\"$instance\",model_name=~\"$model\"}",
+                                                "legendFormat": "{{model_name}} · KV cache (engine {{engine}})",
+                                                "range": true
+                                            }
+                                        },
+                                        "refId": "A",
+                                        "hidden": false
+                                    }
+                                },
+                                {
+                                    "kind": "PanelQuery",
+                                    "spec": {
+                                        "query": {
+                                            "kind": "DataQuery",
+                                            "group": "prometheus",
+                                            "version": "v0",
+                                            "datasource": {
+                                                "name": "${datasource}"
+                                            },
+                                            "spec": {
+                                                "editorMode": "code",
+                                                "expr": "vllm:num_requests_running{job=~\"vllm-exporter|vllm\",instance=~\"$instance\",model_name=~\"$model\"}",
+                                                "legendFormat": "{{model_name}} · running (engine {{engine}})",
+                                                "range": true
+                                            }
+                                        },
+                                        "refId": "B",
+                                        "hidden": false
+                                    }
+                                }
+                            ],
+                            "transformations": [],
+                            "queryOptions": {}
+                        }
+                    },
+                    "vizConfig": {
+                        "kind": "VizConfig",
+                        "group": "timeseries",
+                        "version": "13.0.1",
+                        "spec": {
+                            "options": {
+                                "annotations": {
+                                    "clustering": -1,
+                                    "multiLane": true
+                                },
+                                "legend": {
+                                    "calcs": [
+                                        "min",
+                                        "mean",
+                                        "max",
+                                        "lastNotNull"
+                                    ],
+                                    "displayMode": "table",
+                                    "placement": "bottom",
+                                    "showLegend": true
+                                },
+                                "tooltip": {
+                                    "hideZeros": false,
+                                    "mode": "multi",
+                                    "sort": "desc"
+                                }
+                            },
+                            "fieldConfig": {
+                                "defaults": {
+                                    "unit": "short",
+                                    "min": 0,
+                                    "thresholds": {
+                                        "mode": "absolute",
+                                        "steps": [
+                                            {
+                                                "value": 0,
+                                                "color": "green"
+                                            }
+                                        ]
+                                    },
+                                    "color": {
+                                        "mode": "palette-classic"
+                                    },
+                                    "custom": {
+                                        "axisBorderShow": false,
+                                        "axisCenteredZero": false,
+                                        "axisColorMode": "text",
+                                        "axisLabel": "",
+                                        "axisPlacement": "auto",
+                                        "barAlignment": 0,
+                                        "barWidthFactor": 0.6,
+                                        "drawStyle": "line",
+                                        "fillOpacity": 0,
+                                        "gradientMode": "none",
+                                        "hideFrom": {
+                                            "legend": false,
+                                            "tooltip": false,
+                                            "viz": false
+                                        },
+                                        "insertNulls": false,
+                                        "lineInterpolation": "linear",
+                                        "lineWidth": 1,
+                                        "pointSize": 0,
+                                        "scaleDistribution": {
+                                            "type": "linear"
+                                        },
+                                        "showPoints": "never",
+                                        "showValues": false,
+                                        "spanNulls": false,
+                                        "stacking": {
+                                            "group": "A",
+                                            "mode": "none"
+                                        },
+                                        "thresholdsStyle": {
+                                            "mode": "off"
+                                        }
+                                    }
+                                },
+                                "overrides": [
+                                    {
+                                        "matcher": {
+                                            "id": "byRegexp",
+                                            "options": "KV cache"
+                                        },
+                                        "properties": [
+                                            {
+                                                "id": "unit",
+                                                "value": "percentunit"
+                                            },
+                                            {
+                                                "id": "min",
+                                                "value": 0
+                                            },
+                                            {
+                                                "id": "max",
+                                                "value": 1
+                                            },
+                                            {
+                                                "id": "custom.axisPlacement",
+                                                "value": "left"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "matcher": {
+                                            "id": "byRegexp",
+                                            "options": "running"
+                                        },
+                                        "properties": [
+                                            {
+                                                "id": "unit",
+                                                "value": "short"
+                                            },
+                                            {
+                                                "id": "decimals",
+                                                "value": 0
+                                            },
+                                            {
+                                                "id": "custom.axisPlacement",
+                                                "value": "right"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "layout": {
+            "kind": "GridLayout",
+            "spec": {
+                "items": [
+                    {
+                        "kind": "GridLayoutItem",
+                        "spec": {
+                            "x": 0,
+                            "y": 0,
+                            "width": 24,
+                            "height": 11,
+                            "element": {
+                                "kind": "ElementReference",
+                                "name": "panel-17"
+                            }
+                        }
+                    },
+                    {
+                        "kind": "GridLayoutItem",
+                        "spec": {
+                            "x": 0,
+                            "y": 11,
+                            "width": 12,
+                            "height": 12,
+                            "element": {
+                                "kind": "ElementReference",
+                                "name": "panel-9"
+                            }
+                        }
+                    },
+                    {
+                        "kind": "GridLayoutItem",
+                        "spec": {
+                            "x": 12,
+                            "y": 11,
+                            "width": 12,
+                            "height": 12,
+                            "element": {
+                                "kind": "ElementReference",
+                                "name": "panel-8"
+                            }
+                        }
+                    },
+                    {
+                        "kind": "GridLayoutItem",
+                        "spec": {
+                            "x": 0,
+                            "y": 23,
+                            "width": 12,
+                            "height": 12,
+                            "element": {
+                                "kind": "ElementReference",
+                                "name": "panel-10"
+                            }
+                        }
+                    },
+                    {
+                        "kind": "GridLayoutItem",
+                        "spec": {
+                            "x": 12,
+                            "y": 23,
+                            "width": 12,
+                            "height": 12,
+                            "element": {
+                                "kind": "ElementReference",
+                                "name": "panel-3"
+                            }
+                        }
+                    },
+                    {
+                        "kind": "GridLayoutItem",
+                        "spec": {
+                            "x": 0,
+                            "y": 35,
+                            "width": 12,
+                            "height": 12,
+                            "element": {
+                                "kind": "ElementReference",
+                                "name": "panel-5"
+                            }
+                        }
+                    },
+                    {
+                        "kind": "GridLayoutItem",
+                        "spec": {
+                            "x": 12,
+                            "y": 35,
+                            "width": 12,
+                            "height": 12,
+                            "element": {
+                                "kind": "ElementReference",
+                                "name": "panel-4"
+                            }
+                        }
+                    },
+                    {
+                        "kind": "GridLayoutItem",
+                        "spec": {
+                            "x": 0,
+                            "y": 47,
+                            "width": 12,
+                            "height": 12,
+                            "element": {
+                                "kind": "ElementReference",
+                                "name": "panel-12"
+                            }
+                        }
+                    },
+                    {
+                        "kind": "GridLayoutItem",
+                        "spec": {
+                            "x": 12,
+                            "y": 47,
+                            "width": 12,
+                            "height": 12,
+                            "element": {
+                                "kind": "ElementReference",
+                                "name": "panel-13"
+                            }
+                        }
+                    },
+                    {
+                        "kind": "GridLayoutItem",
+                        "spec": {
+                            "x": 0,
+                            "y": 59,
+                            "width": 12,
+                            "height": 12,
+                            "element": {
+                                "kind": "ElementReference",
+                                "name": "panel-11"
+                            }
+                        }
+                    },
+                    {
+                        "kind": "GridLayoutItem",
+                        "spec": {
+                            "x": 12,
+                            "y": 59,
+                            "width": 12,
+                            "height": 12,
+                            "element": {
+                                "kind": "ElementReference",
+                                "name": "panel-14"
+                            }
+                        }
+                    },
+                    {
+                        "kind": "GridLayoutItem",
+                        "spec": {
+                            "x": 0,
+                            "y": 71,
+                            "width": 12,
+                            "height": 12,
+                            "element": {
+                                "kind": "ElementReference",
+                                "name": "panel-15"
+                            }
+                        }
+                    },
+                    {
+                        "kind": "GridLayoutItem",
+                        "spec": {
+                            "x": 12,
+                            "y": 71,
+                            "width": 12,
+                            "height": 12,
+                            "element": {
+                                "kind": "ElementReference",
+                                "name": "panel-16"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "links": [],
+        "liveNow": false,
+        "preload": false,
+        "tags": [],
+        "timeSettings": {
+            "timezone": "browser",
+            "from": "now-24h",
+            "to": "now",
+            "autoRefresh": "",
+            "autoRefreshIntervals": [
+                "5s",
+                "10s",
+                "30s",
+                "1m",
+                "5m",
+                "15m",
+                "30m",
+                "1h",
+                "2h",
+                "1d"
+            ],
+            "hideTimepicker": false,
+            "fiscalYearStartMonth": 0
+        },
+        "title": "AMD vLLM Inference Dashboard",
+        "variables": [
+            {
+                "kind": "DatasourceVariable",
+                "spec": {
+                    "name": "datasource",
+                    "pluginId": "prometheus",
+                    "refresh": "onDashboardLoad",
+                    "regex": "",
+                    "current": {
+                        "text": "",
+                        "value": ""
+                    },
+                    "options": [],
+                    "multi": false,
+                    "includeAll": false,
+                    "label": "Data source",
+                    "hide": "hideVariable",
+                    "skipUrlSync": false,
+                    "allowCustomValue": true
+                }
+            },
+            {
+                "kind": "QueryVariable",
+                "spec": {
+                    "name": "instance",
+                    "current": {
+                        "text": "",
+                        "value": ""
+                    },
+                    "label": "vLLM Instance",
+                    "hide": "dontHide",
+                    "refresh": "onDashboardLoad",
+                    "skipUrlSync": false,
+                    "description": "Prometheus instance label on vLLM exporter scrape targets (host:port from job vllm-exporter; localhost excluded).",
+                    "query": {
+                        "kind": "DataQuery",
+                        "group": "prometheus",
+                        "version": "v0",
+                        "datasource": {
+                            "name": "${datasource}"
+                        },
+                        "spec": {
+                            "qryType": 1,
+                            "query": "label_values(up{job=~\"vllm-exporter|vllm\",instance!~\"localhost(:.*)?\"}, instance)",
+                            "refId": "PrometheusVariableQueryEditor-VariableQuery"
+                        }
+                    },
+                    "regex": "",
+                    "regexApplyTo": "value",
+                    "sort": "disabled",
+                    "definition": "label_values(up{job=~\"vllm-exporter|vllm\",instance!~\"localhost(:.*)?\"}, instance)",
+                    "options": [],
+                    "multi": false,
+                    "includeAll": false,
+                    "allowCustomValue": false
+                }
+            },
+            {
+                "kind": "QueryVariable",
+                "spec": {
+                    "name": "model",
+                    "current": {
+                        "text": "All",
+                        "value": "$__all"
+                    },
+                    "label": "LLM Model",
+                    "hide": "dontHide",
+                    "refresh": "onTimeRangeChanged",
+                    "skipUrlSync": false,
+                    "description": "Model name on the selected vLLM instance (from vllm:kv_cache_usage_perc).",
+                    "query": {
+                        "kind": "DataQuery",
+                        "group": "prometheus",
+                        "version": "v0",
+                        "datasource": {
+                            "name": "${datasource}"
+                        },
+                        "spec": {
+                            "qryType": 1,
+                            "query": "label_values(vllm:kv_cache_usage_perc{job=~\"vllm-exporter|vllm\",instance=~\"$instance\"}, model_name)",
+                            "refId": "PrometheusVariableQueryEditor-VariableQuery"
+                        }
+                    },
+                    "regex": "",
+                    "regexApplyTo": "value",
+                    "sort": "disabled",
+                    "definition": "label_values(vllm:kv_cache_usage_perc{job=~\"vllm-exporter|vllm\",instance=~\"$instance\"}, model_name)",
+                    "options": [],
+                    "multi": false,
+                    "includeAll": true,
+                    "allowCustomValue": false,
+                    "allValue": ".+"
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Track vllm-dashboard-amd.json with PromQL scoped to job/instance scrape targets, migrate deprecated time_per_output_token_seconds to inter_token_latency_seconds, and unify timeseries styling on both AIC and vLLM dashboards. Add lint-dashboards.py, make grafana-apply/grafana-lint, and wire make grafana-check into CI.
