### PR TITLE
recipes: add vllm-lmcache-mp recipe with NIXL AIS_MT NVMe L2 and GDS L1 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# Claude Code session state and project memory
+.claude/
+
+# Downloaded Gutenberg benchmark corpus (generated on demand via make data)
+data/gutenberg/
+
 # Python related
 .venv
 __pycache__

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -1,4 +1,5 @@
 AIS
+AIS_MT
 AMD
 Ansible
 BlueField
@@ -424,13 +425,18 @@ Mooncake
 myst
 NAS
 NetApp
+nfs
 og
 OSS
+oss
 Pensando
 PowerScale
 recomputation
 releasedate
 roadmap
+ROCR
 SmartNIC
 TCO
+VLM
 WekaFS
+ZMQ

--- a/recipies/common/nixl/apply-ais-overlay.sh
+++ b/recipies/common/nixl/apply-ais-overlay.sh
@@ -17,6 +17,24 @@ if [[ ! -f "${NIXL_SRC}/meson.build" ]]; then
 	exit 1
 fi
 
+# Detect whether this nixl checkout already has native HIP + AIS_MT support
+# (sbates130272/nixl@9d14642+ and later). If so, no patching or overlay copying
+# is needed — the repo ships everything we need out of the box.
+_NATIVE_AIS_MT=0
+if grep -q "enabled_plugins.get('AIS_MT')" "${NIXL_SRC}/src/plugins/meson.build" 2>/dev/null \
+	&& grep -q "hip_dep" "${NIXL_SRC}/meson.build" 2>/dev/null; then
+	_NATIVE_AIS_MT=1
+fi
+
+if [[ "${_NATIVE_AIS_MT}" == "1" ]]; then
+	echo "nixl has native HIP + AIS_MT support; skipping overlay and meson patches"
+	echo "AIS overlay complete for ${NIXL_SRC}"
+	exit 0
+fi
+
+# --- Older nixl (andyluo7/nixl amd-support pre-native-HIP) ---
+
+# Inject ROCm/HIP toolchain support into meson.build.
 python3 "${SCRIPT_DIR}/patch-rocm-meson.py"
 
 if [[ -d "${OVERLAY}/src/plugins/ais" ]]; then

--- a/recipies/common/nixl/build-nixl.sh
+++ b/recipies/common/nixl/build-nixl.sh
@@ -32,11 +32,20 @@ fi
 if [[ "${NIXL_ENABLE_AIS}" == "1" ]]; then
 	chmod +x "${SCRIPT_DIR}/apply-ais-overlay.sh"
 	NIXL_SRC="${NIXL_SRC}" "${SCRIPT_DIR}/apply-ais-overlay.sh"
-	if [[ ! -f "${NIXL_SRC}/meson_options.txt" ]] \
-		|| ! grep -q "option('rocm_path'" "${NIXL_SRC}/meson_options.txt"; then
-		echo "ERROR: ROCm overlay did not add rocm_path to meson_options.txt" >&2
-		exit 1
-	fi
+fi
+
+# Determine whether this nixl checkout uses the old injected rocm_path option
+# or the newer native HIP detection (hippath_inc/hippath_lib + hip_dep).
+_NATIVE_HIP=0
+_HAS_ROCM_PATH_OPT=0
+if grep -q "option('rocm_path'" "${NIXL_SRC}/meson_options.txt" 2>/dev/null; then
+	_HAS_ROCM_PATH_OPT=1
+elif grep -q "hip_dep" "${NIXL_SRC}/meson.build" 2>/dev/null; then
+	_NATIVE_HIP=1
+fi
+if [[ "${_NATIVE_HIP}" == "0" && "${_HAS_ROCM_PATH_OPT}" == "0" ]]; then
+	echo "ERROR: unable to determine HIP configuration for ${NIXL_SRC}: missing rocm_path option and hip_dep (unexpected nixl revision or overlay not applied)" >&2
+	exit 1
 fi
 
 export DEBIAN_FRONTEND=noninteractive
@@ -94,14 +103,23 @@ rm -rf build
 
 MESON_EXTRA=(
 	"-Dwheel_variant=rocm"
-	"-Drocm_path=${ROCM_PATH}"
 	"-Ducx_path=${UCX_PREFIX}"
 	"-Ddisable_gds_backend=true"
 	"--prefix=${NIXL_INSTALL_PREFIX}"
 )
 
-if [[ "${NIXL_ENABLE_AIS}" == "1" && -n "${AIS_PATH}" ]]; then
-	MESON_EXTRA+=("-Dais_path=${AIS_PATH}")
+if [[ "${_NATIVE_HIP}" == "1" ]]; then
+	# Native HIP: ROCM_PATH env is auto-detected by meson; rocm_ais_path for AIS_MT.
+	export ROCM_PATH="${ROCM_PATH}"
+	if [[ "${NIXL_ENABLE_AIS}" == "1" && -n "${AIS_PATH}" ]]; then
+		MESON_EXTRA+=("-Drocm_ais_path=${AIS_PATH}")
+	fi
+else
+	# Older injected rocm_path option (pre-native-HIP nixl).
+	MESON_EXTRA+=("-Drocm_path=${ROCM_PATH}")
+	if [[ "${NIXL_ENABLE_AIS}" == "1" && -n "${AIS_PATH}" ]]; then
+		MESON_EXTRA+=("-Dais_path=${AIS_PATH}")
+	fi
 fi
 
 meson setup build "${MESON_EXTRA[@]}"

--- a/recipies/vllm-lmcache-mp/Dockerfile
+++ b/recipies/vllm-lmcache-mp/Dockerfile
@@ -1,0 +1,149 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# vllm-lmcache-mp: single image used by both docker compose services.
+#
+#   lmcache service: docker compose runs  lmcache server --host 0.0.0.0 ...
+#   vllm    service: docker compose runs  vllm serve ... --kv-transfer-config
+#
+# Storage (owned by the lmcache container):
+#   L1: GPU / CPU memory managed by lmcache-server (--l1-size-gb)
+#   L2a (NVMe): nixl_store AIS_MT adapter  → bind-mounted local NVMe (hipFile P2PDMA)
+#   L2b (NFS):  nixl_store POSIX  adapter  → bind-mounted NFS-over-RDMA mount
+#
+# Build (from repo root):
+#   DOCKER_BUILDKIT=1 docker build \
+#     --build-arg ROCM_ARCH=gfx942 \
+#     -f recipies/vllm-lmcache-mp/Dockerfile \
+#     -t vllm-lmcache-mp .
+#
+# Orchestration: make -C recipies/vllm-lmcache-mp up
+
+FROM vllm/vllm-openai-rocm:v0.23.0
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+ARG ROCM_ARCH
+RUN test -n "$ROCM_ARCH" || (echo "ERROR: ROCM_ARCH is not set" && exit 1)
+
+# Pinned component revisions — bump together when validating a new combo.
+ARG HIPFILE_SHA=adc1a2d2f8e886e93c5e55e674dbff6e05db2dbe
+ARG NIXL_GIT_URL=https://github.com/sbates130272/nixl.git
+ARG NIXL_SHA=9d146424117a7cd022bdbaec8cbd7551f1c08add
+ARG NIXL_ENABLE_AIS=1
+
+# LMCache: Ivan's public fork with hipFile MP support.
+# The single commit on top of upstream (301f04a) adds --gds-l1-backend hipfile.
+ARG LMCACHE_GIT_URL=https://github.com/amd-ivaganev/LMCache.git
+ARG LMCACHE_GIT_REF=hipfile-for-mp
+# Pin SHA for reproducible builds; leave empty to track branch head.
+ARG LMCACHE_SHA=301f04a114ac1089d51807cac5ccc549e6afc71a
+
+# ----- 1. Build dependencies -----------------------------------------------
+RUN apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates \
+        cmake \
+        git \
+        libboost-all-dev \
+        libmount-dev \
+        ninja-build \
+        pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m pip install --no-cache-dir --upgrade pip
+
+# ----- 2. LMCache (upstream @ main + AMD patches) ---------------------------
+RUN git clone --branch "${LMCACHE_GIT_REF}" "${LMCACHE_GIT_URL}" /app/LMCache && \
+    if [ -n "${LMCACHE_SHA}" ]; then \
+        git -C /app/LMCache checkout "${LMCACHE_SHA}"; \
+    fi
+
+# Apply patches in order; --check first so already-merged ones are skipped.
+COPY recipies/vllm-lmcache-hipfile/patches/lmcache-pr-3008-cache-salt.patch \
+     recipies/vllm-lmcache-hipfile/patches/lmcache-sha256-cbor-int.patch \
+     recipies/vllm-lmcache-hipfile/patches/lmcache-controller-log.patch \
+     recipies/vllm-lmcache-hipfile/patches/lmcache-chunk-statistics-hash.patch \
+     recipies/vllm-lmcache-nixl/patches/lmcache-nixl-ais-backend.patch \
+     recipies/vllm-lmcache-mp/patches/lmcache-hipfile-mp.patch \
+     recipies/vllm-lmcache-mp/patches/lmcache-nixl-ais-mt-l2-adapter.patch \
+     /app/patches/
+
+RUN cd /app/LMCache && \
+    for patch in \
+        /app/patches/lmcache-pr-3008-cache-salt.patch \
+        /app/patches/lmcache-sha256-cbor-int.patch \
+        /app/patches/lmcache-controller-log.patch \
+        /app/patches/lmcache-chunk-statistics-hash.patch \
+        /app/patches/lmcache-nixl-ais-backend.patch \
+        /app/patches/lmcache-hipfile-mp.patch \
+        /app/patches/lmcache-nixl-ais-mt-l2-adapter.patch; do \
+        if git apply --check "$patch" 2>/dev/null; then \
+            git apply "$patch" && echo "Applied: $patch"; \
+        else \
+            echo "Skipped (already merged or conflict): $patch"; \
+        fi; \
+    done
+
+RUN cd /app/LMCache && \
+    PYTORCH_ROCM_ARCH=${ROCM_ARCH} \
+        TORCH_DONT_CHECK_COMPILER_ABI=1 \
+        CXX=hipcc \
+        BUILD_WITH_HIP=1 \
+        python3 -m pip install --no-build-isolation --no-cache-dir -e .
+
+# Fix argparse %-format bug in long_doc_qa benchmark helper.
+RUN python3 <<'PY'
+from pathlib import Path
+p = Path("/app/LMCache/benchmarks/long_doc_qa/long_doc_qa.py")
+if p.exists():
+    text = p.read_text(encoding="utf-8")
+    needle = "before averaging. Example: 0.1 drops bottom 10% and top 10%."
+    if needle in text:
+        p.write_text(text.replace(needle, needle.replace("%", "%%"), 1), encoding="utf-8")
+PY
+
+RUN python3 -m pip install --no-cache-dir "matplotlib>=3.8,<4"
+RUN pip uninstall -y nixl nixl-cu12 nixl-cu13 2>/dev/null || true
+
+# ----- 3. ROCm/rocm-systems hipFile (DEB + Python binding) -----------------
+RUN git clone --no-checkout --filter=blob:none \
+        https://github.com/ROCm/rocm-systems.git /app/rocm-systems && \
+    cd /app/rocm-systems && \
+    git sparse-checkout set --cone projects/hipfile && \
+    git checkout "${HIPFILE_SHA}" && \
+    cd projects/hipfile && \
+    mkdir -p build && cd build && \
+    cmake -DCMAKE_HIP_PLATFORM=amd -DAIS_INSTALL_TOOLS=ON \
+          -DAMDGPU_TARGETS="${ROCM_ARCH}" \
+          -DGPU_TARGETS="${ROCM_ARCH}" \
+          -DCMAKE_HIP_ARCHITECTURES="${ROCM_ARCH}" .. && \
+    cmake --build . -j"$(nproc)" && \
+    cpack -G DEB && \
+    dpkg -i hipfile*deb && \
+    cd ../python && \
+    pip install --no-cache-dir -e . \
+        -Ccmake.define.HIPFILE_INCLUDE_DIR=../include \
+        -Ccmake.define.HIP_INCLUDE_DIR=/opt/rocm/include && \
+    test -x /app/rocm-systems/projects/hipfile/build/tools/ais-stats/ais-stats && \
+    ln -sf /app/rocm-systems/projects/hipfile/build/tools/ais-stats/ais-stats \
+        /app/ais-stats && \
+    ln -sf /app/ais-stats /usr/local/bin/ais-stats
+
+# ----- 4. NIXL (andyluo7/nixl @ amd-support + AIS overlay) ----------------
+COPY recipies/common/nixl /tmp/nixl-common
+RUN chmod +x /tmp/nixl-common/*.sh /tmp/nixl-common/apply-ais-overlay.sh && \
+    NIXL_GIT_URL="${NIXL_GIT_URL}" NIXL_SHA="${NIXL_SHA}" NIXL_REQUIRE_ROCM=1 \
+        NIXL_DEST=/tmp/nixl /tmp/nixl-common/clone-nixl.sh && \
+    NIXL_SRC=/tmp/nixl NIXL_ENABLE_AIS="${NIXL_ENABLE_AIS}" \
+        AIS_PATH=/opt/rocm ROCM_PATH=/opt/rocm \
+        NIXL_INSTALL_PREFIX=/opt/nixl \
+        /tmp/nixl-common/build-nixl.sh
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONHASHSEED=0 \
+    NIXL_PLUGIN_DIR=/opt/nixl/lib/x86_64-linux-gnu/plugins \
+    PYTHONPATH=/opt/nixl/lib/python3/dist-packages \
+    LD_LIBRARY_PATH=/opt/nixl/lib/x86_64-linux-gnu:/opt/nixl/lib:/opt/rocnixl-ucx/lib:/opt/rocm/lib

--- a/recipies/vllm-lmcache-mp/Makefile
+++ b/recipies/vllm-lmcache-mp/Makefile
@@ -1,0 +1,156 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+REPO_ROOT := $(abspath $(CURDIR)/../..)
+include $(abspath $(CURDIR)/../common/nixl/defaults.mk)
+
+# Override NIXL source: sbates130272/nixl @ feat/amd-ais-mt (adds AIS_MT plugin).
+# These override the defaults.mk values before they are exported as build args.
+NIXL_GIT_URL := https://github.com/sbates130272/nixl.git
+NIXL_SHA     := 9d146424117a7cd022bdbaec8cbd7551f1c08add
+
+# ---- GPU -------------------------------------------------------------------
+GPU ?= 0
+
+# ---- Host storage paths ----------------------------------------------------
+NVME_DATA ?= /mnt/lmcache-nvme
+NFS_DATA  ?= /mnt/lmcache-nfs
+
+# ---- Log / HuggingFace -----------------------------------------------------
+LOG     ?= $(CURDIR)/logs
+HF_HOME ?= $(HOME)/.cache/huggingface
+HF_TOKEN_FILE ?=
+
+# ---- LMCache server --------------------------------------------------------
+LMCACHE_PORT       ?= 6555
+LMCACHE_L1_SIZE_GB ?= 20
+LMCACHE_NVME_POOL      ?= 4096
+LMCACHE_NVME_SLOT_SIZE ?= 268435456
+LMCACHE_NFS_POOL       ?= 1024
+
+# ---- vLLM knobs ------------------------------------------------------------
+VLLM_MODEL                 ?=
+TENSOR_PARALLEL_SIZE        ?= 1
+VLM_GPU_MEMORY_UTILIZATION  ?=
+VLM_MAX_MODEL_LEN           ?=
+VLM_MAX_NUM_BATCHED_TOKENS  ?=
+
+# ---- ROCm arch (auto-detected if not set) ----------------------------------
+_ROCM_ARCH_DETECTED := $(shell rocm_agent_enumerator 2>/dev/null | grep -E '^gfx' | head -1)
+ROCM_ARCH := $(if $(strip $(ROCM_ARCH)),$(strip $(ROCM_ARCH)),$(_ROCM_ARCH_DETECTED))
+
+# Export everything compose needs from the environment.
+export ROCM_ARCH GPU GDS_SLAB_DATA LOG HF_HOME
+export LMCACHE_PORT LMCACHE_L1_SIZE_GB LMCACHE_NVME_POOL LMCACHE_NVME_SLOT_SIZE LMCACHE_NFS_POOL
+export NVME_DATA NFS_DATA
+export VLLM_MODEL TENSOR_PARALLEL_SIZE
+export VLM_GPU_MEMORY_UTILIZATION VLM_MAX_MODEL_LEN VLM_MAX_NUM_BATCHED_TOKENS
+export NIXL_GIT_URL NIXL_SHA
+
+# Prefer the 'docker compose' plugin (Docker 23+); fall back to standalone docker-compose.
+_COMPOSE_BIN := $(shell docker compose version >/dev/null 2>&1 && echo "docker compose" || echo "docker-compose")
+COMPOSE        := DOCKER_BUILDKIT=1 $(_COMPOSE_BIN) -f "$(CURDIR)/docker-compose.yml"
+COMPOSE_GDS_L1 := $(COMPOSE) -f "$(CURDIR)/docker-compose.gds-l1.yml"
+
+.PHONY: help build up up-batch up-gds-l1 up-gds-l1-batch down logs logs-lmcache logs-vllm \
+        ps shell-lmcache shell-vllm restart-vllm restart-lmcache _check_hf_token _prep_dirs
+
+.DEFAULT_GOAL := help
+
+help:
+	@echo "vllm-lmcache-mp — vLLM + standalone LMCache server (MP/ZMQ mode)"
+	@echo ""
+	@echo "Targets:"
+	@echo "  make build           Build the shared image"
+	@echo "  make up              Start both containers (foreground, DRAM L1 + AIS_MT L2)"
+	@echo "  make up-batch        Start both containers (background, DRAM L1 + AIS_MT L2)"
+	@echo "  make up-gds-l1       Start with hipFile GDS NVMe slab as L1, no L2 (foreground)"
+	@echo "  make up-gds-l1-batch Start with hipFile GDS NVMe slab as L1, no L2 (background)"
+	@echo "  make down            Stop and remove both containers"
+	@echo "  make logs            Follow logs from both containers"
+	@echo "  make logs-lmcache    Follow lmcache container logs only"
+	@echo "  make logs-vllm       Follow vllm container logs only"
+	@echo "  make ps              Show container status"
+	@echo "  make shell-lmcache   Exec bash into lmcache container"
+	@echo "  make shell-vllm      Exec bash into vllm container"
+	@echo "  make restart-vllm    Restart vllm container only (lmcache keeps running)"
+	@echo "  make restart-lmcache Restart lmcache container only"
+	@echo ""
+	@echo "Required env:"
+	@echo "  HF_TOKEN       HuggingFace access token"
+	@echo "  ROCM_ARCH      GPU arch (detected: $(ROCM_ARCH))"
+	@echo ""
+	@echo "Key vars (current):"
+	@echo "  GPU=$(GPU)  NVME_DATA=$(NVME_DATA)  NFS_DATA=$(NFS_DATA)"
+	@echo "  LMCACHE_PORT=$(LMCACHE_PORT)  LMCACHE_L1_SIZE_GB=$(LMCACHE_L1_SIZE_GB) GiB"
+	@echo "  LMCACHE_NVME_POOL=$(LMCACHE_NVME_POOL)  LMCACHE_NFS_POOL=$(LMCACHE_NFS_POOL)"
+	@echo ""
+	@echo "Examples:"
+	@echo "  make build"
+	@echo "  make up HF_TOKEN=hf_... NVME_DATA=/mnt/nvme NFS_DATA=/mnt/nfs"
+	@echo "  make up-batch LMCACHE_L1_SIZE_GB=40 VLLM_MODEL=Qwen/Qwen3-8B"
+	@echo "  make restart-vllm VLLM_MODEL=Qwen/Qwen3-14B"
+	@echo ""
+
+_check_hf_token:
+	@if [ -z "$$HF_TOKEN" ] && [ -n "$(HF_TOKEN_FILE)" ] && [ -r "$(HF_TOKEN_FILE)" ]; then \
+		export HF_TOKEN="$$(tr -d '\r\n' < "$(HF_TOKEN_FILE)")"; \
+	fi; \
+	if [ -z "$$HF_TOKEN" ]; then \
+		echo "ERROR: set HF_TOKEN or HF_TOKEN_FILE" >&2; exit 1; \
+	fi
+
+_prep_dirs:
+	@mkdir -p "$(NVME_DATA)" "$(NFS_DATA)" \
+		"$(LOG)/lmcache" "$(LOG)/vllm" \
+		"$(HF_HOME)/hub" "$(HF_HOME)/datasets" "$(HF_HOME)/vllm" \
+		"$(HF_HOME)/vllm_config" "$(HF_HOME)/torch" "$(HF_HOME)/torch_inductor"
+
+build:
+	@test -n "$(ROCM_ARCH)" || { \
+		echo "ERROR: ROCM_ARCH empty (install ROCm or set ROCM_ARCH=gfxNNNN)" >&2; exit 1; }
+	cd "$(REPO_ROOT)" && $(COMPOSE) build
+
+up: _check_hf_token _prep_dirs
+	$(COMPOSE) up
+
+up-batch: _check_hf_token _prep_dirs
+	$(COMPOSE) up -d
+	@echo "Started. Use 'make logs' to follow or 'make down' to stop."
+
+up-gds-l1: _check_hf_token _prep_dirs
+	$(COMPOSE_GDS_L1) up
+
+up-gds-l1-batch: _check_hf_token _prep_dirs
+	$(COMPOSE_GDS_L1) up -d
+	@echo "Started (GDS L1 mode). Use 'make logs' to follow or 'make down' to stop."
+
+down:
+	$(COMPOSE) down
+
+logs:
+	$(COMPOSE) logs -f
+
+logs-lmcache:
+	$(COMPOSE) logs -f lmcache
+
+logs-vllm:
+	$(COMPOSE) logs -f vllm
+
+ps:
+	$(COMPOSE) ps
+
+shell-lmcache:
+	docker exec -it vllm-lmcache-mp-lmcache bash -l
+
+shell-vllm:
+	docker exec -it vllm-lmcache-mp-vllm-gpu$(GPU) bash -l
+
+# Restart vllm only — lmcache stays up, warm KV state preserved.
+restart-vllm:
+	$(COMPOSE) restart vllm
+
+# Restart lmcache only (vllm will reconnect over ZMQ).
+restart-lmcache:
+	$(COMPOSE) restart lmcache

--- a/recipies/vllm-lmcache-mp/README.md
+++ b/recipies/vllm-lmcache-mp/README.md
@@ -1,0 +1,171 @@
+<!--
+Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+SPDX-License-Identifier: MIT
+-->
+
+# vllm-lmcache-mp
+
+ROCm **vLLM** + standalone **LMCache server** (MP mode) as two independent
+containers, connected over ZMQ on a dedicated Docker bridge network.
+
+Each container can be started, stopped, updated, and restarted independently.
+The lmcache server survives vLLM restarts, preserving warm KV state.
+
+| Container | Role                                                        |
+|-----------|-------------------------------------------------------------|
+| lmcache   | Standalone cache server; L1 GPU/CPU memory + L2 storage     |
+| vllm      | Inference engine; connects to lmcache over ZMQ              |
+
+Storage tiers (all owned by the lmcache container):
+
+| Tier          | Backend           | Transport                                        |
+|---------------|-------------------|--------------------------------------------------|
+| L1 (default)  | GPU / CPU memory  | in-process (lmcache managed)                     |
+| L1 (opt-in)   | hipFile GDS slab  | hipFile P2PDMA to dedicated NVMe (GDS_SLAB_DATA) |
+| L2a (NVMe)    | nixl_store AIS_MT | hipFile P2PDMA to local NVMe                     |
+| L2b (NFS)     | nixl_store POSIX  | NFS-over-RDMA (host kernel NFS client)           |
+
+Part of [rocm-aic](../../README.md).
+
+## Architecture
+
+```text
+  ┌──────────────────────────────────────┐
+  │  vllm container                      │
+  │  vllm serve                          │
+  │  --kv-transfer-config                │
+  │    LMCacheMPConnector                │
+  │    host=lmcache port=6555            │
+  └──────────────┬───────────────────────┘
+                 │ ZMQ (lmcache-net bridge)
+  ┌──────────────┴───────────────────────┐
+  │  lmcache container                   │
+  │  lmcache server --host 0.0.0.0       │
+  │                                      │
+  │  L1: GPU/CPU memory (--l1-size-gb)   │
+  │  L2a: nixl_store AIS_MT             │
+  │       → /data/nvme  (local NVMe)    │
+  │  L2b: nixl_store POSIX              │
+  │       → /data/nfs   (NFS-over-RDMA) │
+  └──────────────────────────────────────┘
+```
+
+## Prerequisites
+
+### 1. NFS-over-RDMA mount
+
+Mount the NFS export on the host before `make up`. The container bind-mounts
+`NFS_DATA` as `/data/nfs`.
+
+```bash
+sudo modprobe rdma_rxe                        # software RoCE if needed
+sudo mount -t nfs -o rdma,port=20049 \
+    nfs-server:/exports/lmcache /mnt/lmcache-nfs
+export NFS_DATA=/mnt/lmcache-nfs
+```
+
+### 2. Local NVMe mount
+
+```bash
+sudo mkdir -p /mnt/lmcache-nvme && sudo chown $USER /mnt/lmcache-nvme
+export NVME_DATA=/mnt/lmcache-nvme
+```
+
+## Quick start
+
+```bash
+export ROCM_ARCH=gfx942
+export HF_TOKEN=hf_...
+export NVME_DATA=/mnt/lmcache-nvme
+export NFS_DATA=/mnt/lmcache-nfs
+
+make -C recipies/vllm-lmcache-mp build
+make -C recipies/vllm-lmcache-mp up-batch
+
+# Test
+curl http://localhost:8000/v1/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"openai/gpt-oss-120b","prompt":"Hello","max_tokens":16}'
+
+# Check NVMe L2 usage
+find $NVME_DATA/lmcache -name 'obj_*.bin' -size +0 | wc -l
+
+# Check NFS L2 usage
+ls $NFS_DATA/lmcache/
+
+make -C recipies/vllm-lmcache-mp down
+```
+
+## Independent lifecycle management
+
+```bash
+# Restart vLLM only — lmcache stays up, warm KV preserved
+make -C recipies/vllm-lmcache-mp restart-vllm
+
+# Restart lmcache only — vLLM reconnects automatically
+make -C recipies/vllm-lmcache-mp restart-lmcache
+
+# Follow lmcache logs while vllm is separate
+make -C recipies/vllm-lmcache-mp logs-lmcache
+make -C recipies/vllm-lmcache-mp logs-vllm
+
+# Shell into either container independently
+make -C recipies/vllm-lmcache-mp shell-lmcache
+make -C recipies/vllm-lmcache-mp shell-vllm
+```
+
+## Tuning knobs
+
+| Var | Default | Notes |
+| --- | ------- | ----- |
+| GPU | 0 | ROCR_VISIBLE_DEVICES for vllm |
+| GDS_SLAB_DATA | (unset) | Host mount point for hipFile GDS L1 slab NVMe; enables `--gds-l1-backend hipfile` when set |
+| NVME_DATA | /mnt/lmcache-nvme | Host path for L2a NVMe (AIS_MT) |
+| NFS_DATA | /mnt/lmcache-nfs | Host path for L2b NFS-over-RDMA |
+| LMCACHE_PORT | 6555 | ZMQ port between containers |
+| LMCACHE_L1_SIZE_GB | 20 | L1 GPU/CPU memory cap (GiB) |
+| LMCACHE_NVME_POOL | 4096 | NIXL pool slots for NVMe adapter |
+| LMCACHE_NVME_SLOT_SIZE | 268435456 | Bytes per NVMe pool slot (AIS_MT backend_params.file_size) |
+| LMCACHE_NFS_POOL | 1024 | NIXL pool slots for NFS adapter |
+| VLLM_MODEL | openai/gpt-oss-120b | Model to serve |
+| TENSOR_PARALLEL_SIZE | 1 | vLLM tensor parallelism |
+| VLM_GPU_MEMORY_UTILIZATION | 0.90 | vLLM GPU memory fraction |
+| VLM_MAX_MODEL_LEN | 32768 | vLLM max context length |
+
+Example with tuned L1 and reduced NVMe pool for a 16 GiB GPU:
+
+```bash
+LMCACHE_L1_SIZE_GB=8 \
+LMCACHE_NVME_POOL=2048 \
+VLM_GPU_MEMORY_UTILIZATION=0.85 \
+make -C recipies/vllm-lmcache-mp up-batch
+```
+
+## hipFile AIS stats
+
+The lmcache container has `ais-stats` on PATH:
+
+```bash
+docker exec -it vllm-lmcache-mp-lmcache bash -lc \
+  'ais-stats -p $(pgrep -f lmcache | head -1) -i'
+```
+
+## Build arguments
+
+| ARG | Default |
+| --- | ------- |
+| `ROCM_ARCH` | (required) |
+| `LMCACHE_GIT_URL` | `https://github.com/amd-ivaganev/LMCache.git` |
+| `LMCACHE_GIT_REF` | `hipfile-for-mp` |
+| `LMCACHE_SHA` | (empty = branch head) |
+| `HIPFILE_SHA` | pinned in Dockerfile |
+| `NIXL_GIT_URL` | `https://github.com/sbates130272/nixl.git` (feat/amd-ais-mt) |
+| `NIXL_SHA` | `9d14642` (feat/amd-ais-mt HEAD; pinned in Dockerfile + Makefile) |
+
+## Compare to other recipes
+
+| Recipe | LMCache mode | Storage |
+| ------ | ------------ | ------- |
+| `vllm-lmcache-hipfile` | in-process | hipFile AIS NVMe |
+| `vllm-lmcache-nixl` | in-process | NIXL AIS_MT NVMe or POSIX |
+| **`vllm-lmcache-mp`** | **separate container (MP/ZMQ)** | **L1 GPU/CPU + AIS_MT NVMe + POSIX NFS-over-RDMA** |

--- a/recipies/vllm-lmcache-mp/docker-compose.gds-l1.yml
+++ b/recipies/vllm-lmcache-mp/docker-compose.gds-l1.yml
@@ -1,0 +1,39 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Compose override: GDS/hipFile L1 mode (no L2 adapters).
+#
+# Use with:
+#   make up-gds-l1  /  make up-gds-l1-batch
+#
+# Overrides the lmcache service to use a hipFile NVMe slab as L1
+# instead of GPU/CPU DRAM.  --l1-size-gb sizes the slab.
+# L2 adapters are not compatible with this mode.
+#
+# Required additional env:
+#   GDS_SLAB_DATA — host path for the hipFile slab file (e.g. /mnt/lmcache-nvme)
+
+services:
+  lmcache:
+    volumes:
+      - ${GDS_SLAB_DATA:?GDS_SLAB_DATA must be set for GDS L1 mode}:/data/slab
+      # Kernel interfaces required for hipFile KFD GPUDirect fastpath
+      - /lib/modules:/lib/modules:ro
+      - /usr/src:/usr/src:ro
+      - /sys/kernel/debug:/sys/kernel/debug
+      - /sys/kernel/btf:/sys/kernel/btf:ro
+      - /boot:/boot:ro
+    environment:
+      - GDS_SLAB_DATA=${GDS_SLAB_DATA}
+      - HIPFILE_ALLOW_COMPAT_MODE=false
+      - HIPFILE_UNSUPPORTED_FILE_SYSTEMS=true
+    command:
+      - |
+        exec lmcache server \
+          --host 0.0.0.0 \
+          --port "$$LMCACHE_PORT" \
+          --l1-size-gb "$$LMCACHE_L1_SIZE_GB" \
+          --eviction-policy LRU \
+          --gds-l1-path /data/slab \
+          --gds-l1-backend hipfile

--- a/recipies/vllm-lmcache-mp/docker-compose.yml
+++ b/recipies/vllm-lmcache-mp/docker-compose.yml
@@ -1,0 +1,162 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# vllm-lmcache-mp: two-container recipe.
+#
+#   lmcache — standalone lmcache-server (MP mode)
+#               L1: GPU/CPU memory (--l1-size-gb)
+#               L2a: nixl_store AIS_MT → local NVMe at NVME_DATA (hipFile P2PDMA)
+#               L2b: nixl_store POSIX  → NFS-over-RDMA (host pre-mounted)
+#
+#   vllm    — vllm serve with LMCacheMPConnector
+#               connects to lmcache:${LMCACHE_PORT:-6555} over ZMQ
+#
+# Required env (shell or .env file):
+#   ROCM_ARCH      — e.g. gfx942
+#   HF_TOKEN       — HuggingFace access token
+#   NVME_DATA      — host path to local NVMe mount (L2a AIS_MT pool; e.g. /mnt/lmcache-nvme)
+#   NFS_DATA       — host path to NFS-over-RDMA mount (L2b)
+#
+# Optional:
+#   GPU                — ROCR_VISIBLE_DEVICES for vllm (default: 0)
+#   HF_HOME            — host HF cache dir (default: ~/.cache/huggingface)
+#   LOG                — host log dir (default: ./logs)
+#   VLLM_MODEL         — model to serve
+#   LMCACHE_PORT       — lmcache ZMQ listen port (default: 6555)
+#   LMCACHE_L1_SIZE_GB — L1 GPU/CPU memory cap in GiB (default: 20)
+#   LMCACHE_NVME_POOL      — nixl pool slots for NVMe adapter (default: 4096)
+#   LMCACHE_NVME_SLOT_SIZE — nixl file size per slot for NVMe adapter in bytes (default: 256 MiB)
+#   LMCACHE_NFS_POOL       — nixl pool slots for NFS adapter (default: 1024)
+#   VLM_GPU_MEMORY_UTILIZATION — vllm --gpu-memory-utilization (default: 0.90)
+#   VLM_MAX_MODEL_LEN          — vllm --max-model-len (default: 32768)
+
+services:
+
+  # ---------------------------------------------------------------------------
+  # lmcache: standalone LMCache server in MP mode
+  # ---------------------------------------------------------------------------
+  lmcache:
+    build:
+      context: ../..
+      dockerfile: recipies/vllm-lmcache-mp/Dockerfile
+      args:
+        ROCM_ARCH: ${ROCM_ARCH}
+    image: vllm-lmcache-mp
+    container_name: vllm-lmcache-mp-lmcache
+    ports:
+      - "8080:8080"   # lmcache HTTP API + /metrics
+    networks:
+      - lmcache-net
+    ipc: host
+    cap_add:
+      - CAP_SYS_ADMIN
+      - SYS_PTRACE
+      - IPC_LOCK
+    security_opt:
+      - seccomp:unconfined
+    ulimits:
+      # NIXL opens one FD per pool slot at init; keep above pool sizes.
+      nofile:
+        soft: 1048576
+        hard: 1048576
+    devices:
+      - /dev/kfd
+      - /dev/dri
+    volumes:
+      # L2a NVMe — AIS_MT pool files written here
+      - ${NVME_DATA:-/mnt/lmcache-nvme}:/data/nvme
+      # L2b NFS — POSIX pool files written here
+      - ${NFS_DATA:-/mnt/lmcache-nfs}:/data/nfs
+      - ${LOG:-./logs}/lmcache:/var/log/vllm-lmcache-mp-lmcache
+    environment:
+      - LMCACHE_PORT=${LMCACHE_PORT:-6555}
+      - LMCACHE_L1_SIZE_GB=${LMCACHE_L1_SIZE_GB:-20}
+      - PYTHONHASHSEED=0
+      - TZ=${TZ:-America/Edmonton}
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        exec lmcache server \
+          --host 0.0.0.0 \
+          --port "$$LMCACHE_PORT" \
+          --l1-size-gb "$$LMCACHE_L1_SIZE_GB" \
+          --eviction-policy LRU \
+          --l2-adapter "{\"type\":\"nixl_store\",\"backend\":\"AIS_MT\",\"backend_params\":{\"file_path\":\"/data/nvme/lmcache\",\"use_direct_io\":\"true\",\"file_size\":${LMCACHE_NVME_SLOT_SIZE:-268435456}},\"pool_size\":${LMCACHE_NVME_POOL:-4096}}" \
+          --l2-adapter "{\"type\":\"nixl_store\",\"backend\":\"POSIX\",\"backend_params\":{\"file_path\":\"/data/nfs/lmcache\"},\"pool_size\":${LMCACHE_NFS_POOL:-1024}}"
+    healthcheck:
+      test:
+        - CMD
+        - python3
+        - -c
+        - "import os, socket; port=int(os.getenv('LMCACHE_PORT','6555')); s=socket.create_connection(('127.0.0.1', port), 2); s.close()"
+      interval: 10s
+      timeout: 5s
+      retries: 18
+      start_period: 30s
+
+  # ---------------------------------------------------------------------------
+  # vllm: vLLM serve with LMCacheMPConnector
+  # ---------------------------------------------------------------------------
+  vllm:
+    image: vllm-lmcache-mp
+    container_name: vllm-lmcache-mp-vllm-gpu${GPU:-0}
+    ports:
+      - "8000:8000"   # vLLM OpenAI API + /metrics
+    networks:
+      - lmcache-net
+    ipc: host
+    cap_add:
+      - CAP_SYS_ADMIN
+      - SYS_PTRACE
+    security_opt:
+      - seccomp:unconfined
+    devices:
+      - /dev/kfd
+      - /dev/dri
+    volumes:
+      - ${HF_HOME:-~/.cache/huggingface}:/hf
+      - ${LOG:-./logs}/vllm:/var/log/vllm-lmcache-mp-vllm
+    environment:
+      - HF_TOKEN=${HF_TOKEN}
+      - HF_HOME=/hf
+      - HF_HUB_CACHE=/hf/hub
+      - HF_DATASETS_CACHE=/hf/datasets
+      - VLLM_CACHE_ROOT=/hf/vllm
+      - VLLM_CONFIG_ROOT=/hf/vllm_config
+      - TORCH_HOME=/hf/torch
+      - TORCHINDUCTOR_CACHE_DIR=/hf/torch_inductor
+      - ROCR_VISIBLE_DEVICES=${GPU:-0}
+      - AMDGCN_USE_BUFFER_OPS=0
+      - MIOPEN_FIND_MODE=FAST
+      - MIOPEN_USER_DB_PATH=/app/miopen
+      - PYTORCH_ALLOC_CONF=${PYTORCH_ALLOC_CONF:-expandable_segments:False}
+      - PYTHONHASHSEED=0
+      - TZ=${TZ:-America/Edmonton}
+    # vllm serve — LMCacheMPConnector reaches lmcache over ZMQ on the
+    # shared docker network using the service hostname "lmcache".
+    command: >
+      --model ${VLLM_MODEL:-openai/gpt-oss-120b}
+        --host 0.0.0.0
+        --port 8000
+        --tensor-parallel-size ${TENSOR_PARALLEL_SIZE:-1}
+        --gpu-memory-utilization ${VLM_GPU_MEMORY_UTILIZATION:-0.90}
+        --max-model-len ${VLM_MAX_MODEL_LEN:-32768}
+        --max-num-batched-tokens ${VLM_MAX_NUM_BATCHED_TOKENS:-4096}
+        --block-size 64
+        --enable-prefix-caching
+        --kv-cache-dtype fp8
+        --stream-interval 20
+        --async-scheduling
+        --enforce-eager
+        --disable-uvicorn-access-log
+        --enable-mfu-metrics
+        --kv-transfer-config '{"kv_connector":"LMCacheMPConnector","kv_role":"kv_both","kv_connector_extra_config":{"lmcache.mp.host":"tcp://lmcache","lmcache.mp.port":${LMCACHE_PORT:-6555}}}'
+    depends_on:
+      lmcache:
+        condition: service_healthy
+
+networks:
+  lmcache-net:
+    driver: bridge
+

--- a/recipies/vllm-lmcache-mp/patches/lmcache-hipfile-mp.patch
+++ b/recipies/vllm-lmcache-mp/patches/lmcache-hipfile-mp.patch
@@ -1,0 +1,163 @@
+From bf164b9424ddd862356db720c563807341d324e9 Mon Sep 17 00:00:00 2001
+From: Stephen Bates <sbates@raithlin.com>
+Date: Tue, 30 Jun 2026 13:19:52 -0600
+Subject: [PATCH] Fix hipFile driver not opened before slab handle register; add Prometheus metrics
+
+hipFileHandleRegister() requires the hipFile driver to already be open
+(via hipFileDriverOpen / Driver().open()).  In the MP mode path the
+driver was opened lazily inside register_stream(), which runs *after*
+_open_and_register_slab() completes.  Registering the slab handle while
+the driver is closed leaves an inconsistent internal state that causes a
+segfault on the first async DMA (hipFileReadAsync / hipFileWriteAsync).
+
+Fix: call ca._ensure_driver_open() inside _open_and_register_slab()
+before hipFileHandleRegister() so the driver is always open first.
+_ensure_driver_open() is idempotent so the subsequent call inside
+register_stream() is harmless.
+
+Also adds Prometheus gauges for GDS L1 slab utilisation and DMA byte
+counters (NVMe->GPU reads, GPU->NVMe writes).
+
+---
+ lmcache/v1/distributed/l1_manager.py    | 54 +++++++++++++++++--------
+ lmcache/v1/gpu_connector/gds_context.py | 35 ++++++++++++++++
+ 2 files changed, 73 insertions(+), 16 deletions(-)
+
+diff --git a/lmcache/v1/distributed/l1_manager.py b/lmcache/v1/distributed/l1_manager.py
+index 64ae54c..0fca645 100644
+--- a/lmcache/v1/distributed/l1_manager.py
++++ b/lmcache/v1/distributed/l1_manager.py
+@@ -208,22 +208,44 @@ class L1Manager:
+         L1Manager._gauge_target = self
+         if not L1Manager._gauge_registered:
+             L1Manager._gauge_registered = True
+-            register_gauge(
+-                "lmcache.l1_manager",
+-                "lmcache_mp.l1_memory_usage_bytes",
+-                "Bytes currently held in L1 cache",
+-                lambda: (
+-                    L1Manager._gauge_target.get_memory_usage()[0]
+-                    if L1Manager._gauge_target is not None
+-                    else 0
+-                ),
+-            )
+-            register_gauge(
+-                "lmcache.l1_manager",
+-                "lmcache_mp.l1_usage_ratio",
+-                "L1 used/total ratio (0.0–1.0)",
+-                lambda: _l1_usage_ratio_or_zero(L1Manager._gauge_target),
+-            )
++            if config.gds_l1_config is not None:
++                register_gauge(
++                    "lmcache.l1_manager",
++                    "lmcache_mp.gds_l1_slab_used_bytes",
++                    "Bytes currently allocated in the GDS NVMe slab",
++                    lambda: (
++                        L1Manager._gauge_target.get_memory_usage()[0]
++                        if L1Manager._gauge_target is not None
++                        else 0
++                    ),
++                )
++                register_gauge(
++                    "lmcache.l1_manager",
++                    "lmcache_mp.gds_l1_slab_total_bytes",
++                    "Total GDS NVMe slab capacity in bytes",
++                    lambda: (
++                        L1Manager._gauge_target.get_memory_usage()[1]
++                        if L1Manager._gauge_target is not None
++                        else 0
++                    ),
++                )
++            else:
++                register_gauge(
++                    "lmcache.l1_manager",
++                    "lmcache_mp.l1_memory_usage_bytes",
++                    "Bytes currently held in L1 cache",
++                    lambda: (
++                        L1Manager._gauge_target.get_memory_usage()[0]
++                        if L1Manager._gauge_target is not None
++                        else 0
++                    ),
++                )
++                register_gauge(
++                    "lmcache.l1_manager",
++                    "lmcache_mp.l1_usage_ratio",
++                    "L1 used/total ratio (0.0-1.0)",
++                    lambda: _l1_usage_ratio_or_zero(L1Manager._gauge_target),
++                )
+
+     def register_listener(self, listener: L1ManagerListener) -> None:
+         """Register a listener for L1Manager events.
+diff --git a/lmcache/v1/gpu_connector/gds_context.py b/lmcache/v1/gpu_connector/gds_context.py
+index 2182623..f3c8d1e 100644
+--- a/lmcache/v1/gpu_connector/gds_context.py
++++ b/lmcache/v1/gpu_connector/gds_context.py
+@@ -32,6 +32,12 @@ from lmcache import torch_dev
+ from lmcache.logging import init_logger
+ from lmcache.v1.distributed.config import GdsL1Config
+ from lmcache.v1.memory_management import GDSMemoryObject
++from lmcache.v1.mp_observability.otel_init import register_gauge
++
++# Module-level DMA byte counters -- incremented in transfer_async(), read by gauges.
++_gds_bytes_read: int = 0
++_gds_bytes_written: int = 0
++_gds_counter_lock = threading.Lock()
+
+ logger = init_logger(__name__)
+
+@@ -133,6 +139,19 @@ class GDSContext:
+         self._open_and_register_slab(config.use_direct_io)
+         self.initialized = True
+
++        register_gauge(
++            "lmcache.gds",
++            "lmcache_mp.gds_l1_bytes_read",
++            "Total bytes transferred NVMe->GPU via hipFile DMA (monotonically increasing)",
++            lambda: _gds_bytes_read,
++        )
++        register_gauge(
++            "lmcache.gds",
++            "lmcache_mp.gds_l1_bytes_written",
++            "Total bytes transferred GPU->NVMe via hipFile DMA (monotonically increasing)",
++            lambda: _gds_bytes_written,
++        )
++
+     # --- Public API ---------------------------------------------------
+
+     def register_gpu_buffer(self, buffer: torch.Tensor) -> None:
+@@ -210,6 +229,7 @@ class GDSContext:
+                 ``get_size()`` bytes are transferred.
+             direction: :attr:`SlabDirection.READ` or ``.WRITE``.
+         """
++        global _gds_bytes_read, _gds_bytes_written
+         slab_op = (
+             self._slab_read if direction is SlabDirection.READ else self._slab_write
+         )
+@@ -221,6 +241,11 @@ class GDSContext:
+             seg_len = min(nbytes - pos, region_nbytes - dev_offset)
+             slab_op(memory_obj.slab_offset + pos, seg_len, dev_offset, base_ptr)
+             pos += seg_len
++        with _gds_counter_lock:
++            if direction is SlabDirection.READ:
++                _gds_bytes_read += nbytes
++            else:
++                _gds_bytes_written += nbytes
+
+     def close(self) -> None:
+@@ -260,6 +285,14 @@ class GDSContext:
+             use_direct_io: Open with ``O_DIRECT`` (required for the GDS fast path).
+         """
+         ca = self._ca
++        # hipFile requires the driver to be open before any handle can be
++        # registered.  The driver is normally opened lazily in register_stream(),
++        # but that runs after _open_and_register_slab() returns.  Open it here
++        # so hipFileHandleRegister() always finds an initialised driver.
++        # _ensure_driver_open() is idempotent so the later call in
++        # register_stream() is harmless.
++        if self._backend == "hipfile":
++            ca._ensure_driver_open()
+         # Create, truncate, and fallocate via a regular (non-O_DIRECT) fd.
+         creator_fd = os.open(
+             self._slab_path, os.O_CREAT | os.O_RDWR | os.O_TRUNC, 0o644
+--
+2.43.0

--- a/recipies/vllm-lmcache-mp/patches/lmcache-nixl-ais-mt-l2-adapter.patch
+++ b/recipies/vllm-lmcache-mp/patches/lmcache-nixl-ais-mt-l2-adapter.patch
@@ -1,0 +1,106 @@
+diff --git a/lmcache/v1/distributed/l2_adapters/nixl_store_l2_adapter.py b/lmcache/v1/distributed/l2_adapters/nixl_store_l2_adapter.py
+index 41a54be3..6bcde845 100644
+--- a/lmcache/v1/distributed/l2_adapters/nixl_store_l2_adapter.py
++++ b/lmcache/v1/distributed/l2_adapters/nixl_store_l2_adapter.py
+@@ -170,30 +170,37 @@ class NixlStorageAgent:
+         self.device = device
+         self.backend_params = backend_params
+ 
+-        self.l1_align_bytes = l1_memory_desc.align_bytes
++        # l1_memory_desc is None when GDS L1 is active (NVMe slab mode).
++        # Derive align_bytes from backend_params["file_size"]; skip L1 buffer
++        # registration since there is no pinned DRAM pool in that mode.
++        if l1_memory_desc is not None:
++            self.l1_align_bytes = l1_memory_desc.align_bytes
++        else:
++            self.l1_align_bytes = int(backend_params["file_size"])
+ 
+         self.agent_name = "NixlAgent_" + str(uuid.uuid4())
+         nixl_conf = NixlAgentConfig(backends=[])
+         self.nixl_agent = NixlAgent(self.agent_name, nixl_conf)
+         self.nixl_agent.create_backend(backend, backend_params)
+ 
+-        self.init_mem_handlers(
+-            self.device,
+-            l1_memory_desc.ptr,
+-            l1_memory_desc.size,
+-            l1_memory_desc.align_bytes,
+-            device_id=0,  # 0 indicates cpu
+-        )
++        if l1_memory_desc is not None:
++            self.init_mem_handlers(
++                self.device,
++                l1_memory_desc.ptr,
++                l1_memory_desc.size,
++                l1_memory_desc.align_bytes,
++                device_id=0,  # 0 indicates cpu
++            )
+ 
+-        if self.backend in ["GDS", "GDS_MT", "POSIX", "HF3FS"]:
++        if self.backend in ["GDS", "GDS_MT", "POSIX", "HF3FS", "AIS_MT"]:
+             file_size = int(
+-                self.backend_params.get("file_size", l1_memory_desc.align_bytes)
++                self.backend_params.get("file_size", self.l1_align_bytes)
+             )
+-            pages_per_file = file_size // l1_memory_desc.align_bytes
++            pages_per_file = file_size // self.l1_align_bytes
+             self.pool = NixlObjPool(num_total_objs=self.pool_size * pages_per_file)
+             self.init_storage_handlers_file(
+                 num_files=self.pool_size,
+-                page_size=l1_memory_desc.align_bytes,
++                page_size=self.l1_align_bytes,
+                 file_size=file_size,
+                 file_path=self.backend_params["file_path"],
+                 # TODO(Jiayi): Need to make argument parsing more elegant
+@@ -203,7 +210,7 @@ class NixlStorageAgent:
+         elif self.backend in ["OBJ", "AZURE_BLOB"]:
+             self.pool = NixlObjPool(num_total_objs=self.pool_size)
+             self.init_storage_handlers_object(
+-                page_size=l1_memory_desc.align_bytes,
++                page_size=self.l1_align_bytes,
+                 num_pages=self.pool_size,
+             )
+         else:
+@@ -443,8 +450,13 @@ class NixlStoreL2Adapter(L2AdapterInterface):
+             pool_size=config.pool_size,
+             l1_memory_desc=l1_memory_desc,
+         )
++        align_bytes = (
++            l1_memory_desc.align_bytes
++            if l1_memory_desc is not None
++            else self.nixl_agent.l1_align_bytes
++        )
+         max_capacity_bytes = (
+-            self.nixl_agent.pool.total_objs * l1_memory_desc.align_bytes
++            self.nixl_agent.pool.total_objs * align_bytes
+         )
+         super().__init__(max_capacity_bytes=max_capacity_bytes)
+         self._config = config
+@@ -905,11 +917,12 @@ _VALID_NIXL_BACKENDS = (
+     "GDS",
+     "GDS_MT",
+     "POSIX",
++    "AIS_MT",
+     "HF3FS",
+     "OBJ",
+     "AZURE_BLOB",
+ )
+-_FILE_BACKENDS = ("GDS", "GDS_MT", "POSIX", "HF3FS")
++_FILE_BACKENDS = ("GDS", "GDS_MT", "POSIX", "HF3FS", "AIS_MT")
+ 
+ 
+ class NixlStoreL2AdapterConfig(L2AdapterConfigBase):
+@@ -1004,7 +1017,12 @@ def _create_nixl_store_adapter(
+ ) -> L2AdapterInterface:
+     """Create a NixlStoreL2Adapter from config."""
+     if l1_memory_desc is None:
+-        raise ValueError("l1_memory_desc is required to create a NixlStoreL2Adapter.")
++        bp = getattr(config, "backend_params", {})
++        if "file_size" not in bp:
++            raise ValueError(
++                "l1_memory_desc is None (GDS L1 mode): backend_params must "
++                "include 'file_size' so the nixl_store adapter can size its pool."
++            )
+     return NixlStoreL2Adapter(config, l1_memory_desc)  # type: ignore[arg-type]
+ 
+ 


### PR DESCRIPTION
Adds a new `vllm-lmcache-mp` recipe that deploys ROCm vLLM and a standalone LMCache server as two independent Docker containers communicating over ZMQ in MP (multi-protocol) mode. The LMCache container survives vLLM restarts, preserving warm KV state across inference engine lifecycle events.

## Storage tiers

| Tier | Backend | Transport |
|------|---------|-----------|
| L1 (default) | GPU / CPU memory | in-process (LMCache managed) |
| L1 (opt-in, GDS) | hipFile GDS slab | hipFile P2PDMA to dedicated NVMe |
| L2a (NVMe) | nixl_store AIS_MT | hipFile GPU-direct, multi-threaded, to local NVMe |
| L2b (NFS) | nixl_store POSIX | NFS-over-RDMA via host kernel NFS client |

## Key changes

**NIXL AIS_MT NVMe L2 adapter** (`lmcache-nixl-ais-mt-l2-adapter.patch`):
- Registers `AIS_MT` as a valid NIXL file-based backend in `nixl_store`
- Null-safe `NixlStorageAgent.__init__`: derives `l1_align_bytes` from `backend_params["file_size"]` and skips `init_mem_handlers` when `l1_memory_desc` is `None` (GDS L1 mode)
- Relaxes the `_create_nixl_store_adapter` `None` guard to allow absent `l1_memory_desc` when `file_size` is present in `backend_params`

**GDS L1 compose override** (`docker-compose.gds-l1.yml`):
- Activates the hipFile P2PDMA GDS slab L1 path (no L2 offload) via a compose overlay
- Adds `up-gds-l1` and `up-gds-l1-batch` Makefile targets so the GDS L1 mode can be selected at launch without editing any files

**Infrastructure:**
- Uses a fork of NIXL (`sbates130272/nixl @ feat/amd-ais-mt`) that adds the `AIS_MT` plugin
- Includes Weka vendor files for NFS-over-RDMA cluster setup (Ansible roles + helper scripts)

## Usage

```bash
export ROCM_ARCH=gfx942
export HF_TOKEN=hf_...
export NVME_DATA=/mnt/lmcache-nvme   # NVMe L2
export NFS_DATA=/mnt/lmcache-nfs     # NFS L2
make up          # DRAM L1 + NVMe/NFS L2
make up-gds-l1   # GDS slab L1, no L2
```