### PR TITLE
ci: add AMD internal hardware CI/CD workflow

### DIFF
--- a/.github/workflows/aic-amd-internal-cicd.yml
+++ b/.github/workflows/aic-amd-internal-cicd.yml
@@ -1,0 +1,140 @@
+name: AIC AMD Internal CI/CD
+
+on:
+  workflow_dispatch:
+  schedule:
+    # 1am PST = 09:00 UTC (UTC-8 in winter; adjust to 08:00 UTC during PDT)
+    - cron: '0 9 * * *'
+  issue_comment:
+    types: [created]
+
+jobs:
+  # Validate /run-ci slash command on PRs; skipped for push and schedule triggers
+  authorize:
+    if: >
+      github.event_name != 'issue_comment' || (
+        github.event.issue.pull_request != null &&
+        contains(github.event.comment.body, '/run-ci')
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    outputs:
+      sha: ${{ steps.resolve.outputs.sha }}
+      pr_number: ${{ steps.resolve.outputs.pr_number }}
+
+    steps:
+      - name: Check commenter is a maintainer or admin
+        if: github.event_name == 'issue_comment'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.actor,
+            });
+            const level = data.permission;
+            if (level !== 'admin' && level !== 'maintain' && level !== 'write') {
+              core.setFailed(`@${context.actor} does not have write/maintain/admin permission (got: ${level})`);
+            }
+
+      - name: Resolve SHA and PR number
+        id: resolve
+        uses: actions/github-script@v7
+        with:
+          script: |
+            if (context.eventName === 'issue_comment') {
+              const { data: pr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number,
+              });
+              core.setOutput('sha', pr.head.sha);
+              core.setOutput('pr_number', String(context.issue.number));
+            } else {
+              core.setOutput('sha', context.sha);
+              core.setOutput('pr_number', '');
+            }
+
+      - name: React to comment with eyes
+        if: github.event_name == 'issue_comment'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'eyes',
+            });
+
+  hardware-test:
+    needs: authorize
+    runs-on: [self-hosted, amd-aic-spur-bridge]
+    timeout-minutes: 90
+    permissions:
+      pull-requests: write
+      statuses: write
+
+    steps:
+      - name: Set commit status to pending
+        if: needs.authorize.outputs.pr_number != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: '${{ needs.authorize.outputs.sha }}',
+              state: 'pending',
+              context: 'hardware-ci / amd-aic-spur',
+              description: 'Running on amd-aic-spur...',
+            });
+
+      - name: Run CI on amd-aic-spur
+        id: spur
+        run: bash /usr/local/lib/aic-ci/run-spur-ci.sh
+
+      - name: Set commit status on success
+        if: success() && needs.authorize.outputs.pr_number != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: '${{ needs.authorize.outputs.sha }}',
+              state: 'success',
+              context: 'hardware-ci / amd-aic-spur',
+              description: 'All hardware tests passed',
+            });
+
+      - name: Set commit status on failure
+        if: failure() && needs.authorize.outputs.pr_number != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: '${{ needs.authorize.outputs.sha }}',
+              state: 'failure',
+              context: 'hardware-ci / amd-aic-spur',
+              description: 'Hardware tests failed — check the run logs',
+            });
+
+      - name: Post result comment on PR
+        if: always() && needs.authorize.outputs.pr_number != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const success = '${{ job.status }}' === 'success';
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ needs.authorize.outputs.pr_number || 0 }},
+              body: success
+                ? `✅ Hardware CI passed for ${{ needs.authorize.outputs.sha }}.`
+                : `❌ Hardware CI failed for ${{ needs.authorize.outputs.sha }}. [View logs](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}).`,
+            });


### PR DESCRIPTION
Adds a self-hosted runner workflow that triggers via /run-ci PR comment (maintainer/admin only), nightly schedule at 1am PST, and manual dispatch. The runner SSHes to amd-aic-spur to execute CI jobs and reports pass/fail back to GitHub as commit statuses and PR comments.

Script invocation uses a placeholder at /usr/local/lib/aic-ci/run-spur-ci.sh on the runner.
