### PR TITLE
Add aic-drivenets recipe and kv-cache-tester benchmark.

### DIFF
--- a/.github/workflows/aic-drivenets-config.yml
+++ b/.github/workflows/aic-drivenets-config.yml
@@ -1,0 +1,40 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+name: aic-drivenets Config
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'recipies/aic-drivenets/configs/**'
+      - 'recipies/aic-drivenets/scripts/**'
+      - '.github/workflows/aic-drivenets-config.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: YAML and recipe scripts
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install tools
+        run: |
+          set -euo pipefail
+          pip install yamllint
+
+      - name: yamllint aic-drivenets configs
+        run: |
+          set -euo pipefail
+          yamllint -c .yamllint recipies/aic-drivenets/configs/
+
+      - name: py_compile recipe scripts
+        run: |
+          set -euo pipefail
+          python3 -m py_compile recipies/aic-drivenets/scripts/*.py

--- a/.github/workflows/kv-cache-tester-shell.yml
+++ b/.github/workflows/kv-cache-tester-shell.yml
@@ -1,0 +1,52 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+name: kv-cache-tester Shell
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'benchmarks/kv-cache-tester/**'
+      - '.github/workflows/kv-cache-tester-shell.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: YAML, scripts, and unit tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: benchmarks/kv-cache-tester
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install tools
+        run: |
+          set -euo pipefail
+          pip install yamllint pyyaml
+          pip install -r requirements.txt
+
+      - name: yamllint configs
+        run: |
+          set -euo pipefail
+          yamllint -c ../../.yamllint configs/
+
+      - name: py_compile scripts
+        run: |
+          set -euo pipefail
+          python3 -m py_compile scripts/*.py
+
+      - name: unit tests
+        run: |
+          set -euo pipefail
+          make test

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,12 @@ recipies/vllm-lmcache-hipfile/data/
 recipies/vllm-lmcache-nixl/data/
 recipies/vllm-lmcache-nixl/logs/
 recipies/vllm-atom-andy/logs/
+recipies/aic-drivenets/logs/
+
+# kv-cache-tester benchmark (upstream clone + logs)
+data/kv-cache-tester/
+benchmarks/kv-cache-tester/logs/
+benchmarks/kv-cache-tester/.venv/
 
 # benchmark logs and reports
 benchmarks/ttft-lmcache/logs/

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -357,3 +357,8 @@ agentx
 semianalysisai
 subagents
 Ctrl
+DriveNets
+Strix
+argv
+dGPU
+drivenets

--- a/README.md
+++ b/README.md
@@ -37,10 +37,12 @@ need only `openai` unless you use the full tool stack.
 | TTFT benchmark (llama.cpp) | [benchmarks/ttft-llamacpp][b-lcp] | [README][r-lcp] |
 | LLM prefill benchmark (Gutenberg) | [benchmarks/llm-prefill-benchmark][b-lpb] | [README][r-lpb] |
 | LLM Agent-X benchmark (CC trace replay) | [benchmarks/llm-agentx][b-lax] | [README][r-lax] |
+| kv-cache-tester benchmark (trace replay) | [benchmarks/kv-cache-tester][b-kct] | [README][r-kct] |
 | vLLM + LMCache hipfile recipe | [recipies/vllm-lmcache-hipfile][r-vr] | [README][r-vr] |
 | Grafana dashboards | [grafana/][grafana-dir] | [README][grafana-readme] |
 | vLLM + LMCache NIXL recipe | [recipies/vllm-lmcache-nixl][r-vn] | [README][r-vn] |
 | vLLM + ATOM + LMCache (Andy blog) | [recipies/vllm-atom-andy][r-vaa] | [README][r-vaa] |
+| vLLM + LMCache gfx950 (DriveNets) | [recipies/aic-drivenets][r-ade] | [README][r-ade] |
 | LMCache patch index | [recipies/vllm-lmcache-hipfile/patches][r-patches] | [README][r-patches] |
 | ROCm inference stack image | [recipies/rocm-inference-stack][r-ris] | [README][r-ris] |
 | LMCache IO simulator | [tools/lmcache-io-tester][t-lit] | [README][t-lit-readme] |
@@ -63,6 +65,7 @@ NVMe, hipFile/AIS, NFS).
 | [ttft-llamacpp][b-lcp] | llama.cpp | Instinct + Radeon | [README][r-lcp] |
 | [llm-prefill-benchmark][b-lpb] | vLLM (OpenAI API) | Engine-agnostic | [README][r-lpb] |
 | [llm-agentx][b-lax] | Text LLM (OpenAI API) | Engine-agnostic | [README][r-lax] |
+| [kv-cache-tester][b-kct] | vLLM (OpenAI API) | Engine-agnostic | [README][r-kct] |
 
 The llama.cpp benchmark includes a `--cache-disk` patch for automatic
 disk-tier prompt caching (see [patches/0001-cache-disk.patch][patch]).
@@ -91,7 +94,7 @@ discovery. From `ansible/`, run `ansible-playbook site.yml` (or
 
 GitHub Actions under [`.github/workflows/`][gh-workflows] include spellcheck,
 lint, benchmark-adjacent recipes (`vllm-lmcache-hipfile-*`, `vllm-lmcache-nixl-*`,
-`llm-prefill-benchmark-*`, `lmcache-io-tester`), and
+`aic-drivenets-*`, `kv-cache-tester-*`, `llm-prefill-benchmark-*`, `lmcache-io-tester`), and
 `test-amdgpu-dkms`.
 
 ## LLM Deployment Infrastructure
@@ -157,16 +160,19 @@ rocm-aic/
 [b-lcp]: benchmarks/ttft-llamacpp/
 [b-lpb]: benchmarks/llm-prefill-benchmark/
 [b-lax]: benchmarks/llm-agentx/
+[b-kct]: benchmarks/kv-cache-tester/
 [r-lmc]: benchmarks/ttft-lmcache/README.md
 [r-lcp]: benchmarks/ttft-llamacpp/README.md
 [r-lpb]: benchmarks/llm-prefill-benchmark/README.md
 [r-lax]: benchmarks/llm-agentx/README.md
+[r-kct]: benchmarks/kv-cache-tester/README.md
 [patch]: benchmarks/ttft-llamacpp/patches/0001-cache-disk.patch
 [r-vr]: recipies/vllm-lmcache-hipfile/
 [grafana-dir]: grafana/
 [grafana-readme]: grafana/README.md
 [r-vn]: recipies/vllm-lmcache-nixl/
 [r-vaa]: recipies/vllm-atom-andy/
+[r-ade]: recipies/aic-drivenets/
 [r-patches]: recipies/vllm-lmcache-hipfile/patches/README.md
 [r-ris]: recipies/rocm-inference-stack/README.md
 [t-lit]: tools/lmcache-io-tester/

--- a/ansible/playbooks/kv-cache-tester.yml
+++ b/ansible/playbooks/kv-cache-tester.yml
@@ -3,7 +3,8 @@
 # SPDX-License-Identifier: MIT
 #
 # Install kv-cache-tester on hosts in group kv_cache_tester and run a probe
-# against kv_cache_tester_api_endpoint (OpenAI-compatible HTTP API). Upstream:
+# against kv_cache_tester_api_endpoint (OpenAI-compatible HTTP API). Default:
+# benchmarks/kv-cache-tester wrapper (trace-replay-blog.yaml). Upstream:
 # https://github.com/callanjfox/kv-cache-tester
 #
 # Run from ansible/:

--- a/ansible/roles/kv_cache_tester/defaults/main.yml
+++ b/ansible/roles/kv_cache_tester/defaults/main.yml
@@ -7,6 +7,11 @@
 kv_cache_tester_repo_url: https://github.com/callanjfox/kv-cache-tester.git
 kv_cache_tester_repo_ref: master
 
+# Prefer benchmarks/kv-cache-tester wrapper (make install data run).
+kv_cache_tester_use_benchmark_wrapper: true
+kv_cache_tester_benchmark_dir: "{{ role_path }}/../../../benchmarks/kv-cache-tester"
+kv_cache_tester_benchmark_config: configs/trace-replay-blog.yaml
+
 kv_cache_tester_install_basename: kv-cache-tester
 # Leave empty to install under {{ ansible_user_dir }}/kv_cache_tester_install_basename.
 kv_cache_tester_install_dir: ""

--- a/ansible/roles/kv_cache_tester/tasks/main.yml
+++ b/ansible/roles/kv_cache_tester/tasks/main.yml
@@ -27,72 +27,122 @@
       group_vars or with -e when kv_cache_tester_run is true.
   when: kv_cache_tester_run | bool
 
-- name: Install git and Python venv support (Debian / Ubuntu)
-  ansible.builtin.apt:
-    name:
-      - git
-      - python3
-      - python3-pip
-      - python3-venv
-    state: present
-    update_cache: true
-  become: true
-  when: ansible_facts.os_family == 'Debian'
-
-- name: Clone or update kv-cache-tester
-  ansible.builtin.git:
-    repo: "{{ kv_cache_tester_repo_url }}"
-    dest: "{{ kv_cache_tester_install_dir }}"
-    version: "{{ kv_cache_tester_repo_ref }}"
-    update: true
-
-- name: Create Python virtualenv for kv-cache-tester
-  ansible.builtin.command:
-    argv:
-      - python3
-      - "-m"
-      - venv
-      - "{{ kv_cache_tester_venv }}"
-    creates: "{{ kv_cache_tester_venv }}/bin/python"
-
-- name: Install Python requirements into venv
-  ansible.builtin.pip:
-    requirements: "{{ kv_cache_tester_install_dir }}/requirements.txt"
-    virtualenv: "{{ kv_cache_tester_venv }}"
-    virtualenv_command: python3 -m venv
-
-- name: Record installed revision
-  ansible.builtin.command:
-    argv:
-      - git
-      - rev-parse
-      - HEAD
-    chdir: "{{ kv_cache_tester_install_dir }}"
-  register: kv_cache_tester_git_head
-  changed_when: false
-
-- name: Show kv-cache-tester checkout
-  ansible.builtin.debug:
-    msg: "kv-cache-tester @ {{ kv_cache_tester_git_head.stdout }}"
-
-- name: Ensure output directory exists
-  ansible.builtin.file:
-    path: "{{ kv_cache_tester_output_dir }}"
-    state: directory
-    mode: "0755"
-  when: kv_cache_tester_run | bool
-
-- name: Run kv-cache-tester against API endpoint
-  when: kv_cache_tester_run | bool
-  ansible.builtin.command:
-    argv: "{{ [kv_cache_tester_venv ~ '/bin/python', kv_cache_tester_install_dir ~ '/' ~ kv_cache_tester_script, '--api-endpoint', kv_cache_tester_api_endpoint, '--output-dir', kv_cache_tester_output_dir] + (kv_cache_tester_extra_args | default([])) }}"
-    chdir: "{{ kv_cache_tester_install_dir }}"
-  register: kv_cache_tester_run_result
-  changed_when: true
-
-- name: Print last lines of kv-cache-tester output
-  ansible.builtin.debug:
-    msg: "{{ kv_cache_tester_run_result.stdout_lines | default([]) | tail(40) }}"
+- name: Run via benchmarks/kv-cache-tester wrapper
   when:
     - kv_cache_tester_run | bool
-    - kv_cache_tester_run_result.stdout_lines is defined
+    - kv_cache_tester_use_benchmark_wrapper | bool
+  block:
+    - name: Install git and Python venv support (Debian / Ubuntu)
+      ansible.builtin.apt:
+        name:
+          - git
+          - python3
+          - python3-pip
+          - python3-venv
+        state: present
+        update_cache: true
+      become: true
+      when: ansible_facts.os_family == 'Debian'
+
+    - name: Install benchmark wrapper dependencies and upstream clone
+      ansible.builtin.command:
+        argv:
+          - make
+          - -C
+          - "{{ kv_cache_tester_benchmark_dir }}"
+          - install
+          - data
+      environment:
+        BASE_URL: "{{ kv_cache_tester_api_endpoint }}"
+        KV_CACHE_TESTER_CONFIG: "{{ kv_cache_tester_benchmark_config }}"
+      changed_when: true
+
+    - name: Run kv-cache-tester profile through benchmark wrapper
+      ansible.builtin.command:
+        argv:
+          - make
+          - -C
+          - "{{ kv_cache_tester_benchmark_dir }}"
+          - run
+      environment:
+        BASE_URL: "{{ kv_cache_tester_api_endpoint }}"
+        KV_CACHE_TESTER_CONFIG: "{{ kv_cache_tester_benchmark_config }}"
+      register: kv_cache_tester_benchmark_run
+      changed_when: true
+
+    - name: Print last lines of benchmark wrapper output
+      ansible.builtin.debug:
+        msg: "{{ kv_cache_tester_benchmark_run.stdout_lines | default([]) | tail(40) }}"
+      when: kv_cache_tester_benchmark_run.stdout_lines is defined
+
+- name: Legacy direct kv-cache-tester install and run
+  when:
+    - kv_cache_tester_run | bool
+    - not (kv_cache_tester_use_benchmark_wrapper | bool)
+  block:
+    - name: Install git and Python venv support (Debian / Ubuntu)
+      ansible.builtin.apt:
+        name:
+          - git
+          - python3
+          - python3-pip
+          - python3-venv
+        state: present
+        update_cache: true
+      become: true
+      when: ansible_facts.os_family == 'Debian'
+
+    - name: Clone or update kv-cache-tester
+      ansible.builtin.git:
+        repo: "{{ kv_cache_tester_repo_url }}"
+        dest: "{{ kv_cache_tester_install_dir }}"
+        version: "{{ kv_cache_tester_repo_ref }}"
+        update: true
+
+    - name: Create Python virtualenv for kv-cache-tester
+      ansible.builtin.command:
+        argv:
+          - python3
+          - "-m"
+          - venv
+          - "{{ kv_cache_tester_venv }}"
+      args:
+        creates: "{{ kv_cache_tester_venv }}/bin/python"
+
+    - name: Install Python requirements into venv
+      ansible.builtin.pip:
+        requirements: "{{ kv_cache_tester_install_dir }}/requirements.txt"
+        virtualenv: "{{ kv_cache_tester_venv }}"
+        virtualenv_command: python3 -m venv
+
+    - name: Record installed revision
+      ansible.builtin.command:
+        argv:
+          - git
+          - rev-parse
+          - HEAD
+        chdir: "{{ kv_cache_tester_install_dir }}"
+      register: kv_cache_tester_git_head
+      changed_when: false
+
+    - name: Show kv-cache-tester checkout
+      ansible.builtin.debug:
+        msg: "kv-cache-tester @ {{ kv_cache_tester_git_head.stdout }}"
+
+    - name: Ensure output directory exists
+      ansible.builtin.file:
+        path: "{{ kv_cache_tester_output_dir }}"
+        state: directory
+        mode: "0755"
+
+    - name: Run kv-cache-tester against API endpoint
+      ansible.builtin.command:
+        argv: "{{ [kv_cache_tester_venv ~ '/bin/python', kv_cache_tester_install_dir ~ '/' ~ kv_cache_tester_script, '--api-endpoint', kv_cache_tester_api_endpoint, '--output-dir', kv_cache_tester_output_dir] + (kv_cache_tester_extra_args | default([])) }}"
+        chdir: "{{ kv_cache_tester_install_dir }}"
+      register: kv_cache_tester_run_result
+      changed_when: true
+
+    - name: Print last lines of kv-cache-tester output
+      ansible.builtin.debug:
+        msg: "{{ kv_cache_tester_run_result.stdout_lines | default([]) | tail(40) }}"
+      when: kv_cache_tester_run_result.stdout_lines is defined

--- a/benchmarks/kv-cache-tester/Makefile
+++ b/benchmarks/kv-cache-tester/Makefile
@@ -1,0 +1,70 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+
+REPO_ROOT := $(abspath $(CURDIR)/../..)
+BENCH_ROOT := $(CURDIR)
+VENV_PYTHON := $(REPO_ROOT)/.venv/bin/python3
+ifeq ($(wildcard $(VENV_PYTHON)),)
+PYTHON ?= python3
+else
+PYTHON ?= $(VENV_PYTHON)
+endif
+
+KV_CACHE_TESTER_ROOT ?= $(REPO_ROOT)/data/kv-cache-tester
+KV_CACHE_TESTER_CONFIG ?= $(BENCH_ROOT)/configs/trace-replay-blog.yaml
+KV_CACHE_TESTER_SMOKE_CONFIG ?= $(BENCH_ROOT)/configs/smoke-single-prompt.yaml
+BASE_URL ?= http://127.0.0.1:8000
+
+.PHONY: help install data check-server run run-smoke test
+
+.DEFAULT_GOAL := help
+
+help:
+	@echo "kv-cache-tester — trace replay stimulus (OpenAI API)"
+	@echo ""
+	@echo "  make install        wrapper venv + clone upstream kv-cache-tester"
+	@echo "  make data           ensure upstream checkout and traces/ submodule"
+	@echo "  make check-server   probe BASE_URL/v1/models"
+	@echo "  make run            trace_replay_tester.py (blog profile)"
+	@echo "  make run-smoke      single_prompt_tester.py (quick validation)"
+	@echo "  make test           unit tests (argv builder)"
+	@echo ""
+	@echo "Env: BASE_URL (default $(BASE_URL))"
+	@echo "     KV_CACHE_TESTER_ROOT (default $(KV_CACHE_TESTER_ROOT))"
+	@echo "     KV_CACHE_TESTER_CONFIG (default trace-replay-blog.yaml)"
+
+install: data
+	@$(PYTHON) -m pip install -r "$(BENCH_ROOT)/requirements.txt"
+	@set -e; \
+	upstream_venv="$(KV_CACHE_TESTER_ROOT)/.venv"; \
+	if [ ! -x "$$upstream_venv/bin/python" ]; then \
+		$(PYTHON) -m venv "$$upstream_venv"; \
+	fi; \
+	"$$upstream_venv/bin/pip" install -r "$(KV_CACHE_TESTER_ROOT)/requirements.txt"
+
+data:
+	@$(PYTHON) "$(BENCH_ROOT)/scripts/install-upstream.py" \
+		--config "$(KV_CACHE_TESTER_CONFIG)" \
+		--dest "$(KV_CACHE_TESTER_ROOT)"
+
+check-server:
+	@$(PYTHON) "$(BENCH_ROOT)/scripts/check-server.py" --url "$(BASE_URL)"
+
+run: install check-server
+	@$(PYTHON) "$(BENCH_ROOT)/scripts/run-profile.py" \
+		--config "$(KV_CACHE_TESTER_CONFIG)" \
+		--upstream-root "$(KV_CACHE_TESTER_ROOT)" \
+		--api-endpoint "$(BASE_URL)" \
+		--bench-root "$(BENCH_ROOT)"
+
+run-smoke: install check-server
+	@$(PYTHON) "$(BENCH_ROOT)/scripts/run-profile.py" \
+		--config "$(KV_CACHE_TESTER_SMOKE_CONFIG)" \
+		--upstream-root "$(KV_CACHE_TESTER_ROOT)" \
+		--api-endpoint "$(BASE_URL)" \
+		--bench-root "$(BENCH_ROOT)"
+
+test:
+	@$(PYTHON) -m unittest discover -s "$(BENCH_ROOT)/tests" -p 'test_*.py'

--- a/benchmarks/kv-cache-tester/README.md
+++ b/benchmarks/kv-cache-tester/README.md
@@ -1,0 +1,81 @@
+<!--
+Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+SPDX-License-Identifier: MIT
+-->
+
+# kv-cache-tester benchmark (trace replay)
+
+Engine-agnostic workload using upstream
+**[callanjfox/kv-cache-tester][kv-cache-tester]** to replay Claude Code traces
+against any OpenAI-compatible vLLM server. Same harness as the
+[LMCache MI300X blog][atom-blog].
+
+Part of [rocm-aic](../../README.md). Used with
+[recipies/aic-drivenets](../../recipies/aic-drivenets/) and
+[recipies/vllm-atom-andy](../../recipies/vllm-atom-andy/).
+
+## Compared to other benchmarks
+
+| Benchmark | Focus |
+|-----------|-------|
+| [llm-prefill-benchmark](../llm-prefill-benchmark) | Gutenberg long-context prefill |
+| [llm-agentx](../llm-agentx) | SemiAnalysis CC agent traces (HF dataset) |
+| **kv-cache-tester** | Upstream 739-trace replay (MI300X blog profile) |
+| [ttft-lmcache](../ttft-lmcache) | Controlled KV hit-rate sweep |
+
+## Prerequisites
+
+- Host: `python3`, `git`
+- Running vLLM server: `curl -sS http://127.0.0.1:8000/v1/models`
+- ~1 GB disk for upstream clone + traces (under `data/kv-cache-tester/`)
+
+## Quick start
+
+```bash
+make -C recipies/aic-drivenets run-batch    # or any vLLM recipe on :8000
+make -C benchmarks/kv-cache-tester install data check-server
+make -C benchmarks/kv-cache-tester run
+```
+
+Smoke test (single prompt, shorter):
+
+```bash
+make -C benchmarks/kv-cache-tester run-smoke BASE_URL=http://127.0.0.1:8000
+```
+
+## Environment
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `BASE_URL` | `http://127.0.0.1:8000` | OpenAI API root (no `/v1` suffix) |
+| `KV_CACHE_TESTER_ROOT` | `../../data/kv-cache-tester` | Upstream git clone |
+| `KV_CACHE_TESTER_CONFIG` | `configs/trace-replay-blog.yaml` | Profile to run |
+| `KV_CACHE_TESTER_SMOKE_CONFIG` | `configs/smoke-single-prompt.yaml` | Smoke profile |
+
+## Profiles
+
+| Config | Script | Use |
+|--------|--------|-----|
+| `trace-replay-blog.yaml` | `trace_replay_tester.py` | Blog stress (4→32 users, 1200s, 100K context) |
+| `smoke-single-prompt.yaml` | `single_prompt_tester.py` | Quick connectivity check |
+
+## Layout
+
+| Path | Role |
+|------|------|
+| `scripts/install-upstream.py` | `git clone --recursive` at pinned ref |
+| `scripts/build_argv.py` | YAML profile → CLI argv |
+| `scripts/run-profile.py` | Execute upstream script |
+| `scripts/check-server.py` | Probe `/v1/models` |
+| `configs/trace-replay-blog.yaml` | MI300X blog defaults |
+| `tests/test_build_argv.py` | CI unit test |
+
+## Ansible
+
+Cluster hosts can use the same wrapper via
+[`ansible/roles/kv_cache_tester`](../../ansible/roles/kv_cache_tester) with
+**`kv_cache_tester_use_benchmark_wrapper: true`** (default).
+
+<!-- References -->
+[kv-cache-tester]: https://github.com/callanjfox/kv-cache-tester
+[atom-blog]: https://andyluo7.github.io/llm/amd/mi300x/vllm/lmcache/performance/2026/05/22/atom-lmcache-kv-cache-offload-mi300x/

--- a/benchmarks/kv-cache-tester/configs/smoke-single-prompt.yaml
+++ b/benchmarks/kv-cache-tester/configs/smoke-single-prompt.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Quick smoke profile (single_prompt_tester.py).
+
+script: single_prompt_tester.py
+output_dir: logs/smoke-latest
+args:
+  min_tokens: 1000
+  max_tokens: 8192
+upstream:
+  repo: https://github.com/callanjfox/kv-cache-tester.git
+  ref: master

--- a/benchmarks/kv-cache-tester/configs/trace-replay-blog.yaml
+++ b/benchmarks/kv-cache-tester/configs/trace-replay-blog.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# MI300X blog stress profile (Andy Luo ATOM + LMCache, trace_replay_tester.py).
+
+script: trace_replay_tester.py
+output_dir: logs/trace-replay-latest
+args:
+  trace_directory: traces
+  start_users: 4
+  max_users: 32
+  max_ttft: 60.0
+  test_duration: 1200
+  max_context: 100000
+  warm_prefix_pct: 0.5
+  timing_strategy: think-only
+  recycle: true
+  seed: 42
+upstream:
+  repo: https://github.com/callanjfox/kv-cache-tester.git
+  ref: master

--- a/benchmarks/kv-cache-tester/requirements.txt
+++ b/benchmarks/kv-cache-tester/requirements.txt
@@ -1,0 +1,7 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Host deps for benchmarks/kv-cache-tester wrapper (upstream has its own venv).
+
+pyyaml>=6.0

--- a/benchmarks/kv-cache-tester/scripts/build_argv.py
+++ b/benchmarks/kv-cache-tester/scripts/build_argv.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+"""Build kv-cache-tester CLI argv from a YAML profile."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError as exc:
+    print("ERROR: PyYAML required (pip install pyyaml)", file=sys.stderr)
+    raise SystemExit(1) from exc
+
+
+def _flag_name(key: str) -> str:
+    return key.replace("_", "-")
+
+
+def build_argv(
+    profile: dict[str, Any],
+    *,
+    api_endpoint: str,
+    upstream_root: Path,
+    output_dir: Path,
+) -> list[str]:
+    script = profile.get("script")
+    if not isinstance(script, str) or not script.strip():
+        raise ValueError("profile must define script")
+
+    args_cfg = profile.get("args")
+    if not isinstance(args_cfg, dict):
+        args_cfg = {}
+
+    argv = [
+        str(upstream_root / script.strip()),
+        "--api-endpoint",
+        api_endpoint,
+        "--output-dir",
+        str(output_dir),
+    ]
+
+    for key, value in args_cfg.items():
+        flag = f"--{_flag_name(str(key))}"
+        if isinstance(value, bool):
+            if value:
+                argv.append(flag)
+            continue
+        argv.extend([flag, str(value)])
+
+    return argv
+
+
+def load_profile(path: Path) -> dict[str, Any]:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"{path}: expected mapping at top level")
+    return data
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--upstream-root", type=Path, required=True)
+    parser.add_argument("--api-endpoint", required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument(
+        "--print-json",
+        action="store_true",
+        help="emit JSON array instead of shell-escaped argv",
+    )
+    args = parser.parse_args()
+
+    profile = load_profile(args.config)
+    argv = build_argv(
+        profile,
+        api_endpoint=args.api_endpoint,
+        upstream_root=args.upstream_root,
+        output_dir=args.output_dir,
+    )
+
+    if args.print_json:
+        print(json.dumps(argv))
+    else:
+        for part in argv:
+            print(part)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/kv-cache-tester/scripts/check-server.py
+++ b/benchmarks/kv-cache-tester/scripts/check-server.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+"""Probe an OpenAI-compatible vLLM HTTP endpoint."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--url",
+        default="http://127.0.0.1:8000",
+        help="API root without /v1 suffix",
+    )
+    args = parser.parse_args()
+
+    base = args.url.rstrip("/")
+    req_url = f"{base}/v1/models"
+    try:
+        with urllib.request.urlopen(req_url, timeout=15) as resp:
+            body = resp.read().decode("utf-8", errors="replace")
+    except urllib.error.URLError as exc:
+        print(f"ERROR: cannot reach {req_url}: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError:
+        print(f"ERROR: non-JSON response from {req_url}", file=sys.stderr)
+        return 1
+
+    if not isinstance(payload, dict) or "data" not in payload:
+        print(f"ERROR: unexpected payload from {req_url}", file=sys.stderr)
+        return 1
+
+    print(f"OK: {req_url} ({len(payload.get('data', []))} model(s))")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/kv-cache-tester/scripts/install-upstream.py
+++ b/benchmarks/kv-cache-tester/scripts/install-upstream.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+"""Clone upstream kv-cache-tester (with traces submodule)."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError as exc:
+    print("ERROR: PyYAML required", file=sys.stderr)
+    raise SystemExit(1) from exc
+
+
+def _run(cmd: list[str], *, cwd: Path | None = None) -> None:
+    print("+", " ".join(cmd), flush=True)
+    subprocess.run(cmd, cwd=cwd, check=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--dest", type=Path, required=True)
+    args = parser.parse_args()
+
+    profile = yaml.safe_load(args.config.read_text(encoding="utf-8"))
+    if not isinstance(profile, dict):
+        print("ERROR: invalid config", file=sys.stderr)
+        return 1
+
+    upstream = profile.get("upstream")
+    if not isinstance(upstream, dict):
+        print("ERROR: config missing upstream mapping", file=sys.stderr)
+        return 1
+
+    repo = str(upstream.get("repo", "")).strip()
+    ref = str(upstream.get("ref", "master")).strip()
+    if not repo:
+        print("ERROR: upstream.repo required", file=sys.stderr)
+        return 1
+
+    dest = args.dest.resolve()
+    dest.parent.mkdir(parents=True, exist_ok=True)
+
+    if (dest / ".git").is_dir():
+        _run(["git", "-C", str(dest), "fetch", "origin", ref])
+        _run(["git", "-C", str(dest), "checkout", ref])
+        _run(["git", "-C", str(dest), "pull", "--ff-only", "origin", ref])
+        _run(["git", "-C", str(dest), "submodule", "update", "--init", "--recursive"])
+    else:
+        _run(
+            [
+                "git",
+                "clone",
+                "--recursive",
+                "--branch",
+                ref,
+                repo,
+                str(dest),
+            ]
+        )
+
+    traces = dest / "traces"
+    if not traces.is_dir():
+        print(f"ERROR: missing traces/ under {dest} (recursive clone failed?)", file=sys.stderr)
+        return 1
+
+    print(f"OK: kv-cache-tester at {dest}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/kv-cache-tester/scripts/run-profile.py
+++ b/benchmarks/kv-cache-tester/scripts/run-profile.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+"""Run a kv-cache-tester profile against a live vLLM endpoint."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+from build_argv import build_argv, load_profile
+
+
+def _upstream_python(upstream_root: Path) -> str:
+    venv_py = upstream_root / ".venv" / "bin" / "python"
+    if venv_py.is_file():
+        return str(venv_py)
+    return sys.executable
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--upstream-root", type=Path, required=True)
+    parser.add_argument("--api-endpoint", required=True)
+    parser.add_argument("--bench-root", type=Path, required=True)
+    args = parser.parse_args()
+
+    profile = load_profile(args.config)
+    output_rel = profile.get("output_dir", "logs/run-latest")
+    if not isinstance(output_rel, str):
+        output_rel = "logs/run-latest"
+    output_dir = (args.bench_root / output_rel).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    argv = build_argv(
+        profile,
+        api_endpoint=args.api_endpoint,
+        upstream_root=args.upstream_root,
+        output_dir=output_dir,
+    )
+
+    python = _upstream_python(args.upstream_root)
+    cmd = [python, *argv]
+    print("+", " ".join(cmd), flush=True)
+    proc = subprocess.run(cmd, cwd=args.upstream_root)
+    return int(proc.returncode)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/kv-cache-tester/tests/test_build_argv.py
+++ b/benchmarks/kv-cache-tester/tests/test_build_argv.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from build_argv import build_argv, load_profile  # noqa: E402
+
+
+class BuildArgvTests(unittest.TestCase):
+    def test_trace_replay_blog_profile(self) -> None:
+        cfg = Path(__file__).resolve().parent.parent / "configs" / "trace-replay-blog.yaml"
+        profile = load_profile(cfg)
+        argv = build_argv(
+            profile,
+            api_endpoint="http://127.0.0.1:8000",
+            upstream_root=Path("/tmp/kv-cache-tester"),
+            output_dir=Path("/tmp/out"),
+        )
+        self.assertEqual(argv[0], "/tmp/kv-cache-tester/trace_replay_tester.py")
+        self.assertIn("--api-endpoint", argv)
+        self.assertIn("http://127.0.0.1:8000", argv)
+        self.assertIn("--trace-directory", argv)
+        self.assertIn("traces", argv)
+        self.assertIn("--recycle", argv)
+        self.assertIn("--seed", argv)
+        self.assertIn("42", argv)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/recipies/aic-drivenets/Dockerfile
+++ b/recipies/aic-drivenets/Dockerfile
@@ -1,0 +1,73 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+
+# gfx950 dGPU vLLM + LMCache (DriveNets / rocm/vllm 7.13).
+ARG VLLM_BASE_TAG=rocm7.13.0_gfx950-dcgpu_ubuntu24.04_py3.13_pytorch_2.10.0_vllm_0.19.1
+FROM rocm/vllm:${VLLM_BASE_TAG}
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+ARG ROCM_ARCH
+RUN test -n "$ROCM_ARCH" || (echo "ERROR: ROCM_ARCH is not set" && exit 1)
+
+ARG LMCACHE_SHA=92fe433ac8e21baf33d9a1b5dda835e1e56c53dd
+ARG LMCACHE_CACHE_SALT_PATCH=lmcache-pr-3008-cache-salt.patch
+
+RUN apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates \
+        cmake \
+        git \
+        libboost-all-dev \
+        libmount-dev \
+        ninja-build \
+        pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY recipies/vllm-lmcache-hipfile/patches/lmcache-pr-3008-cache-salt.patch \
+    recipies/aic-drivenets/requirements-lmcache-runtime.txt \
+    /app/patches/
+
+RUN cd /app && \
+    git clone https://github.com/riley-dixon/LMCache.git && \
+    cd LMCache && \
+    git checkout "${LMCACHE_SHA}" && \
+    git apply "/app/patches/${LMCACHE_CACHE_SALT_PATCH}" && \
+    PYTORCH_ROCM_ARCH=${ROCM_ARCH} \
+        TORCH_DONT_CHECK_COMPILER_ABI=1 \
+        CXX=hipcc \
+        BUILD_WITH_HIP=1 \
+        python3 -m pip install --no-build-isolation --no-cache-dir -e . --no-deps && \
+    python3 -m pip install --no-cache-dir -r /app/patches/requirements-lmcache-runtime.txt && \
+    python3 -m pip uninstall -y \
+        nixl nixl-cu12 nixl-cu13 cupy-cuda12x cufile-python cuda-pathfinder \
+        2>/dev/null || true
+
+RUN python3 <<'PY'
+from pathlib import Path
+
+p = Path("/app/LMCache/benchmarks/long_doc_qa/long_doc_qa.py")
+if p.is_file():
+    text = p.read_text(encoding="utf-8")
+    needle = "before averaging. Example: 0.1 drops bottom 10% and top 10%."
+    if needle in text:
+        p.write_text(text.replace(needle, needle.replace("%", "%%"), 1), encoding="utf-8")
+PY
+
+RUN mkdir -p /app/configs /app/scripts
+
+COPY recipies/aic-drivenets/scripts/ /app/scripts/
+COPY recipies/aic-drivenets/configs/ /app/configs/
+
+RUN python3 /app/scripts/verify-lmcache-hip.py
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONHASHSEED=0 \
+    VLLM_FLOAT32_MATMUL_PRECISION=high \
+    LD_LIBRARY_PATH=/opt/rocm/lib \
+    PATH=/opt/rocm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+ENTRYPOINT ["python3", "/app/scripts/vllm-server"]

--- a/recipies/aic-drivenets/Dockerfile
+++ b/recipies/aic-drivenets/Dockerfile
@@ -42,9 +42,9 @@ RUN cd /app && \
         BUILD_WITH_HIP=1 \
         python3 -m pip install --no-build-isolation --no-cache-dir -e . --no-deps && \
     python3 -m pip install --no-cache-dir -r /app/patches/requirements-lmcache-runtime.txt && \
-    python3 -m pip uninstall -y \
+    (python3 -m pip uninstall -y \
         nixl nixl-cu12 nixl-cu13 cupy-cuda12x cufile-python cuda-pathfinder \
-        2>/dev/null || true
+        2>/dev/null || true)
 
 RUN python3 <<'PY'
 from pathlib import Path

--- a/recipies/aic-drivenets/Makefile
+++ b/recipies/aic-drivenets/Makefile
@@ -1,0 +1,160 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+
+REPO_ROOT := $(abspath $(CURDIR)/../..)
+IMAGE_NAME ?= aic-drivenets
+GPU ?= 0
+CONTAINER_NAME ?= $(IMAGE_NAME)-gpu$(GPU)
+DATA ?= /data
+LOG ?= $(CURDIR)/logs
+HF_HOME ?= $(HOME)/.cache/huggingface
+HF_TOKEN_FILE ?=
+CONTAINER_HF_HOME ?= /hf
+CONTAINER_DATA_DIR ?= /data
+CONTAINER_LOG_DIR ?= /var/log/aic-drivenets
+TZ ?= America/Edmonton
+ADE_LMCACHE_TIER ?= cpu-nvme
+ADE_LMCACHE_LOG_LEVEL ?=
+ADE_TENSOR_PARALLEL_SIZE ?=
+ADE_GPU_MEMORY_UTILIZATION ?=
+ADE_MAX_MODEL_LEN ?=
+ADE_MAX_NUM_BATCHED_TOKENS ?=
+ADE_LMCACHE_MAX_LOCAL_CPU_SIZE ?=
+ADE_LMCACHE_MAX_LOCAL_DISK_SIZE ?=
+VLLM_SERVER_DEV_MODE ?= 1
+VLLM_MODEL ?=
+ARGS ?=
+EXTRA_DOCKER_RUN_FLAGS ?=
+DOCKER_RUN_ATTACH ?= -it
+
+VLLM_BASE_TAG ?= rocm7.13.0_gfx950-dcgpu_ubuntu24.04_py3.13_pytorch_2.10.0_vllm_0.19.1
+
+_ROCM_ARCH_DETECTED := $(shell rocm_agent_enumerator 2>/dev/null | \
+	grep -E '^gfx' | head -1)
+ROCM_ARCH := $(if $(strip $(ROCM_ARCH)),$(strip $(ROCM_ARCH)),$(_ROCM_ARCH_DETECTED))
+ifeq ($(strip $(ROCM_ARCH)),)
+ROCM_ARCH := gfx950
+endif
+
+BUILD_ARGS := --build-arg ROCM_ARCH=$(ROCM_ARCH) --build-arg VLLM_BASE_TAG=$(VLLM_BASE_TAG)
+ifneq ($(strip $(LMCACHE_SHA)),)
+BUILD_ARGS += --build-arg LMCACHE_SHA=$(LMCACHE_SHA)
+endif
+
+.PHONY: help build aic-drivenets run run-batch verify
+
+.DEFAULT_GOAL := help
+
+help:
+	@echo "aic-drivenets Makefile (gfx950 vLLM + LMCache, DriveNets run flags)"
+	@echo ""
+	@echo "  make build         docker build -t $(IMAGE_NAME)"
+	@echo "                      base: rocm/vllm:$(VLLM_BASE_TAG)"
+	@echo "  make verify        confirm LMCache HIP c_ops backend (.so)"
+	@echo "  make run            docker run -it ... bind-mounts configs/ + scripts/"
+	@echo "                      + LOG (server.txt); DATA = LMCache NVMe tier"
+	@echo "                      default CONTAINER_NAME=$(CONTAINER_NAME)"
+	@echo "  make run-batch      docker run -d (non-interactive)"
+	@echo ""
+	@echo "ADE_LMCACHE_TIER: hbm | cpu | cpu-nvme (default)"
+	@echo "  hbm       HBM-only (no LMCache connector)"
+	@echo "  cpu       HBM L1 + CPU DRAM L2"
+	@echo "  cpu-nvme  HBM L1 + CPU L2 + NVMe L3 (needs DATA mount)"
+	@echo ""
+	@echo "Benchmark stimulus: make -C benchmarks/kv-cache-tester install run"
+	@echo ""
+	@echo "make run: requires HF_TOKEN or HF_TOKEN_FILE. See README."
+	@echo ""
+
+run:
+	@$(MAKE) -f "$(CURDIR)/Makefile" _docker_run DOCKER_RUN_ATTACH=-it
+
+run-batch:
+	@$(MAKE) -f "$(CURDIR)/Makefile" _docker_run DOCKER_RUN_ATTACH=-d
+
+_docker_run:
+	@set -e; \
+	HF_TOKEN_FILE_MAKE="$(HF_TOKEN_FILE)"; \
+	if [ -n "$$HF_TOKEN_FILE_MAKE" ]; then export HF_TOKEN_FILE="$$HF_TOKEN_FILE_MAKE"; fi; \
+	command -v docker >/dev/null 2>&1 || { \
+		echo "ERROR: docker not found (install Docker Engine)" >&2; \
+		exit 1; \
+	}; \
+	if [ -z "$$HF_TOKEN" ] && [ -n "$$HF_TOKEN_FILE" ] && [ -r "$$HF_TOKEN_FILE" ]; then \
+		export HF_TOKEN="$$(tr -d '\r\n' < "$$HF_TOKEN_FILE")"; \
+	fi; \
+	if [ -z "$$HF_TOKEN" ]; then \
+		echo "ERROR: set HF_TOKEN or a readable HF_TOKEN_FILE" >&2; \
+		exit 1; \
+	fi; \
+	mkdir -p "$(DATA)" "$(LOG)" "$(HF_HOME)" \
+		"$(HF_HOME)/hub" "$(HF_HOME)/datasets" "$(HF_HOME)/vllm" \
+		"$(HF_HOME)/vllm_config" "$(HF_HOME)/torch" "$(HF_HOME)/torch_inductor"; \
+	docker rm -f "$(CONTAINER_NAME)" >/dev/null 2>&1 || true; \
+	docker run $(DOCKER_RUN_ATTACH) --rm \
+		--name="$(CONTAINER_NAME)" \
+		--hostname="$(CONTAINER_NAME)" \
+		--device=/dev/kfd \
+		--device=/dev/dri \
+		--network=host \
+		--ipc=host \
+		--group-add 44 \
+		--group-add 993 \
+		--cap-add=SYS_PTRACE \
+		--cap-add=SYS_NICE \
+		--shm-size=64g \
+		--env HF_HOME="$(CONTAINER_HF_HOME)" \
+		--env HF_HUB_CACHE="$(CONTAINER_HF_HOME)/hub" \
+		--env HF_DATASETS_CACHE="$(CONTAINER_HF_HOME)/datasets" \
+		--env VLLM_CACHE_ROOT="$(CONTAINER_HF_HOME)/vllm" \
+		--env VLLM_CONFIG_ROOT="$(CONTAINER_HF_HOME)/vllm_config" \
+		--env TORCH_HOME="$(CONTAINER_HF_HOME)/torch" \
+		--env TORCHINDUCTOR_CACHE_DIR="$(CONTAINER_HF_HOME)/torch_inductor" \
+		--env ADE_CONTAINER_DATA_DIR="$(CONTAINER_DATA_DIR)" \
+		--env ADE_SERVER_LOG_DIR="$(CONTAINER_LOG_DIR)" \
+		--env ADE_LMCACHE_TIER="$(ADE_LMCACHE_TIER)" \
+		--env ADE_LMCACHE_LOG_LEVEL="$(ADE_LMCACHE_LOG_LEVEL)" \
+		--env VLLM_SERVER_DEV_MODE="$(VLLM_SERVER_DEV_MODE)" \
+		$$(if [ -n "$(ADE_TENSOR_PARALLEL_SIZE)" ]; then printf '%s' "--env ADE_TENSOR_PARALLEL_SIZE=$(ADE_TENSOR_PARALLEL_SIZE)"; fi) \
+		$$(if [ -n "$(ADE_GPU_MEMORY_UTILIZATION)" ]; then printf '%s' "--env ADE_GPU_MEMORY_UTILIZATION=$(ADE_GPU_MEMORY_UTILIZATION)"; fi) \
+		$$(if [ -n "$(ADE_MAX_MODEL_LEN)" ]; then printf '%s' "--env ADE_MAX_MODEL_LEN=$(ADE_MAX_MODEL_LEN)"; fi) \
+		$$(if [ -n "$(ADE_MAX_NUM_BATCHED_TOKENS)" ]; then printf '%s' "--env ADE_MAX_NUM_BATCHED_TOKENS=$(ADE_MAX_NUM_BATCHED_TOKENS)"; fi) \
+		$$(if [ -n "$(ADE_LMCACHE_MAX_LOCAL_CPU_SIZE)" ]; then printf '%s' "--env ADE_LMCACHE_MAX_LOCAL_CPU_SIZE=$(ADE_LMCACHE_MAX_LOCAL_CPU_SIZE)"; fi) \
+		$$(if [ -n "$(ADE_LMCACHE_MAX_LOCAL_DISK_SIZE)" ]; then printf '%s' "--env ADE_LMCACHE_MAX_LOCAL_DISK_SIZE=$(ADE_LMCACHE_MAX_LOCAL_DISK_SIZE)"; fi) \
+		$$(if [ -n "$(VLLM_MODEL)" ]; then printf '%s' "--env VLLM_MODEL=$(VLLM_MODEL)"; fi) \
+		--env HF_TOKEN="$$HF_TOKEN" \
+		--env ROCR_VISIBLE_DEVICES="$(GPU)" \
+		--env TZ="$(TZ)" \
+		--env PYTORCH_ALLOC_CONF="$${PYTORCH_ALLOC_CONF:-expandable_segments:True}" \
+		-v "$(HF_HOME):$(CONTAINER_HF_HOME)" \
+		-v "$(DATA):$(CONTAINER_DATA_DIR)" \
+		-v "$(LOG):$(CONTAINER_LOG_DIR)" \
+		-v "$(CURDIR)/configs:/app/configs:ro" \
+		-v "$(CURDIR)/scripts:/app/scripts:ro" \
+		-v /boot/config-$$(uname -r):/boot/config-$$(uname -r):ro \
+		$(EXTRA_DOCKER_RUN_FLAGS) \
+		$(IMAGE_NAME) $(ARGS); \
+	if [ "$(DOCKER_RUN_ATTACH)" = "-d" ]; then \
+		echo "Started container $(CONTAINER_NAME)"; \
+	fi
+
+build aic-drivenets:
+	@command -v docker >/dev/null 2>&1 || { \
+		echo "ERROR: docker not found (install Docker Engine)" >&2; \
+		exit 1; \
+	}
+	@test -n "$(ROCM_ARCH)" || { \
+		echo "ERROR: ROCM_ARCH is empty (install ROCm / rocm_agent_enumerator," >&2; \
+		echo "       or set e.g. ROCM_ARCH=gfx950)" >&2; \
+		exit 1; \
+	}
+	docker build -f "$(CURDIR)/Dockerfile" -t $(IMAGE_NAME) $(BUILD_ARGS) "$(REPO_ROOT)"
+
+verify:
+	@command -v docker >/dev/null 2>&1 || { \
+		echo "ERROR: docker not found (install Docker Engine)" >&2; \
+		exit 1; \
+	}
+	docker run --rm $(IMAGE_NAME) python3 /app/scripts/verify-lmcache-hip.py

--- a/recipies/aic-drivenets/README.md
+++ b/recipies/aic-drivenets/README.md
@@ -1,0 +1,108 @@
+<!--
+Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+SPDX-License-Identifier: MIT
+-->
+
+# aic-drivenets
+
+ROCm **vLLM** + **LMCache** local CPU / NVMe tiers on **gfx950 dGPU**, using
+base image **`rocm/vllm:rocm7.13.0_gfx950-dcgpu_ubuntu24.04_py3.13_pytorch_2.10.0_vllm_0.19.1`**.
+Work from **`recipies/aic-drivenets/`**.
+
+Part of [rocm-aic](../../README.md). Unlike [vllm-lmcache-hipfile](../vllm-lmcache-hipfile)
+(GdsBackend + hipFile) and [vllm-lmcache-nixl](../vllm-lmcache-nixl) (NIXL
+POSIX/AIS), this recipe uses LMCache's **`LMCACHE_LOCAL_*`** environment API
+for HBM L1 + CPU DRAM L2 + optional NVMe L3.
+
+## Contents
+
+- [Where things live](#where-things-live)
+- [Quick start](#quick-start)
+- [LMCache tiers](#lmcache-tiers-ade_lmcache_tier)
+- [Benchmark / stimulus](#benchmark--stimulus)
+- [Compare to other recipes](#compare-to-other-recipes)
+
+## Where things live
+
+| What you need | File |
+| --- | --- |
+| **`make build` / `make run` / `make verify`**, mounts, **`ADE_*`** | **`Makefile`** |
+| **`rocm/vllm`** gfx950 base + HIP LMCache | **`Dockerfile`** |
+| Defaults (prefix cache, LMCache tiers, vLLM serve) | **`configs/aic-drivenets.yaml`** |
+| Server entry point | **`scripts/vllm-server`** |
+| HIP backend check | **`scripts/verify-lmcache-hip.py`** |
+
+### Base image
+
+Default **`rocm/vllm:rocm7.13.0_gfx950-dcgpu_ubuntu24.04_py3.13_pytorch_2.10.0_vllm_0.19.1`**.
+Override with **`make build VLLM_BASE_TAG=…`**.
+
+**Hardware:** gfx950 dGPU (Strix Halo class). For MI300X / ATOM workloads use
+[vllm-atom-andy](../vllm-atom-andy).
+
+## Quick start
+
+```bash
+export ROCM_ARCH=gfx950
+make -C recipies/aic-drivenets build
+make -C recipies/aic-drivenets verify
+export HF_TOKEN=your_hf_token_here
+make -C recipies/aic-drivenets run
+```
+
+The **Makefile** bind-mounts **`configs/`** and **`scripts/`** so YAML and
+Python update without **`docker build`**. LMCache NVMe state uses host **`DATA`**
+(default **`/data`** → container **`/data`**). Server logs tee to host **`LOG`**
+(default **`recipies/aic-drivenets/logs`**, file **`server.txt`**).
+
+Port **`800{GPU}`** matches the first index in **`ROCR_VISIBLE_DEVICES`**.
+
+### DriveNets run flags
+
+**`make run`** passes **`--device=/dev/kfd`**, **`--device=/dev/dri`**,
+**`--network=host`**, **`--ipc=host`**, **`--group-add 44`**, **`--group-add 993`**,
+**`--cap-add=SYS_PTRACE`**, **`--cap-add=SYS_NICE`**, **`--shm-size=64g`**, and
+**`-v /data:/data`**.
+
+Mandatory image env: **`PYTHONHASHSEED=0`**, **`VLLM_FLOAT32_MATMUL_PRECISION=high`**.
+
+## LMCache tiers (`ADE_LMCACHE_TIER`)
+
+| Tier | Env | Behavior |
+| --- | --- | --- |
+| **`hbm`** | (LMCache env off) | vLLM prefix cache in HBM only |
+| **`cpu`** | **`LMCACHE_LOCAL_CPU=true`**, 64 GB L2 default | HBM L1 + CPU DRAM L2 |
+| **`cpu-nvme`** | above + disk L3 | adds **`LMCACHE_LOCAL_DISK`**, **`USE_GDS=false`**, **`NUMA_MODE=auto`** |
+
+Default tier: **`cpu-nvme`** (1500 GB disk cap).
+
+Examples:
+
+```bash
+make run ADE_LMCACHE_TIER=cpu
+make run ADE_LMCACHE_TIER=cpu-nvme DATA=/data
+```
+
+## Benchmark / stimulus
+
+Load testing uses **[kv-cache-tester](../../benchmarks/kv-cache-tester/)** (same
+harness as the [LMCache MI300X blog][atom-blog]). After the server is up:
+
+```bash
+make -C benchmarks/kv-cache-tester install data check-server
+make -C benchmarks/kv-cache-tester run BASE_URL=http://127.0.0.1:8000
+```
+
+See [benchmarks/kv-cache-tester/README.md](../../benchmarks/kv-cache-tester/README.md).
+
+## Compare to other recipes
+
+| Recipe | LMCache backend | Base image |
+| --- | --- | --- |
+| vllm-lmcache-hipfile | GdsBackend → hipFile | vllm/vllm-openai-rocm:v0.19.0 |
+| vllm-lmcache-nixl | NixlStorageBackend → NIXL | vllm/vllm-openai-rocm:v0.19.0 |
+| vllm-atom-andy | **`LMCACHE_LOCAL_*`** + ATOM | rocm/atom-dev |
+| **aic-drivenets** | **`LMCACHE_LOCAL_*`** | **rocm/vllm** (gfx950) |
+
+<!-- References -->
+[atom-blog]: https://andyluo7.github.io/llm/amd/mi300x/vllm/lmcache/performance/2026/05/22/atom-lmcache-kv-cache-offload-mi300x/

--- a/recipies/aic-drivenets/configs/aic-drivenets.yaml
+++ b/recipies/aic-drivenets/configs/aic-drivenets.yaml
@@ -1,0 +1,30 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# aic-drivenets: vLLM + LMCache local CPU/NVMe tiers (gfx950 dGPU).
+
+lmcache:
+  chunk_size: 256
+  max_local_cpu_size_gb: 64
+  max_local_disk_size_gb: 1500
+  disk_subdir: lmcache
+  use_gds: false
+  numa_mode: auto
+
+vllm_kv_transfer:
+  kv_connector: LMCacheConnectorV1
+  kv_role: kv_both
+
+vllm:
+  host: "0.0.0.0"
+  tensor_parallel_size: 1
+  model_default: "openai/gpt-oss-120b"
+  max_model_len_default: "32768"
+  max_num_batched_tokens_default: "8192"
+  gpu_memory_utilization_default: "0.90"
+
+serve:
+  enable_prefix_caching: true
+  disable_uvicorn_access_log: true
+  load_format: auto

--- a/recipies/aic-drivenets/requirements-lmcache-runtime.txt
+++ b/recipies/aic-drivenets/requirements-lmcache-runtime.txt
@@ -1,0 +1,18 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# LMCache runtime deps for aic-drivenets (local CPU / NVMe tiers).
+# Excludes torch and cufile-python so the rocm/vllm base is not replaced.
+
+aiofile
+aiofiles
+blake3
+msgspec
+numpy<=2.2.6
+psutil
+py-cpuinfo
+pyyaml
+pyzmq>=25.0.0
+safetensors
+sortedcontainers

--- a/recipies/aic-drivenets/scripts/aic-drivenets-defaults.py
+++ b/recipies/aic-drivenets/scripts/aic-drivenets-defaults.py
@@ -1,0 +1,24 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+DEFAULT_CONTAINER_DATA_DIR = "/data"
+DEFAULT_CONTAINER_SERVER_LOG_DIR = "/var/log/aic-drivenets"
+
+
+def container_data_root() -> Path:
+    """In-container LMCache data root (**`ADE_CONTAINER_DATA_DIR`**)."""
+    v = os.environ.get("ADE_CONTAINER_DATA_DIR", "").strip()
+    return Path(v) if v else Path(DEFAULT_CONTAINER_DATA_DIR)
+
+
+def container_server_log_dir() -> Path:
+    """Directory for **`vllm-server`** tee (**`server.txt`**)."""
+    v = os.environ.get("ADE_SERVER_LOG_DIR", "").strip()
+    return Path(v) if v else Path(DEFAULT_CONTAINER_SERVER_LOG_DIR)

--- a/recipies/aic-drivenets/scripts/verify-lmcache-hip.py
+++ b/recipies/aic-drivenets/scripts/verify-lmcache-hip.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+"""Verify LMCache HIP c_ops was built (not Python fallback on ROCm)."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _lmcache_git_sha() -> str | None:
+    git_dir = Path("/app/LMCache")
+    if not (git_dir / ".git").is_dir():
+        return None
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(git_dir), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return out.stdout.strip() or None
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+
+def _site_package_roots() -> list[Path]:
+    roots: list[Path] = [Path("/app/LMCache")]
+    try:
+        import site
+
+        for entry in site.getsitepackages():
+            roots.append(Path(entry) / "lmcache")
+    except ImportError:
+        pass
+    return roots
+
+
+def _find_c_ops_so() -> Path | None:
+    for root in _site_package_roots():
+        if not root.is_dir():
+            continue
+        for path in sorted(root.rglob("c_ops*.so")):
+            if path.is_file():
+                return path
+    return None
+
+
+def _check_rocm_torch() -> str:
+    import torch
+
+    ver = torch.__version__
+    if "rocm" not in ver and not torch.version.hip:
+        raise SystemExit(f"ERROR: expected ROCm torch, got {ver}")
+    hip = Path(torch.__file__).resolve().parent / "lib" / "libtorch_hip.so"
+    if not hip.is_file():
+        raise SystemExit(f"ERROR: missing {hip}")
+    return ver
+
+
+def main() -> int:
+    try:
+        torch_ver = _check_rocm_torch()
+    except ImportError as e:
+        print(f"FAIL: cannot import torch ({e})", file=sys.stderr)
+        return 1
+
+    so_path = _find_c_ops_so()
+    if so_path is None:
+        print(
+            "FAIL: no lmcache c_ops*.so found under /app/LMCache or site-packages.\n"
+            "Rebuild with BUILD_WITH_HIP=1 and pip install -e . --no-deps.",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        import lmcache.c_ops as c_ops  # noqa: F401
+    except ImportError:
+        pass
+
+    sha = _lmcache_git_sha()
+    print(f"OK: ROCm torch={torch_ver}")
+    print(f"    LMCache HIP c_ops at {so_path}")
+    if sha:
+        print(f"    LMCache git HEAD: {sha}")
+
+    try:
+        out = subprocess.run(
+            [sys.executable, "-m", "pip", "show", "lmcache"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        for line in out.stdout.splitlines():
+            if line.startswith(("Name:", "Version:", "Location:")):
+                print(f"    {line}")
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        pass
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/recipies/aic-drivenets/scripts/vllm-server
+++ b/recipies/aic-drivenets/scripts/vllm-server
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import threading
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError as e:
+    print("ERROR: PyYAML is required (import yaml).", file=sys.stderr)
+    raise SystemExit(1) from e
+
+import importlib.util
+
+_script_dir = Path(__file__).resolve().parent
+
+
+def _load_defaults_module():
+    path = _script_dir / "aic-drivenets-defaults.py"
+    spec = importlib.util.spec_from_file_location("vllm_ade_defaults", path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load {path}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_defaults = _load_defaults_module()
+container_data_root = _defaults.container_data_root
+container_server_log_dir = _defaults.container_server_log_dir
+_cfg_next_to_script = _script_dir / "configs"
+_CONFIG_DIR = (
+    _cfg_next_to_script
+    if _cfg_next_to_script.is_dir()
+    else _script_dir.parent / "configs"
+)
+_SERVICE_YAML = _CONFIG_DIR / "aic-drivenets.yaml"
+
+
+def _lmcache_tier() -> str:
+    return os.environ.get("ADE_LMCACHE_TIER", "cpu-nvme").strip().lower()
+
+
+def _apply_lmcache_log_level(env: dict[str, str]) -> None:
+    v = os.environ.get("ADE_LMCACHE_LOG_LEVEL", "").strip()
+    env["LMCACHE_LOG_LEVEL"] = v if v else "INFO"
+
+
+def _apply_lmcache_tier_env(
+    env: dict[str, str],
+    tier: str,
+    lmc_cfg: dict[str, Any],
+    data_root: Path,
+) -> bool:
+    """Return True when LMCache connector should be enabled."""
+    if tier in ("hbm", "hbm-only", "none", "off"):
+        for k in (
+            "LMCACHE_LOCAL_CPU",
+            "LMCACHE_LOCAL_DISK",
+            "LMCACHE_MAX_LOCAL_CPU_SIZE",
+            "LMCACHE_MAX_LOCAL_DISK_SIZE",
+            "LMCACHE_CHUNK_SIZE",
+            "USE_GDS",
+            "NUMA_MODE",
+        ):
+            env.pop(k, None)
+        return False
+
+    if tier not in ("cpu", "cpu-nvme", "cpu_nvme", "cpu+disk"):
+        print(
+            f"ERROR: ADE_LMCACHE_TIER must be hbm, cpu, or cpu-nvme (got {tier!r})",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+    chunk = lmc_cfg.get("chunk_size", 256)
+    max_cpu = lmc_cfg.get("max_local_cpu_size_gb", 64)
+    override_cpu = os.environ.get("ADE_LMCACHE_MAX_LOCAL_CPU_SIZE", "").strip()
+    if override_cpu:
+        max_cpu = override_cpu
+
+    env["LMCACHE_LOCAL_CPU"] = "true"
+    env["LMCACHE_CHUNK_SIZE"] = str(int(chunk))
+    env["LMCACHE_MAX_LOCAL_CPU_SIZE"] = str(max_cpu)
+    env.setdefault("PYTHONHASHSEED", "0")
+
+    if tier in ("cpu-nvme", "cpu_nvme", "cpu+disk"):
+        subdir = lmc_cfg.get("disk_subdir", "lmcache")
+        if not isinstance(subdir, str) or not subdir.strip():
+            subdir = "lmcache"
+        disk_path = (data_root / subdir).resolve()
+        disk_path.mkdir(parents=True, exist_ok=True)
+        env["LMCACHE_LOCAL_DISK"] = str(disk_path)
+
+        max_disk = lmc_cfg.get("max_local_disk_size_gb", 1500)
+        override_disk = os.environ.get("ADE_LMCACHE_MAX_LOCAL_DISK_SIZE", "").strip()
+        if override_disk:
+            max_disk = override_disk
+        env["LMCACHE_MAX_LOCAL_DISK_SIZE"] = str(max_disk)
+
+        use_gds = lmc_cfg.get("use_gds", False)
+        env["USE_GDS"] = "true" if use_gds else "false"
+
+        numa_mode = lmc_cfg.get("numa_mode", "auto")
+        if isinstance(numa_mode, str) and numa_mode.strip():
+            env["NUMA_MODE"] = numa_mode.strip()
+
+    return True
+
+
+def _tee_thread(stream: Any, log_f: Any) -> None:
+    for line in iter(stream.readline, b""):
+        if not line:
+            break
+        log_f.write(line)
+        log_f.flush()
+        try:
+            sys.stdout.buffer.write(line)
+            sys.stdout.buffer.flush()
+        except BrokenPipeError:
+            break
+
+
+def _first_gpu_index(rocr: str) -> str:
+    port = rocr.split(",", 1)[0].strip()
+    if not port.isdigit():
+        print(
+            "error: first GPU index in ROCR_VISIBLE_DEVICES must be a "
+            f"non-negative integer (got: {rocr})",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    if "," in rocr:
+        print(
+            f"aic-drivenets: using first index {port} from "
+            f"ROCR_VISIBLE_DEVICES={rocr} for ports",
+            file=sys.stderr,
+        )
+    return port
+
+
+def _vllm_binary() -> str:
+    path = shutil.which("vllm")
+    if not path:
+        print("ERROR: vllm not found on PATH", file=sys.stderr)
+        raise SystemExit(1)
+    return path
+
+
+def main() -> int:
+    if not os.environ.get("ROCR_VISIBLE_DEVICES", "").strip():
+        print("Error: ROCR_VISIBLE_DEVICES not set", file=sys.stderr)
+        return 1
+
+    if not _SERVICE_YAML.is_file():
+        print(f"ERROR: missing {_SERVICE_YAML}", file=sys.stderr)
+        return 1
+
+    svc = yaml.safe_load(_SERVICE_YAML.read_text(encoding="utf-8"))
+    vcfg = svc["vllm"]
+    prof = svc.get("serve")
+    if not isinstance(prof, dict):
+        print("ERROR: aic-drivenets.yaml must define serve (mapping)", file=sys.stderr)
+        return 1
+
+    lmc_cfg = svc.get("lmcache")
+    if not isinstance(lmc_cfg, dict):
+        lmc_cfg = {}
+
+    data_root = container_data_root()
+    data_root.mkdir(parents=True, exist_ok=True)
+
+    rocr = os.environ.get("ROCR_VISIBLE_DEVICES", "0").strip() or "0"
+    gpu_idx = _first_gpu_index(rocr)
+    vllm_port = int(f"800{gpu_idx}")
+
+    env = os.environ.copy()
+    env["PYTHONHASHSEED"] = "0"
+    env["VLLM_FLOAT32_MATMUL_PRECISION"] = "high"
+    _apply_lmcache_log_level(env)
+    _prepend_rocm_ld_library_path(env)
+
+    tier = _lmcache_tier()
+    use_lmcache = _apply_lmcache_tier_env(env, tier, lmc_cfg, data_root)
+
+    if _truthy("VLLM_SERVER_DEV_MODE", "1"):
+        env["VLLM_SERVER_DEV_MODE"] = "1"
+    else:
+        env.pop("VLLM_SERVER_DEV_MODE", None)
+
+    model = os.environ.get("VLLM_MODEL", "").strip() or str(vcfg["model_default"])
+
+    tp_override = os.environ.get("ADE_TENSOR_PARALLEL_SIZE", "").strip()
+    if tp_override:
+        tp_size = int(tp_override)
+    else:
+        tp_size = int(vcfg["tensor_parallel_size"])
+
+    gpu_mem = (
+        os.environ.get("ADE_GPU_MEMORY_UTILIZATION", "").strip()
+        or os.environ.get("VLLM_GPU_MEMORY_UTILIZATION", "").strip()
+        or str(vcfg["gpu_memory_utilization_default"])
+    )
+    max_len = (
+        os.environ.get("ADE_MAX_MODEL_LEN", "").strip()
+        or str(vcfg["max_model_len_default"])
+    )
+    max_batched = (
+        os.environ.get("ADE_MAX_NUM_BATCHED_TOKENS", "").strip()
+        or str(vcfg["max_num_batched_tokens_default"])
+    )
+
+    cmd: list[str] = [
+        _vllm_binary(),
+        "serve",
+        model,
+        "--host",
+        str(vcfg["host"]),
+        "--port",
+        str(vllm_port),
+        "--tensor-parallel-size",
+        str(tp_size),
+        "--gpu-memory-utilization",
+        gpu_mem,
+        "--max-model-len",
+        max_len,
+        "--max-num-batched-tokens",
+        max_batched,
+    ]
+
+    if prof.get("enable_prefix_caching", True):
+        cmd.append("--enable-prefix-caching")
+
+    if use_lmcache:
+        kv_obj = svc.get("vllm_kv_transfer")
+        if not isinstance(kv_obj, dict):
+            print(
+                "ERROR: aic-drivenets.yaml must define vllm_kv_transfer",
+                file=sys.stderr,
+            )
+            return 1
+        kv_raw = json.dumps(kv_obj, separators=(",", ":"))
+        cmd.extend(["--kv-transfer-config", kv_raw])
+
+    lf = prof.get("load_format")
+    if isinstance(lf, str) and lf and lf != "auto":
+        cmd.extend(["--load-format", lf])
+
+    if prof.get("disable_uvicorn_access_log", True):
+        cmd.append("--disable-uvicorn-access-log")
+
+    log_root = container_server_log_dir()
+    log_root.mkdir(parents=True, exist_ok=True)
+    log_path = log_root / "server.txt"
+    log_f = log_path.open("ab", buffering=0)
+    listen = str(vcfg["host"])
+    print(
+        f"aic-drivenets ADE_LMCACHE_TIER={tier} lmcache={'on' if use_lmcache else 'off'} "
+        f"http://{listen}:{vllm_port}/v1 log={log_path}",
+        flush=True,
+    )
+    proc = subprocess.Popen(
+        cmd,
+        env=env,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+    assert proc.stdout is not None
+    tee = threading.Thread(
+        target=_tee_thread,
+        args=(proc.stdout, log_f),
+        daemon=True,
+    )
+    tee.start()
+    rc = proc.wait()
+    tee.join(timeout=30)
+    proc.stdout.close()
+    log_f.close()
+    return int(rc)
+
+
+def _truthy(name: str, default: str = "1") -> bool:
+    v = os.environ.get(name, default).strip().lower()
+    return v not in ("0", "false", "no", "off", "")
+
+
+def _prepend_rocm_ld_library_path(env: dict[str, str]) -> None:
+    try:
+        import torch
+
+        torch_lib = str(Path(torch.__file__).resolve().parent / "lib")
+    except ImportError:
+        torch_lib = ""
+    rocm_lib = "/opt/rocm/lib"
+    prev_ld = env.get("LD_LIBRARY_PATH", "")
+    parts = [p for p in (torch_lib, rocm_lib) if p] + [
+        p for p in prev_ld.split(":") if p
+    ]
+    env["LD_LIBRARY_PATH"] = ":".join(dict.fromkeys(parts))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/recipies/vllm-atom-andy/README.md
+++ b/recipies/vllm-atom-andy/README.md
@@ -132,21 +132,20 @@ if serving from that path.
 ## kv-cache-tester / trace replay
 
 The blog uses **`trace_replay_tester.py`** from
-[callanjfox/kv-cache-tester][kv-cache-tester] (739 Claude Code traces). This repo
-ships an Ansible role at
-[ansible/roles/kv_cache_tester](../../ansible/roles/kv_cache_tester).
-
-Stress run parameters from the blog (after the server is up on port 8000):
+[callanjfox/kv-cache-tester][kv-cache-tester] (739 Claude Code traces). Run it
+via the repo benchmark wrapper at
+[benchmarks/kv-cache-tester](../../benchmarks/kv-cache-tester):
 
 ```bash
-ansible-playbook ansible/playbooks/kv-cache-tester.yml \
-  -e kv_cache_tester_api_endpoint=http://127.0.0.1:8000 \
-  -e kv_cache_tester_script=trace_replay_tester.py \
-  -e 'kv_cache_tester_extra_args=["--trace-directory","traces","--start-users","4","--max-users","32","--max-ttft","60.0","--test-duration","1200","--max-context","100000","--warm-prefix-pct","0.5","--timing-strategy","think-only","--recycle","--seed","42"]'
+make -C benchmarks/kv-cache-tester install data check-server
+make -C benchmarks/kv-cache-tester run BASE_URL=http://127.0.0.1:8000
 ```
 
+See [benchmarks/kv-cache-tester/README.md](../../benchmarks/kv-cache-tester/README.md)
+for profiles, smoke tests, and Ansible integration.
+
 Traces must exist under the kv-cache-tester checkout (**`traces/`**). Clone with
-**`git clone --recursive`** per upstream instructions.
+**`git clone --recursive`** per upstream instructions (handled by **`make data`**).
 
 ## Compare to other recipes
 


### PR DESCRIPTION
Introduce gfx950 vLLM+LMCache Docker recipe (DriveNets run flags, local
CPU/NVMe tiers) and a benchmarks/kv-cache-tester wrapper for MI300X
blog trace replay stimulus, with CI and Ansible integration.