### PR TITLE
aai-day-release: add SPUR cluster support + long-ISL YaRN cliff targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,7 @@ data/agentx/
 .slurm/logs/
 .slurm/reports/
 
+# spur output files
+spur-*.out
+rdma-test-*.out
+rdma-test-*.err

--- a/aai-day-release/.slurm/run-build-distribute.sh
+++ b/aai-day-release/.slurm/run-build-distribute.sh
@@ -125,6 +125,19 @@
 #   AAI_SMOKE_SCRAPE_S   test: seconds to let Prometheus scrape before the health
 #                        check / TSDB summary                       (default: 45)
 #
+#   AAI_SPUR_CLUSTER     set to 1 when running on a SPUR-based Slurm controller.
+#                        SPUR's sbatch does not support --parsable, --wait, or
+#                        --overcommit.  When set, _sbatch_run writes the job script to
+#                        a temp file (SPUR requires a file, not stdin), submits without
+#                        those flags, parses the job id from "Submitted batch job NNNN",
+#                        and polls squeue until the job leaves the queue.  cmd_load and
+#                        cmd_push also drop --overcommit from their srun calls.
+#                        (default: 0)
+#   AAI_SPUR_CONTROLLER  SPUR controller address passed as --controller to every
+#                        sbatch/srun/squeue call when AAI_SPUR_CLUSTER=1.
+#                        (default: $SPUR_CONTROLLER_ADDR if set, else
+#                         http://crs-m2m-cpu-spur-005.crusoe.amd.com:6817)
+#
 #   AAI_TLS_CERT         corporate CA cert (BuildKit secret, never baked into image)
 #                        (default: $HOME/certs/zscaler-ca.crt if it exists; else none)
 #   AAI_COMPRESS         zstd | gzip | none                (default: zstd if available,
@@ -147,8 +160,23 @@ AAI_DAY_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 AAI_ROCM_ARCH="${AAI_ROCM_ARCH:-gfx90a;gfx942;gfx950;gfx1100;gfx1101;gfx1150;gfx1151;gfx1200;gfx1201}"
 AAI_IMAGE="${AAI_IMAGE:-rocm-aic-aai-day:latest}"
 AAI_IMAGE_DIR="${AAI_IMAGE_DIR:-/scratch/${USER}/images}"
-AAI_BUILD_PARTITION="${AAI_BUILD_PARTITION:-defq}"
-AAI_BUILD_CONSTRAINT="${AAI_BUILD_CONSTRAINT:-MARKHAM&CPUONLY}"
+AAI_SPUR_CLUSTER="${AAI_SPUR_CLUSTER:-0}"
+AAI_SPUR_CONTROLLER="${AAI_SPUR_CONTROLLER:-${SPUR_CONTROLLER_ADDR:-http://crs-m2m-cpu-spur-005.crusoe.amd.com:6817}}"
+
+# When running on SPUR, default the partition to amd-spur (the only partition)
+# and clear the build/test constraints (SPUR nodes have no MARKHAM/CPUONLY/GFX942
+# feature labels; node selection is done by partition or explicit --nodelist).
+if [[ "${AAI_SPUR_CLUSTER}" == "1" ]]; then
+    AAI_BUILD_PARTITION="${AAI_BUILD_PARTITION:-amd-spur}"
+    # Use ${VAR-default} (not ${VAR:-default}) so an explicitly set empty string
+    # ("AAI_BUILD_CONSTRAINT=") is honoured as "no constraint".
+    AAI_BUILD_CONSTRAINT="${AAI_BUILD_CONSTRAINT-}"
+    AAI_TEST_CONSTRAINT="${AAI_TEST_CONSTRAINT-}"
+else
+    AAI_BUILD_PARTITION="${AAI_BUILD_PARTITION:-defq}"
+    AAI_BUILD_CONSTRAINT="${AAI_BUILD_CONSTRAINT:-MARKHAM&CPUONLY}"
+    AAI_TEST_CONSTRAINT="${AAI_TEST_CONSTRAINT:-MARKHAM&GFX942&NVME}"
+fi
 AAI_BUILD_CPUS="${AAI_BUILD_CPUS:-32}"
 AAI_BUILD_TIME="${AAI_BUILD_TIME:-02:00:00}"
 AAI_LOAD_TIME="${AAI_LOAD_TIME:-00:30:00}"
@@ -159,7 +187,6 @@ AAI_CACHE_REF="${AAI_CACHE_REF:-}"
 AAI_CACHE_MODE="${AAI_CACHE_MODE:-max}"
 AAI_BUILDX_BUILDER="${AAI_BUILDX_BUILDER:-aai-cache}"
 AAI_CACHE_INSECURE="${AAI_CACHE_INSECURE:-}"
-AAI_TEST_CONSTRAINT="${AAI_TEST_CONSTRAINT:-MARKHAM&GFX942&NVME}"
 AAI_TEST_TIME="${AAI_TEST_TIME:-00:20:00}"
 AAI_TEST_CPUS="${AAI_TEST_CPUS:-8}"
 AAI_TEST_MEM="${AAI_TEST_MEM:-32G}"
@@ -239,12 +266,11 @@ _sbatch_run() {
     local jobname="$1" logname="$2" body="$3"; shift 3
     command -v sbatch >/dev/null 2>&1 || die "sbatch not found; set AAI_BUILD_LOCAL=1 to build here"
 
-    # Batch script = shebang (sbatch requires one) + a prologue that creates the
-    # per-job log dir and redirects everything into <logname>.out, then the
-    # caller's body.  AAI_DAY_DIR is absolute and on shared storage, so it
-    # resolves on the compute node without relying on SLURM_SUBMIT_DIR.  Slurm's
-    # own --output is /dev/null, so only the pre-redirect lines (none here) would
-    # be discarded -- mirrors run-cliff.sbatch.
+    # Batch script = shebang + a prologue that creates the per-job log dir and
+    # redirects everything into <logname>.out, then the caller's body.
+    # AAI_DAY_DIR is absolute and on shared storage, so it resolves on the
+    # compute node without relying on SLURM_SUBMIT_DIR.  --output=/dev/null
+    # discards any pre-redirect output (there is none here).
     local script
     script="$(cat <<PROLOGUE
 #!/bin/bash
@@ -254,50 +280,102 @@ PROLOGUE
 )"
     script+=$'\n'"${body}"
 
-    # Submit in the background so we can read the (parsable) job id as soon as it
-    # is printed, report the log path, and live-tail while --wait blocks the
-    # client until the job ends.  stdbuf -oL forces the id line to flush to the
-    # temp file at once (stdout to a file is otherwise fully buffered).
-    local idfile; idfile="$(mktemp)"
-    local -a _stdbuf=(); command -v stdbuf >/dev/null 2>&1 && _stdbuf=(stdbuf -oL)
-    "${_stdbuf[@]}" sbatch --parsable --wait \
-        --job-name="${jobname}" \
-        --partition="${AAI_BUILD_PARTITION}" \
-        --output=/dev/null \
-        "$@" \
-        <<<"${script}" >"${idfile}" &
-    local sb_pid=$!
+    local jobid="" logfile="" rc=0
 
-    # Wait briefly for the parsable job id to land in the temp file.
-    local jobid="" tries=0
-    while [[ ! -s "${idfile}" ]] && kill -0 "${sb_pid}" 2>/dev/null && (( tries < 150 )); do
-        sleep 0.2; tries=$((tries + 1))
-    done
-    jobid="$(head -n1 "${idfile}" 2>/dev/null | tr -d '[:space:]' | cut -d';' -f1)"
+    if [[ "${AAI_SPUR_CLUSTER}" == "1" ]]; then
+        # SPUR sbatch does not support --parsable, --wait, or reading the script
+        # from stdin.  Write the script to a temp file, submit without those
+        # flags, parse "Submitted batch job NNNN" from stdout, then poll squeue
+        # until the job is no longer in the queue.
+        local tmpscript; tmpscript="$(mktemp --suffix=.sh)"
+        printf '%s\n' "${script}" > "${tmpscript}"
+        chmod +x "${tmpscript}"
 
-    local logfile="${AAI_DAY_DIR}/logs/${jobid:-unknown}/${logname}.out"
-    if [[ -n "${jobid}" ]]; then
+        local submit_out
+        submit_out="$(sbatch \
+            --controller="${AAI_SPUR_CONTROLLER}" \
+            --job-name="${jobname}" \
+            --partition="${AAI_BUILD_PARTITION}" \
+            --output=/dev/null \
+            "$@" \
+            "${tmpscript}" 2>&1)" || { rm -f "${tmpscript}"; die "sbatch submission failed: ${submit_out}"; }
+        rm -f "${tmpscript}"
+
+        jobid="$(printf '%s\n' "${submit_out}" | grep -oE '[0-9]+$' | tail -1)"
+        [[ -n "${jobid}" ]] || die "could not parse job id from sbatch output: ${submit_out}"
+        logfile="${AAI_DAY_DIR}/logs/${jobid}/${logname}.out"
         log "submitted ${jobname} as job ${jobid} (partition ${AAI_BUILD_PARTITION})"
         log "log: ${logfile}"
-    else
-        log "submitted ${jobname} (job id not yet available; partition ${AAI_BUILD_PARTITION})"
-    fi
 
-    # Follow the job's log live (tail -F retries until the job creates the file).
-    local tail_pid=""
-    if [[ -n "${jobid}" ]]; then
+        # Live-tail the log while polling squeue for job completion.
+        local tail_pid=""
         ( tail -F "${logfile}" 2>/dev/null ) & tail_pid=$!
-    fi
 
-    # Block on the sbatch client; with --wait its exit status IS the job's.
-    local rc=0
-    wait "${sb_pid}" || rc=$?
-    if [[ -n "${tail_pid}" ]]; then
-        sleep 1  # let tail's final poll flush the last lines before we stop it
+        # Wait for the job to appear in the queue before polling for its exit;
+        # a fast scheduler may dequeue it before the first squeue check fires.
+        local appear_tries=0
+        until squeue --controller="${AAI_SPUR_CONTROLLER}" -j "${jobid}" -h 2>/dev/null | grep -q . \
+              || (( appear_tries >= 60 )); do
+            sleep 1; appear_tries=$((appear_tries + 1))
+        done
+        # Poll until the job leaves the queue.
+        while squeue --controller="${AAI_SPUR_CONTROLLER}" -j "${jobid}" -h 2>/dev/null | grep -q .; do
+            sleep 10
+        done
+
+        # Give the log a moment to flush its last lines.
+        sleep 2
         kill "${tail_pid}" >/dev/null 2>&1 || true
         wait "${tail_pid}" 2>/dev/null || true
+
+        # Read the real exit code from sacct ("<code>:<signal>" format).
+        local acct_exit
+        acct_exit="$(sacct --controller="${AAI_SPUR_CONTROLLER}" -j "${jobid}" \
+            --format=ExitCode --noheader 2>/dev/null \
+            | awk 'NR==1{split($1,a,":"); print a[1]}')"
+        rc="${acct_exit:-1}"
+    else
+        # Standard Slurm path: --parsable prints the bare job id; --wait blocks
+        # until the job finishes and exits with the job's exit code.
+        local idfile; idfile="$(mktemp)"
+        local -a _stdbuf=(); command -v stdbuf >/dev/null 2>&1 && _stdbuf=(stdbuf -oL)
+        "${_stdbuf[@]}" sbatch --parsable --wait \
+            --job-name="${jobname}" \
+            --partition="${AAI_BUILD_PARTITION}" \
+            --output=/dev/null \
+            "$@" \
+            <<<"${script}" >"${idfile}" &
+        local sb_pid=$!
+
+        # Wait briefly for the parsable job id to land in the temp file.
+        local tries=0
+        while [[ ! -s "${idfile}" ]] && kill -0 "${sb_pid}" 2>/dev/null && (( tries < 150 )); do
+            sleep 0.2; tries=$((tries + 1))
+        done
+        jobid="$(head -n1 "${idfile}" 2>/dev/null | tr -d '[:space:]' | cut -d';' -f1)"
+
+        logfile="${AAI_DAY_DIR}/logs/${jobid:-unknown}/${logname}.out"
+        if [[ -n "${jobid}" ]]; then
+            log "submitted ${jobname} as job ${jobid} (partition ${AAI_BUILD_PARTITION})"
+            log "log: ${logfile}"
+        else
+            log "submitted ${jobname} (job id not yet available; partition ${AAI_BUILD_PARTITION})"
+        fi
+
+        local tail_pid=""
+        if [[ -n "${jobid}" ]]; then
+            ( tail -F "${logfile}" 2>/dev/null ) & tail_pid=$!
+        fi
+
+        wait "${sb_pid}" || rc=$?
+        if [[ -n "${tail_pid}" ]]; then
+            sleep 1
+            kill "${tail_pid}" >/dev/null 2>&1 || true
+            wait "${tail_pid}" 2>/dev/null || true
+        fi
+        rm -f "${idfile}" 2>/dev/null || true
     fi
-    rm -f "${idfile}" 2>/dev/null || true
+
     return "${rc}"
 }
 
@@ -394,7 +472,7 @@ cd "${AAI_DAY_DIR}"
 ${_builder_setup}
 mkdir -p "${AAI_IMAGE_DIR}"
 tmp="${tarball}.partial.\$\$"
-docker buildx build --builder ${AAI_BUILDX_BUILDER} --output type=docker,dest=- \
+docker buildx build --builder ${AAI_BUILDX_BUILDER} --progress=plain --output type=docker,dest=- \
     --build-arg ROCM_ARCH="${AAI_ROCM_ARCH}" \
     ${_secret_arg} \
     ${_cache_args} \
@@ -442,7 +520,9 @@ REMOTE
             _sel=(--nodelist="${AAI_BUILD_NODE}")
             log "building on ${AAI_BUILD_NODE} via sbatch (partition ${AAI_BUILD_PARTITION})"
         else
-            _sel=(--constraint="${AAI_BUILD_CONSTRAINT}")
+            if [[ -n "${AAI_BUILD_CONSTRAINT:-}" ]]; then
+                _sel=(--constraint="${AAI_BUILD_CONSTRAINT}")
+            fi
             log "building via sbatch (partition ${AAI_BUILD_PARTITION}, constraint ${AAI_BUILD_CONSTRAINT})"
         fi
         _sbatch_run aai-day-build build "${remote_script}" \
@@ -512,13 +592,16 @@ REMOTE
             _sel=(--nodelist="${AAI_BUILD_NODE}")
             log "building exporters on ${AAI_BUILD_NODE} via sbatch (partition ${AAI_BUILD_PARTITION})"
         else
-            _sel=(--constraint="${AAI_BUILD_CONSTRAINT}")
+            if [[ -n "${AAI_BUILD_CONSTRAINT:-}" ]]; then
+                _sel=(--constraint="${AAI_BUILD_CONSTRAINT}")
+            fi
             log "building exporters via sbatch (partition ${AAI_BUILD_PARTITION}, constraint ${AAI_BUILD_CONSTRAINT})"
         fi
+        local -a _exp_overcommit=(); [[ "${AAI_SPUR_CLUSTER}" != "1" ]] && _exp_overcommit=(--overcommit)
         _sbatch_run aai-day-build-exporters build-exporters "${remote_script}" \
             "${_sel[@]}" \
             --nodes=1 --ntasks=1 \
-            --cpus-per-task=2 --mem=8G --overcommit \
+            --cpus-per-task=2 --mem=8G "${_exp_overcommit[@]}" \
             --time="${AAI_LOAD_TIME}"
     fi
     log "exporter build complete: ${nvme_tar}, ${rdma_tar}"
@@ -553,14 +636,17 @@ cmd_load() {
     log "tarball: ${tarball}"
 
     # Small, oversubscribable request so the load can slip in alongside running
-    # GPU jobs -- docker load needs no GPU.  --overcommit/--oversubscribe are
-    # honored only if the partition allows them; harmless otherwise.
+    # GPU jobs -- docker load needs no GPU.  --overcommit is dropped on SPUR
+    # (unsupported); harmless on standard Slurm.
+    local -a _overcommit_arg=(); [[ "${AAI_SPUR_CLUSTER}" != "1" ]] && _overcommit_arg=(--overcommit)
+    local -a _spur_ctl_arg=(); [[ "${AAI_SPUR_CLUSTER}" == "1" ]] && _spur_ctl_arg=(--controller="${AAI_SPUR_CONTROLLER}")
     srun \
+        "${_spur_ctl_arg[@]}" \
         --job-name=aai-day-load \
         --partition="${AAI_BUILD_PARTITION}" \
         --nodelist="${AAI_TARGETS}" \
         --nodes="${n}" --ntasks-per-node=1 \
-        --cpus-per-task=2 --mem=8G --overcommit \
+        --cpus-per-task=2 --mem=8G "${_overcommit_arg[@]}" \
         --time="${AAI_LOAD_TIME}" \
         bash -c "
 set -euo pipefail
@@ -621,15 +707,20 @@ REMOTE
         _sel=(--nodelist="${AAI_BUILD_NODE}")
         log "pushing from ${AAI_BUILD_NODE} via srun (partition ${AAI_BUILD_PARTITION})"
     else
-        _sel=(--constraint="${AAI_BUILD_CONSTRAINT}")
+        if [[ -n "${AAI_BUILD_CONSTRAINT:-}" ]]; then
+            _sel=(--constraint="${AAI_BUILD_CONSTRAINT}")
+        fi
         log "pushing via srun (partition ${AAI_BUILD_PARTITION}, constraint ${AAI_BUILD_CONSTRAINT})"
     fi
+    local -a _push_overcommit=(); [[ "${AAI_SPUR_CLUSTER}" != "1" ]] && _push_overcommit=(--overcommit)
+    local -a _push_spur_ctl=(); [[ "${AAI_SPUR_CLUSTER}" == "1" ]] && _push_spur_ctl=(--controller="${AAI_SPUR_CONTROLLER}")
     srun \
+        "${_push_spur_ctl[@]}" \
         --job-name=aai-day-push \
         --partition="${AAI_BUILD_PARTITION}" \
         "${_sel[@]}" \
         --nodes=1 --ntasks=1 \
-        --cpus-per-task=2 --mem=8G --overcommit \
+        --cpus-per-task=2 --mem=8G "${_push_overcommit[@]}" \
         --time="${AAI_LOAD_TIME}" \
         bash -c "${remote_script}"
     log "push complete: ${AAI_PUSH_REF}"
@@ -835,9 +926,10 @@ exit \${img_rc}
 REMOTE
 )"
 
+    local -a _gres_arg=(); [[ "${AAI_SPUR_CLUSTER}" != "1" ]] && _gres_arg=(--gres=gpu:1)
     _sbatch_run aai-day-test smoke-test "${remote_script}" \
         "${_sel[@]}" \
-        --gres=gpu:1 \
+        "${_gres_arg[@]}" \
         --nodes=1 --ntasks=1 \
         --cpus-per-task="${AAI_TEST_CPUS}" --mem="${AAI_TEST_MEM}" \
         --time="${AAI_TEST_TIME}"

--- a/aai-day-release/Makefile
+++ b/aai-day-release/Makefile
@@ -98,7 +98,26 @@ PYTHON := $(if $(wildcard $(REPO_ROOT)/.venv/bin/python3),$(REPO_ROOT)/.venv/bin
 # /scratch so a failed build resumes from the last good layer on any node
 # (set AAI_CACHE_DIR= to disable); AAI_BUILD_EXPORTERS=0 skips the fabric images.
 DIST := $(CURDIR)/.slurm/run-build-distribute.sh
-export AAI_CACHE_DIR ?= /scratch/$(USER)/images/buildcache
+
+# ---- SPUR cluster overrides ------------------------------------------------
+# When AAI_SPUR_CLUSTER=1, default storage paths to /shared_nfs (the NFS volume
+# shared across all SPUR compute nodes) instead of /scratch (not present on
+# this cluster), and wire up the known controller address.
+AAI_SPUR_CLUSTER ?= 0
+ifeq ($(AAI_SPUR_CLUSTER),1)
+export AAI_SPUR_CLUSTER
+export AAI_SPUR_CONTROLLER  ?= http://crs-m2m-cpu-spur-005.crusoe.amd.com:6817
+export AAI_IMAGE_DIR        ?= /shared_nfs/$(USER)/images
+export AAI_CACHE_DIR        ?= /shared_nfs/$(USER)/images/buildcache
+# SPUR nodes have 8x NVMe drives combined into a single LVM at /mnt/m2m_nobackup.
+# Use override (not ?=) so these win over the top-level ?= defaults set earlier.
+# HF_HOME points to shared_nfs since /scratch does not exist on this cluster.
+override export NVME_DATA     := /mnt/m2m_nobackup/aai-cliff/nvme
+override export GDS_SLAB_DATA := /mnt/m2m_nobackup/aai-cliff/slab
+override export HF_HOME       := /shared_nfs/$(USER)/hf
+else
+export AAI_CACHE_DIR        ?= /scratch/$(USER)/images/buildcache
+endif
 
 # The cliff sbatch has its own node-appropriate defaults for the HuggingFace
 # cache (staged on /scratch), the LMCache storage tiers (node-local /tmp), and
@@ -111,10 +130,10 @@ export AAI_CACHE_DIR ?= /scratch/$(USER)/images/buildcache
 # Makefile's own defaults ($(origin ...) = "file"); a value the user set on the
 # command line or in their environment is kept and still flows through.
 _CLIFF_STRIP := env \
-    $(if $(filter file,$(origin HF_HOME)),-u HF_HOME) \
-    $(if $(filter file,$(origin NVME_DATA)),-u NVME_DATA) \
+    $(if $(filter 0,$(AAI_SPUR_CLUSTER)),$(if $(filter file,$(origin HF_HOME)),-u HF_HOME)) \
+    $(if $(filter 0,$(AAI_SPUR_CLUSTER)),$(if $(filter file,$(origin NVME_DATA)),-u NVME_DATA)) \
     $(if $(filter file,$(origin NFS_DATA)),-u NFS_DATA) \
-    $(if $(filter file,$(origin GDS_SLAB_DATA)),-u GDS_SLAB_DATA) \
+    $(if $(filter 0,$(AAI_SPUR_CLUSTER)),$(if $(filter file,$(origin GDS_SLAB_DATA)),-u GDS_SLAB_DATA)) \
     $(if $(filter file,$(origin AAI_METRICS_DIR)),-u AAI_METRICS_DIR)
 
 # ---- Export tarball --------------------------------------------------------
@@ -373,11 +392,27 @@ smoke-test:                    # Load + smoke-test the image on a GPU+NVMe node
 # a node with AAI_CLIFF_NODE, narrow arms with AAI_CLIFF_ARMS=nvme (etc), and
 # override the job wall-time with AAI_CLIFF_TIME=HH:MM:SS (e.g. an overnight full
 # sweep).  The job creates logs/<job-id>/ itself and redirects its output there.
+# _CLIFF_SBATCH_ARGS: partition + constraint overrides passed on the sbatch
+# command line (takes precedence over #SBATCH directives in run-cliff.sbatch).
+# On SPUR, override to amd-spur with no constraint and no --gres (no GPU GRES
+# configured); on standard Slurm the script's own #SBATCH lines take effect.
+ifeq ($(AAI_SPUR_CLUSTER),1)
+_CLIFF_SPUR_CTL  := SPUR_CONTROLLER_ADDR=$(AAI_SPUR_CONTROLLER)
+_CLIFF_SBATCH_ARGS := --partition=amd-spur --constraint= \
+    $(if $(AAI_CLIFF_NODE),--nodelist=$(AAI_CLIFF_NODE),)
+# SPUR sbatch does not support --parsable; parse job id from "Submitted batch job N"
+_CLIFF_SUBMIT     = $(_CLIFF_SPUR_CTL) $(_CLIFF_STRIP) sbatch \
+    $(_CLIFF_SBATCH_ARGS) $(1) .slurm/run-cliff.sbatch 2>&1 | \
+    tee /dev/stderr | grep -oE '[0-9]+$$' | tail -1
+else
+_CLIFF_SBATCH_ARGS := $(if $(AAI_CLIFF_NODE),--nodelist=$(AAI_CLIFF_NODE),)
+_CLIFF_SUBMIT     = $(_CLIFF_STRIP) sbatch --parsable \
+    $(_CLIFF_SBATCH_ARGS) $(1) .slurm/run-cliff.sbatch
+endif
+
 cliff-submit:
-	@cd "$(CURDIR)" && jobid=$$($(_CLIFF_STRIP) sbatch --parsable \
-	    $(if $(AAI_CLIFF_NODE),--nodelist=$(AAI_CLIFF_NODE),) \
-	    $(if $(AAI_CLIFF_TIME),--time=$(AAI_CLIFF_TIME),) \
-	    .slurm/run-cliff.sbatch) && \
+	@cd "$(CURDIR)" && jobid=$$($(call _CLIFF_SUBMIT,\
+	    $(if $(AAI_CLIFF_TIME),--time=$(AAI_CLIFF_TIME),))) && \
 	    echo "submitted cliff job $$jobid" && \
 	    echo "log: $(CURDIR)/logs/$$jobid/cliff.out"
 
@@ -385,9 +420,7 @@ cliff-submit:
 # Respects user overrides of BENCH_CONCUR / BENCH_ITERS.
 cliff-short:
 	@cd "$(CURDIR)" && jobid=$$(BENCH_CONCUR="$${BENCH_CONCUR:-1}" BENCH_ITERS="$${BENCH_ITERS:-1}" \
-	    $(_CLIFF_STRIP) sbatch --parsable --job-name=aai-day-cliff-short \
-	    $(if $(AAI_CLIFF_NODE),--nodelist=$(AAI_CLIFF_NODE),) \
-	    .slurm/run-cliff.sbatch) && \
+	    $(call _CLIFF_SUBMIT,--job-name=aai-day-cliff-short)) && \
 	    echo "submitted cliff-short job $$jobid (BENCH_CONCUR=$${BENCH_CONCUR:-1} BENCH_ITERS=$${BENCH_ITERS:-1})" && \
 	    echo "log: $(CURDIR)/logs/$$jobid/cliff.out"
 
@@ -421,10 +454,8 @@ cliff-long-64k:                # sbatch a 64k-ISL YaRN(x2 -> 65536) 3-arm sweep
 	    AAI_LOCAL_CPU="$${AAI_LOCAL_CPU:-true}" LMCACHE_MAX_LOCAL_CPU_SIZE="$${LMCACHE_MAX_LOCAL_CPU_SIZE:-64}" \
 	    LMCACHE_NVME_POOL="$(if $(filter file,$(origin LMCACHE_NVME_POOL)),262144,$(LMCACHE_NVME_POOL))" AAI_NIXL_BUFFER_SIZE="$${AAI_NIXL_BUFFER_SIZE:-8589934592}" \
 	    LMCACHE_L1_SIZE_GB="$(if $(filter file,$(origin LMCACHE_L1_SIZE_GB)),320,$(LMCACHE_L1_SIZE_GB))" \
-	    $(_CLIFF_STRIP) sbatch --parsable --job-name=aai-day-cliff-long64k \
-	    $(if $(AAI_CLIFF_NODE),--nodelist=$(AAI_CLIFF_NODE),) \
-	    --time=$(if $(AAI_CLIFF_TIME),$(AAI_CLIFF_TIME),16:00:00) \
-	    .slurm/run-cliff.sbatch) && \
+	    $(call _CLIFF_SUBMIT,--job-name=aai-day-cliff-long64k \
+	    --time=$(if $(AAI_CLIFF_TIME),$(AAI_CLIFF_TIME),16:00:00))) && \
 	    echo "submitted cliff-long-64k job $$jobid (ISL=64000, YaRN x2 -> 65536, DRAM L1=64G, NVMe pool=262144, all 3 arms)" && \
 	    echo "log: $(CURDIR)/logs/$$jobid/cliff.out"
 
@@ -438,10 +469,8 @@ cliff-long-128k:               # sbatch a 128k-ISL YaRN(x4 -> 131072) 3-arm swee
 	    AAI_LOCAL_CPU="$${AAI_LOCAL_CPU:-true}" LMCACHE_MAX_LOCAL_CPU_SIZE="$${LMCACHE_MAX_LOCAL_CPU_SIZE:-64}" \
 	    LMCACHE_NVME_POOL="$(if $(filter file,$(origin LMCACHE_NVME_POOL)),524288,$(LMCACHE_NVME_POOL))" AAI_NIXL_BUFFER_SIZE="$${AAI_NIXL_BUFFER_SIZE:-8589934592}" \
 	    LMCACHE_L1_SIZE_GB="$(if $(filter file,$(origin LMCACHE_L1_SIZE_GB)),640,$(LMCACHE_L1_SIZE_GB))" \
-	    $(_CLIFF_STRIP) sbatch --parsable --job-name=aai-day-cliff-long128k \
-	    $(if $(AAI_CLIFF_NODE),--nodelist=$(AAI_CLIFF_NODE),) \
-	    --time=$(if $(AAI_CLIFF_TIME),$(AAI_CLIFF_TIME),24:00:00) \
-	    .slurm/run-cliff.sbatch) && \
+	    $(call _CLIFF_SUBMIT,--job-name=aai-day-cliff-long128k \
+	    --time=$(if $(AAI_CLIFF_TIME),$(AAI_CLIFF_TIME),24:00:00))) && \
 	    echo "submitted cliff-long-128k job $$jobid (ISL=128000, YaRN x4 -> 131072, DRAM L1=64G, NVMe pool=524288, all 3 arms)" && \
 	    echo "log: $(CURDIR)/logs/$$jobid/cliff.out"
 


### PR DESCRIPTION
Merges SPUR Slurm compatibility work from both local/fixes and origin/vcave/spur-adjustments into a single coherent set of changes.

## SPUR cluster support (run-build-distribute.sh + Makefile)

AAI_SPUR_CLUSTER=1 activates a SPUR-aware submission path throughout the build/distribute/test pipeline.  SPUR's sbatch differs from standard Slurm in three ways: it does not support --parsable, --wait, or reading the job script from stdin; it does not honour --overcommit; and it requires --controller=<addr> on every sbatch/srun/squeue call.

Changes:

- _sbatch_run: SPUR path writes the batch script to a temp file, submits without --parsable/--wait, parses the job id from "Submitted batch job N", waits for the job to appear in squeue (race-guard), polls squeue until the job leaves the queue, then reads the real exit code from sacct (replacing the previous fragile log-grep approach).  Standard-Slurm path is unchanged.

- Partition/constraint defaults: AAI_SPUR_CLUSTER=1 sets the partition to amd-spur and clears the build/test constraints (SPUR nodes carry no MARKHAM/CPUONLY/GFX942 feature labels).  Uses ${VAR-} (not ${VAR:-}) so an explicit empty string ("AAI_BUILD_CONSTRAINT=") is honoured.

- --constraint= guard: all three places that pass --constraint= to sbatch/srun now check that AAI_BUILD_CONSTRAINT is non-empty first, avoiding a bare --constraint= that some Slurm versions reject.

- --overcommit: dropped from all srun and _sbatch_run calls under SPUR (unsupported flag).

- --gres=gpu:1: dropped from the smoke-test sbatch call under SPUR (SPUR nodes have no GPU GRES configured; GPU access is via the partition).

- --controller=: threaded through all sbatch/srun/squeue calls under SPUR via AAI_SPUR_CONTROLLER (default: $SPUR_CONTROLLER_ADDR env or the known SPUR controller address).

- docker buildx build: add --progress=plain so build output is visible in sbatch logs rather than the interactive TTY renderer (from vcave).

- AIS_KFD_SYMBOL: set default to kfd_ioctl_ais in the smoke-test's exporter launch (previously empty, which relied on the monitoring lib's own default; explicit is clearer).

Makefile:

- SPUR storage defaults: AAI_SPUR_CLUSTER=1 points AAI_IMAGE_DIR, AAI_CACHE_DIR, and HF_HOME at /shared_nfs (NFS volume shared across all SPUR compute nodes) and overrides NVME_DATA/GDS_SLAB_DATA to /mnt/m2m_nobackup (the 8× NVMe LVM on each SPUR node).

- _CLIFF_SUBMIT macro: abstracts the repeated sbatch ... run-cliff.sbatch invocation, with a SPUR-specific variant that omits --parsable and parses the job id from the sbatch stdout instead, and passes SPUR_CONTROLLER_ADDR.

- cliff-submit / cliff-short / cliff-long-64k / cliff-long-128k: all use _CLIFF_SUBMIT so the SPUR/standard path is handled in one place.

- _CLIFF_STRIP: guards -u HF_HOME, -u NVME_DATA, and -u GDS_SLAB_DATA on AAI_SPUR_CLUSTER=0 only, so SPUR's override values (set via `override export`) are not stripped before the cliff sbatch invocation.

## Long-ISL YaRN cliff targets (Makefile + run-cliff.sbatch)

cliff-long-64k / cliff-long-128k: new Make targets that sbatch a full 3-arm cliff sweep at 64k-ISL (YaRN x2 -> 65536) and 128k-ISL (YaRN x4 -> 131072) respectively.  Pool/slab sizing is set via Makefile $(origin) guards so the long-ISL values win over the small compose defaults that are already exported into the recipe shell (the pool/slab mis-sizing that silently caused the c>=32 cliff collapse in jobs 67536798/67537066). Every knob is overridable from the command line.

run-cliff.sbatch:

- VLM_ROPE_SCALING / VLM_YARN_FACTOR / VLM_YARN_ORIG_LEN: new knobs for optional RoPE context extension (YaRN etc.).  Builds the --hf-overrides JSON arg once; empty by default (no scaling).

- AAI_LOCAL_CPU / LMCACHE_MAX_LOCAL_CPU_SIZE: expose the DRAM L1 tier toggle for the nvme arm as top-level knobs (previously hard-coded false).

- AAI_KV_LOAD_FAILURE_POLICY: pass vLLM's kv_load_failure_policy for the kvd arms (fail/recompute/empty); omitted from the JSON when empty.

- AAI_NVME_AUTO / _detect_or_provision_nvme: auto-detect or provision a dedicated local NVMe for the LMCache tiers, with 4-tier fallback: reuse labelled mount -> format raw spare -> use already-mounted non-root NVMe -> fall back to /tmp.  Provisioning requires passwordless sudo.

## .gitignore

Add spur-*.out, rdma-test-*.out, rdma-test-*.err patterns for SPUR job output files that should not be tracked.
