### PR TITLE
Add llm-agentx benchmark for SemiAnalysis CC agent trace replay.

### DIFF
--- a/.github/workflows/llm-agentx-python.yml
+++ b/.github/workflows/llm-agentx-python.yml
@@ -1,0 +1,69 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+name: llm-agentx Python
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'benchmarks/llm-agentx/scripts/**'
+      - 'benchmarks/llm-agentx/configs/**'
+      - 'benchmarks/llm-agentx/tests/**'
+      - '.github/workflows/llm-agentx-python.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  python-scripts:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: benchmarks/llm-agentx
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install deps
+        run: pip install -r requirements.txt
+
+      - name: download-dataset.py --help
+        run: python3 scripts/download-dataset.py --help
+
+      - name: replay-trace.py --help
+        run: python3 scripts/replay-trace.py --help
+
+      - name: parse-results.py --help
+        run: python3 scripts/parse-results.py --help
+
+      - name: Validate cc-traces-hf.yaml
+        run: python3 -c "import yaml; yaml.safe_load(open('configs/cc-traces-hf.yaml'))"
+
+      - name: Validate fixture traces.jsonl
+        run: |
+          python3 -c "
+          import json
+          row = json.loads(open('tests/fixtures/traces.jsonl').readline())
+          assert row['id'] == 'ci-trace-0'
+          assert len(row['requests']) == 2
+          print('OK')
+          "
+
+      - name: replay-trace dry run (fixture)
+        run: |
+          python3 scripts/replay-trace.py \
+            --url http://127.0.0.1:9 \
+            --data-root tests/fixtures \
+            --trace-id ci-trace-0 \
+            --dry-run \
+            --skip-health-check \
+            -o "${RUNNER_TEMP}/replay.jsonl"
+          test "$(wc -l < "${RUNNER_TEMP}/replay.jsonl")" -eq 2

--- a/.github/workflows/llm-agentx-shell.yml
+++ b/.github/workflows/llm-agentx-shell.yml
@@ -1,0 +1,65 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+name: llm-agentx Shell
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'benchmarks/llm-agentx/**'
+      - '.github/workflows/llm-agentx-shell.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  run-agent-smoke:
+    name: run-agent dry-run smoke
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: benchmarks/llm-agentx
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install deps
+        run: pip install -r requirements.txt
+
+      - name: Serial run-agent (dry-run fixtures)
+        env:
+          AGENTX_DATA_ROOT: ${{ github.workspace }}/benchmarks/llm-agentx/tests/fixtures
+          AGENTX_DRY_RUN: '1'
+          AGENTX_SEED: '42'
+          ITERATIONS: '1'
+        run: |
+          set -euo pipefail
+          ./run-agent.sh 2>&1 | tee "${RUNNER_TEMP}/run-agent.log"
+          grep -q 'run-agent: iteration=1/1' "${RUNNER_TEMP}/run-agent.log"
+
+      - name: run-agent-parallel (2 workers, dry-run)
+        env:
+          AGENTX_DATA_ROOT: ${{ github.workspace }}/benchmarks/llm-agentx/tests/fixtures
+          AGENTX_DRY_RUN: '1'
+          BASE_SEED: '100'
+          ITERATIONS: '1'
+        run: |
+          set -euo pipefail
+          WORKERS=2 OUTPUT_DIR="${RUNNER_TEMP}/parallel-out" ./run-agent-parallel.sh
+          test -f "${RUNNER_TEMP}/parallel-out/"*/worker-0.jsonl
+          test -f "${RUNNER_TEMP}/parallel-out/"*/worker-1.jsonl
+
+      - name: parse-results on parallel output
+        run: |
+          set -euo pipefail
+          run_dir="$(ls -td "${RUNNER_TEMP}/parallel-out"/*/ | head -1)"
+          python3 scripts/parse-results.py "${run_dir}" -o "${RUNNER_TEMP}/summary.json"
+          python3 -c "import json; s=json.load(open('${RUNNER_TEMP}/summary.json')); assert s['step_count'] >= 4"

--- a/.gitignore
+++ b/.gitignore
@@ -67,9 +67,13 @@ benchmarks/ttft-llamacpp/logs/
 benchmarks/ttft-llamacpp/reports/
 benchmarks/llm-prefill-benchmark/logs/
 benchmarks/llm-prefill-benchmark/reports/
+benchmarks/llm-agentx/logs/
+benchmarks/llm-agentx/reports/
 
-# Generated Gutenberg benchmark corpus (repo-root data/gutenberg/)
-data/gutenberg/
+# Generated CC trace corpus (repo-root data/cc-traces/)
+data/cc-traces/
+# Legacy Agent-X download path (safe to remove locally)
+data/agentx/
 
 # slurm logs and reports
 .slurm/logs/

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -351,3 +351,9 @@ SLO
 PyPI
 GMU
 callanjfox
+SemiAnalysis
+agentic
+agentx
+semianalysisai
+subagents
+Ctrl

--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ python -m pip install -r requirements.txt
 ```
 
 Benchmark Docker images install slimmer, image-local
-`requirements.txt` files under `benchmarks/ttft-*` and
-`benchmarks/llm-prefill-benchmark` (see each benchmark README).
+`requirements.txt` files under `benchmarks/ttft-*`,
+`benchmarks/llm-prefill-benchmark`, and
+`benchmarks/llm-agentx` (see each benchmark README).
 Scripts such as `benchmarks/llm-prefill-benchmark/scripts/test-aic.py`
 need only `openai` unless you use the full tool stack.
 
@@ -35,6 +36,7 @@ need only `openai` unless you use the full tool stack.
 | TTFT benchmark (vLLM + LMCache) | [benchmarks/ttft-lmcache][b-lmc] | [README][r-lmc] |
 | TTFT benchmark (llama.cpp) | [benchmarks/ttft-llamacpp][b-lcp] | [README][r-lcp] |
 | LLM prefill benchmark (Gutenberg) | [benchmarks/llm-prefill-benchmark][b-lpb] | [README][r-lpb] |
+| LLM Agent-X benchmark (CC trace replay) | [benchmarks/llm-agentx][b-lax] | [README][r-lax] |
 | vLLM + LMCache hipfile recipe | [recipies/vllm-lmcache-hipfile][r-vr] | [README][r-vr] |
 | Grafana dashboards | [grafana/][grafana-dir] | [README][grafana-readme] |
 | vLLM + LMCache NIXL recipe | [recipies/vllm-lmcache-nixl][r-vn] | [README][r-vn] |
@@ -60,6 +62,7 @@ NVMe, hipFile/AIS, NFS).
 | [ttft-lmcache][b-lmc] | vLLM + LMCache | Instinct (CDNA) | [README][r-lmc] |
 | [ttft-llamacpp][b-lcp] | llama.cpp | Instinct + Radeon | [README][r-lcp] |
 | [llm-prefill-benchmark][b-lpb] | vLLM (OpenAI API) | Engine-agnostic | [README][r-lpb] |
+| [llm-agentx][b-lax] | Text LLM (OpenAI API) | Engine-agnostic | [README][r-lax] |
 
 The llama.cpp benchmark includes a `--cache-disk` patch for automatic
 disk-tier prompt caching (see [patches/0001-cache-disk.patch][patch]).
@@ -153,9 +156,11 @@ rocm-aic/
 [b-lmc]: benchmarks/ttft-lmcache/
 [b-lcp]: benchmarks/ttft-llamacpp/
 [b-lpb]: benchmarks/llm-prefill-benchmark/
+[b-lax]: benchmarks/llm-agentx/
 [r-lmc]: benchmarks/ttft-lmcache/README.md
 [r-lcp]: benchmarks/ttft-llamacpp/README.md
 [r-lpb]: benchmarks/llm-prefill-benchmark/README.md
+[r-lax]: benchmarks/llm-agentx/README.md
 [patch]: benchmarks/ttft-llamacpp/patches/0001-cache-disk.patch
 [r-vr]: recipies/vllm-lmcache-hipfile/
 [grafana-dir]: grafana/

--- a/benchmarks/llm-agentx/Makefile
+++ b/benchmarks/llm-agentx/Makefile
@@ -1,0 +1,115 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+
+REPO_ROOT := $(abspath $(CURDIR)/../..)
+BENCH_ROOT := $(CURDIR)
+VENV_PYTHON := $(REPO_ROOT)/.venv/bin/python3
+ifeq ($(wildcard $(VENV_PYTHON)),)
+PYTHON ?= python3
+else
+PYTHON ?= $(VENV_PYTHON)
+endif
+
+AGENTX_DATA_ROOT ?= $(REPO_ROOT)/data/cc-traces
+HF_CONFIG ?= $(BENCH_ROOT)/configs/cc-traces-hf.yaml
+REQ_FILE := $(BENCH_ROOT)/requirements.txt
+
+BASE_URL ?= http://127.0.0.1:8000
+MODEL ?= Qwen/Qwen2.5-3B-Instruct
+WORKERS ?= 4
+ITERATIONS ?= 1
+BASE_SEED ?= 42
+AGENTX_MAX_REQUESTS ?=
+MAX_TOKENS ?= 512
+AGENTX_HONOR_THINK_TIME ?= 0
+AGENTX_MAX_CONTEXT ?=
+AGENTX_STRICT ?= 0
+
+.PHONY: help install check-deps check-data check-server data run run-parallel report
+
+.DEFAULT_GOAL := help
+
+help:
+	@echo "llm-agentx — SemiAnalysis CC agent trace replay (OpenAI API)"
+	@echo ""
+	@echo "  make install        pip install -r requirements.txt (uses $(PYTHON))"
+	@echo "  make check-server   verify BASE_URL and MODEL"
+	@echo "  make data           download CC traces from Hugging Face"
+	@echo "  make run            serial run-agent.sh (ITERATIONS=$(ITERATIONS))"
+	@echo "  make run-parallel   run-agent-parallel.sh (WORKERS=$(WORKERS))"
+	@echo "  make report         aggregate latest parallel run logs"
+	@echo ""
+	@echo "Python: $(PYTHON)"
+	@echo "Env: BASE_URL, MODEL, AGENTX_DATA_ROOT, ITERATIONS, WORKERS,"
+	@echo "     AGENTX_MAX_REQUESTS, AGENTX_MAX_CONTEXT, AGENTX_STRICT,"
+	@echo "     AGENTX_HONOR_THINK_TIME, MAX_TOKENS"
+
+install:
+	@$(PYTHON) -m pip install -r "$(REQ_FILE)"
+
+check-deps:
+	@set -e; \
+	command -v $(PYTHON) >/dev/null 2>&1 || { \
+		echo "ERROR: $(PYTHON) not found (create .venv: python3 -m venv $(REPO_ROOT)/.venv)" >&2; \
+		exit 1; \
+	}; \
+	$(PYTHON) -c "import huggingface_hub, yaml, tiktoken" 2>/dev/null || { \
+		echo "ERROR: missing Python deps for llm-agentx" >&2; \
+		echo "  fix: make -C $(BENCH_ROOT) install" >&2; \
+		exit 1; \
+	}
+
+check-data:
+	@test -f "$(AGENTX_DATA_ROOT)/traces.jsonl" || { \
+		echo "ERROR: missing $(AGENTX_DATA_ROOT)/traces.jsonl — run 'make data' first" >&2; \
+		exit 1; \
+	}
+
+check-server: check-deps
+	@$(PYTHON) "$(BENCH_ROOT)/scripts/replay-trace.py" \
+		--url "$(BASE_URL)" --data-root "$(AGENTX_DATA_ROOT)" \
+		--model "$(MODEL)" --check-only
+
+data: check-deps
+	@set -e; \
+	echo "make data: -> $(AGENTX_DATA_ROOT) (python=$(PYTHON))"; \
+	$(PYTHON) "$(BENCH_ROOT)/scripts/download-dataset.py" \
+		--config $(HF_CONFIG) --output $(AGENTX_DATA_ROOT)
+
+run: check-deps check-data
+	@set -e; \
+	"$(PYTHON)" "$(BENCH_ROOT)/scripts/replay-trace.py" \
+		--url "$(BASE_URL)" --data-root "$(AGENTX_DATA_ROOT)" \
+		--model "$(MODEL)" --check-only; \
+	ts=$$(date -u +%Y%m%dT%H%M%SZ); \
+	out="$(BENCH_ROOT)/logs/run-agent/$$ts/run.jsonl"; \
+	mkdir -p "$$(dirname "$$out")"; \
+	PYTHON="$(PYTHON)" BASE_URL="$(BASE_URL)" MODEL="$(MODEL)" \
+		AGENTX_DATA_ROOT="$(AGENTX_DATA_ROOT)" \
+		ITERATIONS="$(ITERATIONS)" 		AGENTX_MAX_REQUESTS="$(AGENTX_MAX_REQUESTS)" \
+		AGENTX_MAX_CONTEXT="$(AGENTX_MAX_CONTEXT)" AGENTX_STRICT="$(AGENTX_STRICT)" \
+		AGENTX_HONOR_THINK_TIME="$(AGENTX_HONOR_THINK_TIME)" MAX_TOKENS="$(MAX_TOKENS)" \
+		bash "$(BENCH_ROOT)/run-agent.sh" >"$$out"; \
+	echo "wrote $$out"
+
+run-parallel: check-deps check-data
+	@PYTHON="$(PYTHON)" BASE_URL="$(BASE_URL)" MODEL="$(MODEL)" \
+		AGENTX_DATA_ROOT="$(AGENTX_DATA_ROOT)" \
+		WORKERS="$(WORKERS)" ITERATIONS="$(ITERATIONS)" BASE_SEED="$(BASE_SEED)" \
+		AGENTX_MAX_REQUESTS="$(AGENTX_MAX_REQUESTS)" \
+		AGENTX_HONOR_THINK_TIME="$(AGENTX_HONOR_THINK_TIME)" \
+		MAX_TOKENS="$(MAX_TOKENS)" \
+		bash "$(BENCH_ROOT)/run-agent-parallel.sh" "$(WORKERS)"
+
+report: check-deps
+	@set -e; \
+	latest="$$(ls -td "$(BENCH_ROOT)/logs/run-agent-parallel"/*/ 2>/dev/null | head -1)"; \
+	if [ -z "$$latest" ]; then \
+		echo "error: no run-agent-parallel logs under $(BENCH_ROOT)/logs/" >&2; \
+		exit 1; \
+	fi; \
+	echo "report: $$latest"; \
+	$(PYTHON) "$(BENCH_ROOT)/scripts/parse-results.py" "$$latest" \
+		-o "$(BENCH_ROOT)/reports/$$(basename "$$latest").json"

--- a/benchmarks/llm-agentx/README.md
+++ b/benchmarks/llm-agentx/README.md
@@ -1,0 +1,115 @@
+<!--
+Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+SPDX-License-Identifier: MIT
+-->
+
+# LLM Agent-X benchmark (CC trace replay)
+
+Engine-agnostic workload for replaying [SemiAnalysis Claude Code agent
+traces][cc-traces] against any OpenAI-compatible text LLM server. Measures
+per-request TTFT, wall time, and token usage under realistic agentic context
+growth (main-agent turns plus nested sub-agent requests).
+
+Part of [rocm-aic](../../README.md).
+
+Dataset source:
+[semianalysisai/cc-traces-weka-with-subagents-052726-256k][hf-dataset]
+(470 traces, in+out ≤ 256k proxy tokens, Apache-2.0). Pinned in
+[`configs/cc-traces-hf.yaml`](configs/cc-traces-hf.yaml).
+
+Traces ship **metadata only** (`in`, `out`, `hash_ids`, timing) — no prompt
+text. The replay client synthesizes filler prompts sized with the dataset's
+proxy tokenizer (`o200k_base`) to match each request's input length.
+
+## Compared to other benchmarks
+
+| Benchmark | Focus |
+|-----------|-------|
+| [llm-prefill-benchmark](../llm-prefill-benchmark) | Long text prefill (Gutenberg) |
+| **llm-agentx** | Real agentic CC traces + KV-oriented ISL growth |
+| [ttft-lmcache](../ttft-lmcache) | Controlled KV-cache hit-rate sweep |
+
+## Prerequisites
+
+- Python 3.10+ with benchmark deps:
+
+```bash
+cd benchmarks/llm-agentx
+make install    # uses repo .venv/bin/python3 when present
+```
+
+- Running text LLM server: `curl -sS http://127.0.0.1:8000/v1/models`
+- ~900 MB disk after `make data`
+- Start vLLM **detached** before `make run-parallel`. Interactive
+  `docker run -it` in the **same** shell can receive Ctrl+C and stop the
+  server.
+
+## Quick start
+
+```bash
+cd benchmarks/llm-agentx
+make install
+make data
+export BASE_URL=http://127.0.0.1:8000
+export MODEL=Qwen/Qwen2.5-3B-Instruct
+make check-server
+make run ITERATIONS=5
+make run-parallel WORKERS=4 ITERATIONS=10
+make report
+```
+
+Dry-run against CI fixtures (no server):
+
+```bash
+AGENTX_DATA_ROOT=tests/fixtures AGENTX_DRY_RUN=1 ./run-agent.sh
+```
+
+Cap requests per trace (useful for smoke tests):
+
+```bash
+AGENTX_MAX_REQUESTS=3 make run ITERATIONS=1
+```
+
+## Environment
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `BASE_URL` | `http://127.0.0.1:8000` | OpenAI API root (no `/v1` suffix) |
+| `MODEL` | `Qwen/Qwen2.5-3B-Instruct` | Must match a served model id |
+| `AGENTX_DATA_ROOT` | `../../data/cc-traces` | `traces.jsonl` corpus |
+| `ITERATIONS` | `1` | Traces per worker run |
+| `AGENTX_SEED` | random | Trace selection seed |
+| `AGENTX_MAX_REQUESTS` | unset | Cap requests replayed per trace |
+| `AGENTX_MAX_CONTEXT` | auto from `/v1/models` | Skip requests when `in+out` exceeds limit |
+| `AGENTX_STRICT` | `0` | Fail instead of skip on oversized requests |
+| `AGENTX_HONOR_THINK_TIME` | `0` | Sleep trace `think_time` between requests |
+| `MAX_TOKENS` | `512` | Cap completion tokens per request |
+| `AGENTX_DRY_RUN` | `0` | Skip HTTP; emit fixture metrics |
+| `AGENTX_HF_HOME` | `data/cc-traces/.hf-cache` | HF download cache |
+| `LLM_AGENTX_BENCH_ROOT` | auto | Override benchmark tree (Slurm) |
+
+## Replay model
+
+For each trace, requests are replayed in order. Main-agent turns (`type`
+`s`/`n`) accumulate chat history; `type: subagent` blocks start a fresh
+sub-agent conversation for their inner requests. Each HTTP call pads the
+prompt to the trace's `in` token count and requests up to `out` completion
+tokens (capped by `MAX_TOKENS`).
+
+## Layout
+
+| Path | Role |
+|------|------|
+| `run-agent.sh` | Serial loop; JSONL on stdout |
+| `run-agent-parallel.sh` | Parallel workers |
+| `scripts/download-dataset.py` | HF fetch of `traces.jsonl` |
+| `scripts/token_fill.py` | o200k_base filler for target ISL |
+| `scripts/replay-trace.py` | Trace replay + TTFT metrics |
+| `scripts/parse-results.py` | Aggregate worker JSONL |
+| `configs/cc-traces-hf.yaml` | Pinned HF dataset |
+| `tests/fixtures/traces.jsonl` | CI mini trace |
+
+## References
+
+[cc-traces]: https://huggingface.co/datasets/semianalysisai/cc-traces-weka-with-subagents-052726-256k
+[hf-dataset]: https://huggingface.co/datasets/semianalysisai/cc-traces-weka-with-subagents-052726-256k

--- a/benchmarks/llm-agentx/configs/cc-traces-hf.yaml
+++ b/benchmarks/llm-agentx/configs/cc-traces-hf.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# SemiAnalysis Claude Code agent traces for Weka-style KV-cache replay.
+repo_id: semianalysisai/cc-traces-weka-with-subagents-052726-256k
+revision: main
+trace_file: traces.jsonl

--- a/benchmarks/llm-agentx/lib/bench-root.sh
+++ b/benchmarks/llm-agentx/lib/bench-root.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Resolve LLM_AGENTX_BENCH_ROOT (benchmarks/llm-agentx).
+_llm_agentx_bench_root() {
+	if [[ -n "${LLM_AGENTX_BENCH_ROOT:-}" ]]; then
+		printf '%s' "${LLM_AGENTX_BENCH_ROOT}"
+		return 0
+	fi
+	local lib_dir repo
+	lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+	repo="$(cd "${lib_dir}/../.." && pwd)"
+	printf '%s/benchmarks/llm-agentx' "${repo}"
+}

--- a/benchmarks/llm-agentx/requirements.txt
+++ b/benchmarks/llm-agentx/requirements.txt
@@ -1,0 +1,8 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+
+huggingface_hub>=0.25.0
+PyYAML>=6.0
+tiktoken>=0.7.0

--- a/benchmarks/llm-agentx/run-agent-parallel.sh
+++ b/benchmarks/llm-agentx/run-agent-parallel.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Launch N parallel run-agent.sh workers with distinct AGENTX_SEED values.
+#
+# Usage:
+#   ./run-agent-parallel.sh [WORKERS]
+#
+# Wrapper env: WORKERS, BASE_SEED, OUTPUT_DIR, STAGGER_SEC, ITERATIONS
+#
+# SIGINT/SIGTERM stops benchmark workers only (does not propagate to the
+# shell's other jobs). Start vLLM detached (e.g. make run-batch) rather than
+# interactive docker run -it in the same shell session.
+
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+run_agent="${here}/run-agent.sh"
+
+if [[ ! -x "${run_agent}" ]]; then
+	echo "error: missing or non-executable ${run_agent}" >&2
+	exit 1
+fi
+
+WORKERS="${1:-${WORKERS:-4}}"
+BASE_SEED="${BASE_SEED:-$RANDOM}"
+OUTPUT_DIR="${OUTPUT_DIR:-${here}/logs/run-agent-parallel}"
+STAGGER_SEC="${STAGGER_SEC:-0}"
+ITERATIONS="${ITERATIONS:-1}"
+
+if ! [[ "${WORKERS}" =~ ^[1-9][0-9]*$ ]]; then
+	echo "error: WORKERS must be a positive integer (got ${WORKERS})" >&2
+	exit 1
+fi
+if ! [[ "${BASE_SEED}" =~ ^[0-9]+$ ]]; then
+	echo "error: BASE_SEED must be a non-negative integer (got ${BASE_SEED})" >&2
+	exit 1
+fi
+
+mkdir -p "${OUTPUT_DIR}"
+stamp=$(date -u +%Y%m%dT%H%M%SZ)
+run_dir="${OUTPUT_DIR}/${stamp}"
+mkdir -p "${run_dir}"
+
+echo "run-agent-parallel: workers=${WORKERS} base_seed=${BASE_SEED} iterations=${ITERATIONS}" >&2
+echo "run-agent-parallel: output=${run_dir}" >&2
+
+failed=0
+pids=()
+_interrupted=0
+
+_stop_workers() {
+	local w pid
+	for ((w = 0; w < ${#pids[@]}; w++)); do
+		pid="${pids[w]}"
+		if [[ -n "${pid}" ]] && kill -0 "${pid}" 2>/dev/null; then
+			kill -TERM "${pid}" 2>/dev/null || true
+		fi
+	done
+}
+
+_on_interrupt() {
+	_interrupted=1
+	echo "run-agent-parallel: interrupted — stopping workers (vLLM/docker untouched)" >&2
+	_stop_workers
+}
+
+trap '_on_interrupt' INT TERM
+
+for ((w = 0; w < WORKERS; w++)); do
+	seed=$((BASE_SEED + w))
+	out_jsonl="${run_dir}/worker-${w}.jsonl"
+	out_log="${run_dir}/worker-${w}.log"
+
+	(
+		export AGENTX_SEED="${seed}"
+		export RUN_AGENT_WORKER="${w}"
+		exec bash "${run_agent}"
+	) >"${out_jsonl}" 2>"${out_log}" &
+	pid=$!
+	pids+=("${pid}")
+	echo "run-agent-parallel: started worker=${w} pid=${pid} seed=${seed}" >&2
+
+	if [[ "${w}" -lt $((WORKERS - 1)) && "${STAGGER_SEC}" != "0" ]]; then
+		sleep "${STAGGER_SEC}"
+	fi
+done
+
+for ((w = 0; w < WORKERS; w++)); do
+	pid="${pids[w]}"
+	if wait "${pid}"; then
+		echo "run-agent-parallel: worker=${w} pid=${pid} ok" >&2
+	else
+		rc=$?
+		if [[ "${_interrupted}" -eq 1 && "${rc}" -gt 128 ]]; then
+			echo "run-agent-parallel: worker=${w} pid=${pid} stopped" >&2
+		else
+			echo "run-agent-parallel: worker=${w} pid=${pid} FAILED (see ${run_dir}/worker-${w}.log)" >&2
+			failed=$((failed + 1))
+		fi
+	fi
+done
+
+trap - INT TERM
+
+echo "run-agent-parallel: done failed=${failed}/${WORKERS} dir=${run_dir}" >&2
+if [[ "${_interrupted}" -eq 1 ]]; then
+	exit 130
+fi
+if [[ "${failed}" -gt 0 ]]; then
+	exit 1
+fi

--- a/benchmarks/llm-agentx/run-agent.sh
+++ b/benchmarks/llm-agentx/run-agent.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Serial CC trace replay loop. Prints one JSON object per request to stdout.
+# Env: BASE_URL, MODEL, AGENTX_DATA_ROOT, ITERATIONS, AGENTX_SEED,
+#      AGENTX_MAX_REQUESTS, MAX_TOKENS, AGENTX_DRY_RUN, AGENTX_HONOR_THINK_TIME,
+#      RUN_AGENT_WORKER, RUN_AGENT_REPLAY (override replay-trace.py path).
+
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/bench-root.sh
+source "${here}/lib/bench-root.sh"
+BENCH_ROOT="${LLM_AGENTX_BENCH_ROOT:-${here}}"
+REPLAY="${RUN_AGENT_REPLAY:-${BENCH_ROOT}/scripts/replay-trace.py}"
+_default_python() {
+	local repo_root
+	repo_root="$(cd "${BENCH_ROOT}/../.." && pwd)"
+	if [[ -x "${repo_root}/.venv/bin/python3" ]]; then
+		printf '%s/.venv/bin/python3' "${repo_root}"
+		return 0
+	fi
+	printf 'python3'
+}
+PYTHON="${PYTHON:-$(_default_python)}"
+
+BASE_URL="${BASE_URL:-http://127.0.0.1:8000}"
+MODEL="${MODEL:-Qwen/Qwen2.5-3B-Instruct}"
+_default_data_root() {
+	local repo_root
+	repo_root="$(cd "${BENCH_ROOT}/../.." && pwd)"
+	if [[ -d "${repo_root}/data/cc-traces" ]]; then
+		printf '%s/data/cc-traces' "${repo_root}"
+	else
+		printf '%s/tests/fixtures' "${BENCH_ROOT}"
+	fi
+}
+AGENTX_DATA_ROOT="${AGENTX_DATA_ROOT:-$(_default_data_root)}"
+ITERATIONS="${ITERATIONS:-1}"
+MAX_TOKENS="${MAX_TOKENS:-512}"
+AGENTX_DRY_RUN="${AGENTX_DRY_RUN:-0}"
+AGENTX_HONOR_THINK_TIME="${AGENTX_HONOR_THINK_TIME:-0}"
+AGENTX_STRICT="${AGENTX_STRICT:-0}"
+RUN_AGENT_WORKER="${RUN_AGENT_WORKER:-}"
+
+if ! [[ "${ITERATIONS}" =~ ^[1-9][0-9]*$ ]]; then
+	echo "error: ITERATIONS must be a positive integer (got ${ITERATIONS})" >&2
+	exit 1
+fi
+
+if [[ -n "${AGENTX_SEED+x}" && -n "${AGENTX_SEED}" ]]; then
+	if ! [[ "${AGENTX_SEED}" =~ ^[0-9]+$ ]]; then
+		echo "error: AGENTX_SEED must be a non-negative integer (got ${AGENTX_SEED})" >&2
+		exit 1
+	fi
+	SEED="${AGENTX_SEED}"
+	_seed_log=" seed=${AGENTX_SEED}"
+else
+	SEED="${RANDOM}"
+	_seed_log=" seed=${SEED} (random)"
+fi
+
+_worker_log=""
+if [[ -n "${RUN_AGENT_WORKER}" ]]; then
+	_worker_log=" worker=${RUN_AGENT_WORKER}"
+fi
+
+_replay_opts=(
+	--url "${BASE_URL}"
+	--data-root "${AGENTX_DATA_ROOT}"
+	--model "${MODEL}"
+	--max-tokens "${MAX_TOKENS}"
+	--count 1
+)
+
+if [[ -n "${AGENTX_MAX_REQUESTS:-}" ]]; then
+	_replay_opts+=(--max-requests "${AGENTX_MAX_REQUESTS}")
+fi
+if [[ "${AGENTX_DRY_RUN}" == "1" ]]; then
+	_replay_opts+=(--dry-run --skip-health-check)
+fi
+if [[ "${AGENTX_HONOR_THINK_TIME}" == "1" ]]; then
+	_replay_opts+=(--honor-think-time)
+fi
+if [[ -n "${AGENTX_MAX_CONTEXT:-}" ]]; then
+	_replay_opts+=(--max-context "${AGENTX_MAX_CONTEXT}")
+fi
+if [[ "${AGENTX_STRICT}" == "1" ]]; then
+	_replay_opts+=(--strict)
+fi
+
+echo "run-agent: iterations=${ITERATIONS}${_worker_log}${_seed_log} data=${AGENTX_DATA_ROOT}" >&2
+
+for ((i = 1; i <= ITERATIONS; i++)); do
+	iter_seed=$((SEED + i - 1))
+	echo "run-agent: iteration=${i}/${ITERATIONS} seed=${iter_seed}" >&2
+	tmp="$(mktemp)"
+	"${PYTHON}" "${REPLAY}" \
+		"${_replay_opts[@]}" \
+		--seed "${iter_seed}" \
+		-o "${tmp}"
+
+	while IFS= read -r line; do
+		[[ -z "${line}" ]] && continue
+		if [[ -n "${RUN_AGENT_WORKER}" ]]; then
+			"${PYTHON}" -c "
+import json, sys
+row = json.loads(sys.argv[1])
+row['run_agent_iteration'] = int(sys.argv[2])
+row['run_agent_seed'] = int(sys.argv[3])
+row['run_agent_worker'] = int(sys.argv[4])
+print(json.dumps(row, ensure_ascii=False))
+" "${line}" "${i}" "${iter_seed}" "${RUN_AGENT_WORKER}"
+		else
+			"${PYTHON}" -c "
+import json, sys
+row = json.loads(sys.argv[1])
+row['run_agent_iteration'] = int(sys.argv[2])
+row['run_agent_seed'] = int(sys.argv[3])
+print(json.dumps(row, ensure_ascii=False))
+" "${line}" "${i}" "${iter_seed}"
+		fi
+	done <"${tmp}"
+	rm -f "${tmp}"
+done

--- a/benchmarks/llm-agentx/run-agent.sh
+++ b/benchmarks/llm-agentx/run-agent.sh
@@ -11,7 +11,7 @@
 set -euo pipefail
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=lib/bench-root.sh
+# shellcheck source=./benchmarks/llm-agentx/lib/bench-root.sh
 source "${here}/lib/bench-root.sh"
 BENCH_ROOT="${LLM_AGENTX_BENCH_ROOT:-${here}}"
 REPLAY="${RUN_AGENT_REPLAY:-${BENCH_ROOT}/scripts/replay-trace.py}"

--- a/benchmarks/llm-agentx/scripts/download-dataset.py
+++ b/benchmarks/llm-agentx/scripts/download-dataset.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+"""Download SemiAnalysis CC traces from Hugging Face."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError as exc:
+    raise SystemExit("error: PyYAML required (pip install PyYAML)") from exc
+
+try:
+    from huggingface_hub import hf_hub_download
+except ImportError as exc:
+    raise SystemExit("error: huggingface_hub required") from exc
+
+
+def load_hf_config(path: Path) -> dict[str, Any]:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"error: invalid HF config: {path}")
+    return data
+
+
+def resolve_hf_cache(output: Path, override: Path | None) -> Path:
+    if override is not None:
+        base = override
+    elif os.environ.get("AGENTX_HF_HOME"):
+        base = Path(os.environ["AGENTX_HF_HOME"])
+    elif os.environ.get("HF_HOME"):
+        base = Path(os.environ["HF_HOME"])
+    else:
+        base = output / ".hf-cache"
+    cache_dir = (base / "hub").resolve()
+    try:
+        cache_dir.mkdir(parents=True, exist_ok=True)
+    except PermissionError as exc:
+        raise SystemExit(
+            f"error: cannot create HF cache {cache_dir}: {exc}\n"
+            "  fix: export AGENTX_HF_HOME=$PWD/../../data/cc-traces/.hf-cache"
+        ) from exc
+    return cache_dir
+
+
+def count_traces(path: Path) -> int:
+    count = 0
+    with path.open(encoding="utf-8") as fh:
+        for line in fh:
+            if line.strip():
+                count += 1
+    return count
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--config",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent / "configs" / "cc-traces-hf.yaml",
+    )
+    p.add_argument(
+        "--output",
+        type=Path,
+        help="Destination root (default: repo data/cc-traces)",
+    )
+    p.add_argument(
+        "--hf-cache",
+        type=Path,
+        help="HF hub cache root (default: <output>/.hf-cache/hub)",
+    )
+    args = p.parse_args()
+
+    cfg = load_hf_config(args.config.resolve())
+    repo_id = str(cfg["repo_id"])
+    revision = str(cfg.get("revision") or "main")
+    trace_file = str(cfg.get("trace_file") or "traces.jsonl")
+
+    repo_root = Path(__file__).resolve().parent.parent.parent.parent
+    output = args.output or (repo_root / "data" / "cc-traces")
+    output = output.resolve()
+    hf_cache = resolve_hf_cache(output, args.hf_cache)
+
+    print(f"download-dataset: {repo_id} @ {revision} -> {output}")
+    print(f"  hf cache: {hf_cache}")
+
+    local = hf_hub_download(
+        repo_id=repo_id,
+        repo_type="dataset",
+        filename=trace_file,
+        revision=revision,
+        cache_dir=str(hf_cache),
+    )
+    dest = output / trace_file
+    output.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(local, dest)
+    print(f"  {trace_file} -> {dest}")
+
+    meta = {
+        "repo_id": repo_id,
+        "revision": revision,
+        "trace_file": trace_file,
+        "trace_count": count_traces(dest),
+    }
+    meta_path = output / "meta.json"
+    meta_path.write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+    print(f"  traces: {meta['trace_count']} -> {meta_path}")
+    print(f"done: {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/llm-agentx/scripts/parse-results.py
+++ b/benchmarks/llm-agentx/scripts/parse-results.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+"""Aggregate llm-agentx run JSONL files into a summary JSON."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def load_jsonl_rows(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    if not path.is_file():
+        return rows
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict):
+            rows.append(obj)
+    return rows
+
+
+def percentile(values: list[float], pct: float) -> float:
+    if not values:
+        raise ValueError("empty values")
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    k = (len(ordered) - 1) * (pct / 100.0)
+    f = int(k)
+    c = min(f + 1, len(ordered) - 1)
+    if f == c:
+        return ordered[f]
+    return ordered[f] + (ordered[c] - ordered[f]) * (k - f)
+
+
+def stats(values: list[float]) -> dict[str, float]:
+    return {
+        "min": min(values),
+        "max": max(values),
+        "mean": statistics.fmean(values),
+        "p50": percentile(values, 50),
+        "p95": percentile(values, 95),
+    }
+
+
+def summarize_run(path: Path) -> dict[str, Any]:
+    rows = load_jsonl_rows(path)
+    ttfts = [
+        float(r["client_ttft_seconds"])
+        for r in rows
+        if isinstance(r.get("client_ttft_seconds"), (int, float))
+    ]
+    walls = [
+        float(r["client_wall_time_seconds"])
+        for r in rows
+        if isinstance(r.get("client_wall_time_seconds"), (int, float))
+    ]
+    tasks = {str(r.get("trace_id")) for r in rows if r.get("trace_id") is not None}
+    summary: dict[str, Any] = {
+        "file": path.name,
+        "request_count": len(rows),
+        "trace_count": len(tasks),
+        "all_http_ok": all(r.get("http_status") == 200 for r in rows) if rows else False,
+    }
+    if ttfts:
+        summary["ttft_seconds"] = stats(ttfts)
+    if walls:
+        summary["wall_time_seconds"] = stats(walls)
+    return summary
+
+
+def aggregate(run_dir: Path) -> dict[str, Any]:
+    workers = sorted(run_dir.glob("worker-*.jsonl"))
+    serial = run_dir / "run.jsonl"
+    files = workers if workers else ([serial] if serial.is_file() else [])
+    per_file = [summarize_run(p) for p in files]
+
+    all_rows: list[dict[str, Any]] = []
+    for p in files:
+        all_rows.extend(load_jsonl_rows(p))
+
+    ttfts = [
+        float(r["client_ttft_seconds"])
+        for r in all_rows
+        if isinstance(r.get("client_ttft_seconds"), (int, float))
+    ]
+    walls = [
+        float(r["client_wall_time_seconds"])
+        for r in all_rows
+        if isinstance(r.get("client_wall_time_seconds"), (int, float))
+    ]
+
+    summary: dict[str, Any] = {
+        "run_dir": str(run_dir),
+        "file_count": len(files),
+        "step_count": len(all_rows),
+        "trace_count": len({str(r.get("trace_id")) for r in all_rows if r.get("trace_id")}),
+        "runs": per_file,
+        "all_http_ok": all(r.get("http_status") == 200 for r in all_rows) if all_rows else False,
+    }
+    if ttfts:
+        summary["ttft_seconds"] = stats(ttfts)
+    if walls:
+        summary["wall_time_seconds"] = stats(walls)
+    return summary
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "run_dir",
+        type=Path,
+        help="run-agent/<timestamp>/ or run-agent-parallel/<timestamp>/",
+    )
+    p.add_argument("-o", "--output", type=Path, help="Write summary JSON (default: stdout)")
+    args = p.parse_args()
+    run_dir = args.run_dir.resolve()
+    if not run_dir.is_dir():
+        print(f"error: not a directory: {run_dir}", file=sys.stderr)
+        return 1
+    data = aggregate(run_dir)
+    text = json.dumps(data, indent=2) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text, encoding="utf-8")
+        print(f"wrote {args.output}", file=sys.stderr)
+    else:
+        print(text, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/llm-agentx/scripts/replay-trace.py
+++ b/benchmarks/llm-agentx/scripts/replay-trace.py
@@ -1,0 +1,541 @@
+#!/usr/bin/env python3
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+"""Replay SemiAnalysis CC agent traces against an OpenAI-compatible server."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Iterator
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+if str(_SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPT_DIR))
+
+from token_fill import count_messages, pad_messages_to_in  # noqa: E402
+
+
+def _parse_sse_line(line: str) -> dict | None:
+    line = line.strip()
+    if not line.startswith("data:"):
+        return None
+    data = line[5:].strip()
+    if data == "[DONE]":
+        return None
+    try:
+        chunk = json.loads(data)
+    except json.JSONDecodeError:
+        return None
+    return chunk if isinstance(chunk, dict) else None
+
+
+def stream_completion(
+    base_url: str, payload: dict, api_key: str | None
+) -> tuple[int, dict[str, Any], float, float | None]:
+    body = dict(payload)
+    body["stream"] = True
+    body.setdefault("stream_options", {"include_usage": True})
+
+    url = base_url.rstrip("/") + "/v1/chat/completions"
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(body).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+
+    t0 = time.perf_counter()
+    ttft: float | None = None
+    content_parts: list[str] = []
+    usage: dict | None = None
+    http_status = 0
+
+    try:
+        with urllib.request.urlopen(req, timeout=3600) as resp:
+            http_status = resp.status
+            for raw_line in resp:
+                line = raw_line.decode("utf-8", errors="replace")
+                chunk = _parse_sse_line(line)
+                if not chunk:
+                    continue
+                if chunk.get("usage") is not None:
+                    usage = chunk["usage"]
+                choices = chunk.get("choices")
+                if not isinstance(choices, list) or not choices:
+                    continue
+                choice0 = choices[0]
+                if not isinstance(choice0, dict):
+                    continue
+                delta = choice0.get("delta")
+                if isinstance(delta, dict):
+                    piece = delta.get("content")
+                    if piece:
+                        if ttft is None:
+                            ttft = time.perf_counter() - t0
+                        content_parts.append(piece)
+    except urllib.error.HTTPError as exc:
+        http_status = exc.code
+        err_body = exc.read().decode("utf-8", errors="replace")
+        try:
+            err_json = json.loads(err_body)
+        except json.JSONDecodeError:
+            err_json = {"error": err_body}
+        wall = time.perf_counter() - t0
+        return http_status, {
+            "http_status": http_status,
+            "client_wall_time_seconds": wall,
+            "client_ttft_seconds": ttft,
+            "error": err_json,
+            "content": "".join(content_parts),
+        }, wall, ttft
+    except urllib.error.URLError as exc:
+        wall = time.perf_counter() - t0
+        return 0, {
+            "http_status": 0,
+            "client_wall_time_seconds": wall,
+            "client_ttft_seconds": None,
+            "error": {"message": str(exc)},
+            "content": "",
+        }, wall, None
+
+    wall = time.perf_counter() - t0
+    return http_status, {
+        "http_status": http_status,
+        "client_wall_time_seconds": wall,
+        "client_ttft_seconds": ttft,
+        "content": "".join(content_parts),
+        "usage": usage,
+    }, wall, ttft
+
+
+def fetch_models_body(base_url: str) -> dict[str, Any] | None:
+    url = base_url.rstrip("/") + "/v1/models"
+    try:
+        with urllib.request.urlopen(url, timeout=30) as resp:
+            body = json.loads(resp.read().decode("utf-8"))
+    except (urllib.error.URLError, urllib.error.HTTPError, json.JSONDecodeError, OSError):
+        return None
+    return body if isinstance(body, dict) else None
+
+
+def fetch_served_models(base_url: str) -> list[str] | None:
+    body = fetch_models_body(base_url)
+    if body is None:
+        return None
+    data = body.get("data")
+    if not isinstance(data, list):
+        return None
+    ids: list[str] = []
+    for item in data:
+        if isinstance(item, dict) and isinstance(item.get("id"), str):
+            ids.append(item["id"])
+    return ids
+
+
+def fetch_model_max_context(base_url: str, model: str) -> int | None:
+    body = fetch_models_body(base_url)
+    if body is None:
+        return None
+    data = body.get("data")
+    if not isinstance(data, list):
+        return None
+    for item in data:
+        if not isinstance(item, dict) or item.get("id") != model:
+            continue
+        raw = item.get("max_model_len")
+        if isinstance(raw, int) and raw > 0:
+            return raw
+    return None
+
+
+def validate_model(base_url: str, model: str) -> bool:
+    body = fetch_models_body(base_url)
+    if body is None:
+        print(
+            f"error: server not reachable at {base_url.rstrip('/')}/v1/models",
+            file=sys.stderr,
+        )
+        return False
+    served = fetch_served_models(base_url)
+    if served is None or model not in served:
+        print(f"error: MODEL={model!r} is not served at {base_url}", file=sys.stderr)
+        print(f"  served models: {', '.join(served) if served else '(none)'}", file=sys.stderr)
+        return False
+    max_ctx = fetch_model_max_context(base_url, model)
+    if max_ctx is not None:
+        print(f"  server max_context: {max_ctx} tokens", file=sys.stderr)
+    return True
+
+
+def completion_budget(trace_out: int, max_tokens_cap: int) -> int:
+    if trace_out > 0:
+        return min(trace_out, max_tokens_cap)
+    return max_tokens_cap
+
+
+def exceeds_max_context(
+    trace_in: int, trace_out: int, max_tokens_cap: int, max_context: int | None
+) -> bool:
+    if max_context is None:
+        return False
+    return trace_in + completion_budget(trace_out, max_tokens_cap) > max_context
+
+
+def load_traces(path: Path) -> list[dict[str, Any]]:
+    traces: list[dict[str, Any]] = []
+    with path.open(encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            obj = json.loads(line)
+            if isinstance(obj, dict):
+                traces.append(obj)
+    return traces
+
+
+def iter_model_requests(requests: list[Any]) -> Iterator[tuple[dict[str, Any], bool]]:
+    """Yield (request, is_subagent_inner) in trace order."""
+    for req in requests:
+        if not isinstance(req, dict):
+            continue
+        req_type = req.get("type")
+        if req_type == "subagent":
+            inner = req.get("requests")
+            if isinstance(inner, list):
+                for item in inner:
+                    if isinstance(item, dict) and item.get("type") in ("s", "n"):
+                        yield item, True
+        elif req_type in ("s", "n"):
+            yield req, False
+
+
+def replay_request(
+    *,
+    base_url: str,
+    model: str,
+    messages: list[dict[str, Any]],
+    req: dict[str, Any],
+    max_tokens_cap: int,
+    max_context: int | None,
+    skip_oversized: bool,
+    api_key: str | None,
+    dry_run: bool,
+    honor_think_time: bool,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    trace_in = int(req.get("in") or 0)
+    trace_out = int(req.get("out") or 0)
+    max_tokens = completion_budget(trace_out, max_tokens_cap)
+
+    row: dict[str, Any] = {
+        "trace_request_type": req.get("type"),
+        "trace_model": req.get("model"),
+        "trace_in": trace_in,
+        "trace_out": trace_out,
+        "trace_hash_ids": req.get("hash_ids"),
+        "trace_t_seconds": req.get("t"),
+        "model": model,
+    }
+
+    if skip_oversized and exceeds_max_context(
+        trace_in, trace_out, max_tokens_cap, max_context
+    ):
+        row.update(
+            {
+                "skipped": True,
+                "skip_reason": "exceeds_max_context",
+                "server_max_context": max_context,
+                "required_tokens": trace_in + max_tokens,
+            }
+        )
+        return messages, row
+
+    payload_messages = pad_messages_to_in(messages, trace_in)
+    approx_in = count_messages(payload_messages)
+    row["approx_prompt_tokens"] = approx_in
+
+    if honor_think_time:
+        think = req.get("think_time")
+        if isinstance(think, (int, float)) and think > 0:
+            time.sleep(float(think))
+
+    if dry_run:
+        row.update(
+            {
+                "http_status": 200,
+                "client_ttft_seconds": float(req.get("ttft") or 0.0),
+                "client_wall_time_seconds": float(req.get("api_time") or 0.0),
+                "dry_run": True,
+            }
+        )
+        next_messages = list(payload_messages)
+        next_messages.append(
+            {"role": "assistant", "content": f"[dry-run output len={trace_out}]"}
+        )
+        return next_messages, row
+
+    payload = {
+        "model": model,
+        "messages": payload_messages,
+        "max_tokens": max_tokens,
+        "temperature": 0.0,
+    }
+    status, result, _wall, _ttft = stream_completion(base_url, payload, api_key)
+    usage = result.get("usage") if isinstance(result.get("usage"), dict) else {}
+    row.update(
+        {
+            "http_status": status,
+            "client_ttft_seconds": result.get("client_ttft_seconds"),
+            "client_wall_time_seconds": result.get("client_wall_time_seconds"),
+            "prompt_tokens": usage.get("prompt_tokens"),
+            "completion_tokens": usage.get("completion_tokens"),
+            "assistant_content_len": len(result.get("content") or ""),
+        }
+    )
+    if "error" in result:
+        row["error"] = result["error"]
+
+    next_messages = list(payload_messages)
+    content = result.get("content") or ""
+    if content:
+        next_messages.append({"role": "assistant", "content": content})
+    return next_messages, row
+
+
+def replay_trace(
+    *,
+    base_url: str,
+    model: str,
+    trace: dict[str, Any],
+    max_tokens_cap: int,
+    max_context: int | None,
+    skip_oversized: bool,
+    max_requests: int | None,
+    api_key: str | None,
+    dry_run: bool,
+    honor_think_time: bool,
+) -> list[dict[str, Any]]:
+    trace_id = str(trace.get("id") or "")
+    requests = trace.get("requests")
+    if not isinstance(requests, list):
+        requests = []
+
+    rows: list[dict[str, Any]] = []
+    main_messages: list[dict[str, Any]] = [
+        {
+            "role": "system",
+            "content": "You are a coding assistant. Reply concisely.",
+        }
+    ]
+    sub_messages: list[dict[str, Any]] = []
+
+    for idx, (req, is_subagent) in enumerate(iter_model_requests(requests)):
+        if max_requests is not None and idx >= max_requests:
+            break
+
+        if is_subagent:
+            if not sub_messages:
+                sub_messages = [
+                    {
+                        "role": "system",
+                        "content": "You are a sub-agent coding assistant.",
+                    }
+                ]
+            sub_messages, row = replay_request(
+                base_url=base_url,
+                model=model,
+                messages=sub_messages,
+                req=req,
+                max_tokens_cap=max_tokens_cap,
+                max_context=max_context,
+                skip_oversized=skip_oversized,
+                api_key=api_key,
+                dry_run=dry_run,
+                honor_think_time=honor_think_time,
+            )
+        else:
+            main_messages, row = replay_request(
+                base_url=base_url,
+                model=model,
+                messages=main_messages,
+                req=req,
+                max_tokens_cap=max_tokens_cap,
+                max_context=max_context,
+                skip_oversized=skip_oversized,
+                api_key=api_key,
+                dry_run=dry_run,
+                honor_think_time=honor_think_time,
+            )
+            sub_messages = []
+
+        row["trace_id"] = trace_id
+        row["request_index"] = idx
+        row["is_subagent_inner"] = is_subagent
+        rows.append(row)
+
+        if row.get("skipped"):
+            continue
+
+        status = row.get("http_status")
+        if not dry_run and (status is None or int(status) < 200 or int(status) >= 300):
+            break
+
+    return rows
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--url", required=True, help="Server base URL (no /v1 suffix)")
+    p.add_argument("--data-root", type=Path, required=True)
+    p.add_argument("--traces-file", type=Path, help="Default: <data-root>/traces.jsonl")
+    p.add_argument("--model", default="Qwen/Qwen2.5-3B-Instruct")
+    p.add_argument("--trace-id", help="Single trace id")
+    p.add_argument("--seed", type=int, help="Random trace selection seed")
+    p.add_argument("--count", type=int, default=1, help="Random traces when --trace-id unset")
+    p.add_argument("--max-tokens", type=int, default=512, help="Cap completion tokens")
+    p.add_argument(
+        "--max-requests",
+        type=int,
+        help="Cap model requests replayed per trace",
+    )
+    p.add_argument("--api-key", default="dummy-key")
+    p.add_argument("--dry-run", action="store_true")
+    p.add_argument("-o", "--output", type=Path, help="Write JSONL results")
+    p.add_argument("--skip-health-check", action="store_true")
+    p.add_argument(
+        "--check-only",
+        action="store_true",
+        help="Verify BASE_URL and MODEL, then exit",
+    )
+    p.add_argument(
+        "--honor-think-time",
+        action="store_true",
+        help="Sleep trace think_time between requests",
+    )
+    p.add_argument(
+        "--max-context",
+        type=int,
+        help="Server context limit; default: read max_model_len from /v1/models",
+    )
+    p.add_argument(
+        "--strict",
+        action="store_true",
+        help="Fail on oversized requests instead of skipping them",
+    )
+    args = p.parse_args()
+
+    skip_oversized = not args.strict
+
+    if args.check_only:
+        if args.dry_run:
+            print("error: --check-only cannot be used with --dry-run", file=sys.stderr)
+            return 1
+        return 0 if validate_model(args.url, args.model) else 1
+
+    data_root = args.data_root.resolve()
+    traces_path = args.traces_file or (data_root / "traces.jsonl")
+    if not traces_path.is_file():
+        print(f"error: missing {traces_path}", file=sys.stderr)
+        return 1
+
+    traces = load_traces(traces_path)
+    if not traces:
+        print(f"error: no traces in {traces_path}", file=sys.stderr)
+        return 1
+
+    if not args.dry_run and not args.skip_health_check:
+        if not validate_model(args.url, args.model):
+            return 1
+
+    max_context = args.max_context
+    if max_context is None and not args.dry_run:
+        max_context = fetch_model_max_context(args.url, args.model)
+    if skip_oversized and max_context is not None:
+        print(
+            f"replay: max_context={max_context} (oversized trace requests skipped)",
+            file=sys.stderr,
+        )
+    elif skip_oversized and max_context is None:
+        print(
+            "replay: warning: max_context unknown; oversized requests may 400",
+            file=sys.stderr,
+        )
+
+    if args.trace_id:
+        selected = [t for t in traces if str(t.get("id")) == args.trace_id]
+        if not selected:
+            print(f"error: trace id not found: {args.trace_id}", file=sys.stderr)
+            return 1
+    else:
+        rng = random.Random(args.seed)
+        n = min(args.count, len(traces))
+        selected = rng.sample(traces, n)
+
+    all_rows: list[dict[str, Any]] = []
+    for trace in selected:
+        rows = replay_trace(
+            base_url=args.url,
+            model=args.model,
+            trace=trace,
+            max_tokens_cap=args.max_tokens,
+            max_context=max_context,
+            skip_oversized=skip_oversized,
+            max_requests=args.max_requests,
+            api_key=args.api_key,
+            dry_run=args.dry_run,
+            honor_think_time=args.honor_think_time,
+        )
+        all_rows.extend(rows)
+
+    skipped = sum(1 for r in all_rows if r.get("skipped"))
+    if skipped:
+        print(f"replay: skipped {skipped} request(s) over max_context", file=sys.stderr)
+
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        with args.output.open("w", encoding="utf-8") as fh:
+            for row in all_rows:
+                fh.write(json.dumps(row, ensure_ascii=False) + "\n")
+        print(f"wrote {len(all_rows)} rows -> {args.output}", file=sys.stderr)
+    else:
+        for row in all_rows:
+            print(json.dumps(row, ensure_ascii=False))
+
+    bad = [
+        r
+        for r in all_rows
+        if not r.get("skipped")
+        and r.get("http_status") not in (200, None)
+        and not r.get("dry_run")
+    ]
+    if bad:
+        for row in bad[:3]:
+            err = row.get("error")
+            task_id = row.get("trace_id")
+            step = row.get("request_index")
+            status = row.get("http_status")
+            if isinstance(err, dict):
+                msg = err.get("message") or err.get("error") or json.dumps(err)
+            else:
+                msg = str(err) if err is not None else f"HTTP {status}"
+            print(f"error: trace {task_id} request {step}: {msg}", file=sys.stderr)
+        if len(bad) > 3:
+            print(f"error: {len(bad) - 3} more failed request(s)", file=sys.stderr)
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/llm-agentx/scripts/token_fill.py
+++ b/benchmarks/llm-agentx/scripts/token_fill.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+"""Token counting and filler text for CC trace replay (o200k_base proxy)."""
+
+from __future__ import annotations
+
+import functools
+from typing import Any
+
+try:
+    import tiktoken
+except ImportError as exc:
+    raise SystemExit("error: tiktoken required (pip install tiktoken)") from exc
+
+_FILLER_UNIT = " benchmark"
+
+
+@functools.lru_cache(maxsize=1)
+def _encoding():
+    return tiktoken.get_encoding("o200k_base")
+
+
+def count_text(text: str) -> int:
+    return len(_encoding().encode(text))
+
+
+def count_messages(messages: list[dict[str, Any]]) -> int:
+    """Approximate chat prompt tokens for OpenAI-style messages."""
+    total = 3
+    for msg in messages:
+        role = str(msg.get("role") or "")
+        content = msg.get("content")
+        if isinstance(content, list):
+            parts: list[str] = []
+            for part in content:
+                if isinstance(part, dict):
+                    if part.get("type") == "text":
+                        parts.append(str(part.get("text") or ""))
+            text = "\n".join(parts)
+        else:
+            text = str(content or "")
+        total += count_text(role) + count_text(text) + 4
+    return total
+
+
+def make_filler(target_tokens: int) -> str:
+    if target_tokens <= 0:
+        return ""
+    unit_tokens = max(count_text(_FILLER_UNIT), 1)
+    repeats = max(1, (target_tokens // unit_tokens) + 1)
+    text = _FILLER_UNIT * repeats
+    tokens = _encoding().encode(text)
+    if len(tokens) >= target_tokens:
+        return _encoding().decode(tokens[:target_tokens])
+    return text
+
+
+def pad_messages_to_in(
+    messages: list[dict[str, Any]],
+    target_in: int,
+) -> list[dict[str, Any]]:
+    """Grow the last user turn (or add one) until messages reach target_in."""
+    if target_in <= 0:
+        return list(messages)
+
+    out = [dict(m) for m in messages]
+    current = count_messages(out)
+    if current >= target_in:
+        return out
+
+    need = target_in - current
+    filler = make_filler(need)
+
+    if out and out[-1].get("role") == "user":
+        prev = str(out[-1].get("content") or "")
+        out[-1] = {"role": "user", "content": prev + filler}
+    else:
+        out.append({"role": "user", "content": filler})
+
+    while count_messages(out) < target_in:
+        extra = make_filler(target_in - count_messages(out))
+        last = out[-1]
+        if last.get("role") == "user":
+            last["content"] = str(last.get("content") or "") + extra
+        else:
+            out.append({"role": "user", "content": extra})
+
+    return out

--- a/benchmarks/llm-agentx/tests/fixtures/traces.jsonl
+++ b/benchmarks/llm-agentx/tests/fixtures/traces.jsonl
@@ -1,0 +1,1 @@
+{"id": "ci-trace-0", "models": ["ci-model"], "block_size": 64, "hash_id_scope": "local", "requests": [{"t": 0.0, "type": "s", "model": "ci-model", "in": 48, "out": 12, "hash_ids": [0, 1, 2, 3], "api_time": 0.42, "ttft": 0.18}, {"t": 1.2, "type": "s", "model": "ci-model", "in": 72, "out": 16, "hash_ids": [0, 1, 2, 3, 4, 5], "api_time": 0.55, "think_time": 0.1, "ttft": 0.22}]}


### PR DESCRIPTION
Introduce benchmarks/llm-agentx to replay semianalysisai/cc-traces-weka- with-subagents-052726-256k against OpenAI-compatible vLLM servers. The client synthesizes o200k_base-sized prompts from trace in/out metadata, records TTFT and wall time, and skips requests that exceed the served max_model_len. Includes Makefile orchestration, CI smoke workflows, and repo README/.gitignore updates for data/cc-traces.
