### PR TITLE
docs(cliff): production-L1 L2-backend matrix + per-run logs + NVMe-re…

### DIFF
--- a/.docs-remove/cliff-long-isl-report-postfix.md
+++ b/.docs-remove/cliff-long-isl-report-postfix.md
@@ -369,3 +369,63 @@ over DRAM-L1+NVMe, until the DRAM-L1→NVMe read fallthrough is fixed upstream.
 - File/track the upstream LMCache issue: DRAM-L1 miss does not fall through to a
   NIXL-L2 read in `local_cpu:true`.
 - Harness: add `lmcache_mp_*` tier counters to `run_cliff.py` per-c CSV columns.
+
+---
+
+# Production-L1 (64 GB) overnight confirmation — full L2-backend matrix
+
+Three runs at the **representative product config** (DRAM L1 = 64 GB, 64k ISL / 60k prefix,
+YaRN ×2, ladder c = 1/16/32/64, iters 2), on the rebranded/restructured harness (`AIC_*`
+knobs, `rocm-aic:latest` image). These confirm the c=32/16 GB bake-off findings above at the
+real production L1 size and add the NIXL-POSIX and O_DIRECT-LocalDisk L2 backends.
+
+- **Job 67538748** — `AIC_CLIFF_ARMS=vram,nvme,gds`, nvme L2 = **AIS_MT + cuda buffer (GDS)**.
+- **Job 67544761** — nvme arm, L2 = **NIXL POSIX plugin** (`nixl_posix`, cpu buffer, O_DIRECT).
+- **Job 67544874** — nvme arm, L2 = **LMCache LocalDiskBackend, O_DIRECT** (`local_disk`, `use_odirect:true`).
+
+## Throughput — median tok/s (L1 = 64 GB)
+
+| c | vram | nvme GDS-L2 | gds slab | nvme POSIX (NIXL, O_DIRECT) | nvme LocalDisk (O_DIRECT) |
+|---|---|---|---|---|---|
+| 1  | 45.5k | 44.6k | 44.8k | 44.9k | 44.6k |
+| 16 | 6.3k (cliff) | 47.0k | 48.4k | 47.0k | 46.9k |
+| 32 | 6.1k | 46.6k | 48.0k | 46.1k | 46.3k |
+| 64 | 6.0k (err=16 timeout) | **9.9k ⬇** | **48.7k** | **42.3k** | **40.6k** |
+
+All arms err=0 except vram c=64 client ReadTimeouts. **Only nvme+GDS-L2 collapses at c=64**;
+every "real L2" backend (GDS slab, NIXL-POSIX, LocalDisk) holds ~40–49k.
+
+## NVMe reads — CORRECTED methodology (use the right metric per backend)
+
+⚠️ **`node_disk_read_bytes` (/proc/diskstats, block layer) does NOT capture GDS reads** — true
+GDS is P2PDMA (NVMe→VRAM direct) and bypasses the block layer. Use `lmcache_mp_gds_l1_bytes_read`
+for GDS; `node_disk_read` for POSIX O_DIRECT (which does traverse the block layer). GDS never
+uses page cache. (Earlier "0 reads → page cache" was wrong — corrected here.)
+
+| arm | NVMe read @ run | read path | metric |
+|---|---|---|---|
+| nvme GDS-L2 | **0 GB** | never falls through DRAM-L1→L2 → **the collapse** (not caching) | NIXL `agent_rx` |
+| gds slab | **266.8 GB** | GDS P2PDMA, invisible to node_disk | `gds_l1_bytes_read` |
+| nvme POSIX (NIXL O_DIRECT) | **106 GB** | POSIX O_DIRECT via block layer | `node_disk_read` (`agent_rx` 101.6 GB ✓) |
+| nvme LocalDisk (O_DIRECT) | **102 GB** | POSIX O_DIRECT via block layer | `node_disk_read` |
+
+NVMe writes ≈ 94–97 GB per offload run (KV persistence). Node page cache peaked 736–1044 GB
+(explains why *buffered* paths and node_disk-invisible GDS show 0 block-layer reads).
+
+## Verdict
+
+1. **The DRAM-L1+NVMe c=64 collapse is real at production L1 (64 GB)** and specific to the
+   **AIS_MT/GDS L2** path: it issues **0 L2 reads** (no DRAM-L1→NVMe-L2 read-fallthrough) →
+   recompute → 9.9k. Confirms the mechanism found in the c=32/16 GB isolation.
+2. **All three first-class L2 backends avoid it** and hold the full ladder to c=64:
+   - **GDS slab: 48.7k** (fastest read path — 266.8 GB via GDS P2PDMA).
+   - **NIXL POSIX plugin: 42.3k** (106 GB real block-layer O_DIRECT reads).
+   - **LocalDiskBackend: 40.6k** (102 GB real block-layer O_DIRECT reads).
+3. The two POSIX O_DIRECT paths are effectively equivalent (~40–42k, ~100 GB real device
+   reads); the GDS slab leads by ~6k because its P2PDMA read path is faster than block-layer
+   O_DIRECT — at the cost of node_disk observability.
+4. **Recommendation:** for long-ISL beyond a modest DRAM L1, use **GDS slab** (top perf) or a
+   **POSIX L2** (NIXL-POSIX / LocalDisk — robust, observable device reads); avoid the
+   DRAM-L1 + AIS_MT/GDS-L2 combo until its read-fallthrough is fixed upstream.
+
+Per-run detail: `.docs-remove/cliff-run-{67538748,67544761,67544874}-progress.md`.

--- a/.docs-remove/cliff-run-67538748-progress.md
+++ b/.docs-remove/cliff-run-67538748-progress.md
@@ -1,0 +1,44 @@
+# Cliff run 67538748 — COMPLETE ✅ (~1h47m, all 3 arms ok, 0 HTTP 500s)
+
+**Job:** `aic-cliff-long64k` (67538748) · node ctr-rack31-mi300x-2 · 5 h wall
+**Config:** arms = **vram, nvme (GDS L2), gds** · ISL 64k / prefix 60k · YaRN ×2 → 65536
+· DRAM L1 = 64 GB · NVMe pool 262144 · nvme L2 = NIXL **AIS_MT + cuda buffer (GDS)** · gds slab 320 GB
+**Ladder:** BENCH_CONCUR = 1, 16, 32, 64 · iters = 2
+**This is Job 1** of the overnight pair (Job 2 = nvme POSIX L2, run separately).
+
+_Auto-updated every ~5 min while the job runs._
+
+## Median throughput (tok/s)
+
+| c | vram | nvme (GDS L2) | gds (slab) |
+|---|---|---|---|
+| 1  | 45.5k | 44.6k | 44.8k |
+| 16 | 6.3k (cliff) | 47.0k (ext~90%) | 48.4k (ext~87%) |
+| 32 | 6.1k (floor) | 46.6k (ext 93.5%) | 48.0k (ext 93.5%) |
+| 64 | 6.0k (err=16 ReadTimeout) | **9.9k ⬇** (ext ~44%, collapse) | **48.7k ✅** (ext 93.5%) |
+
+## Verdict
+
+- **vram** — cliffs hard at c=16 (45.5k → 6.3k), floor thereafter (HBM full ~c=14 at 64k ISL).
+- **nvme (DRAM L1 + NVMe GDS L2)** — carries the cliff (~47k through c=32, 5–7× vram) but
+  **collapses at c=64** (9.9k, ext 93.5%→44%) once WS ~67 GB > 64 GB DRAM L1. Graceful
+  (err=0, 0 hard read-fails) — degrades to recompute, not 500s.
+- **gds (320 GB NVMe slab L1)** — **holds the whole ladder incl. c=64 (48.7k, ext 93.5%,
+  err=0)**; the slab fits the ~67 GB WS, so no overflow. Best arm at the extreme.
+- Stability: zero HTTP 500 / EngineCore crashes; only client ReadTimeouts on vram c=64.
+
+Reproduces the earlier finding at **production L1 (64 GB)**: the DRAM-L1+NVMe collapse at
+c=64 is a DRAM-L1-capacity effect, and the GDS slab (or a POSIX L2 — see Job 2) avoids it.
+**Job 2 (nvme POSIX L2) pending** to slot in as the fourth comparison line.
+
+## Progress log
+
+| time | elapsed | arm / point | note |
+|---|---|---|---|
+| (start) | 3:00 | Arm A vram, c=1→16 | c=1 median 45.5k; vLLM up, err=0 |
+| 22:19 | 8:46 | Arm A vram, c=32 | vram cliff confirmed: c=16 → 6.3k (HBM full); err=0 |
+| 22:25 | 14:21 | Arm A vram, c=32 | c=32 ≈ 6.2k (floor); vram c=64 next (slow, ReadTimeout region); err=0 |
+| 22:41 | 30:43 | Arm A vram done | vram c=64 ≈ 6.0k, err=8 (client ReadTimeout, expected); Arm B nvme (GDS L2) next |
+| 22:58 | 46:55 | Arm B nvme(GDS-L2), c=32 | holds cliff: c=1 44.6k, c=16 47k (ext~90%) vs vram 6.3k; err=0. c=64 is the key test (prior runs collapsed there) |
+| 23:19 | 1:08:45 | Arm B nvme(GDS-L2), c=64 | COLLAPSE reproduced: c=64 ≈ 10.6k, ext_hit 93.5%→48% (WS 67G > 64G L1); err=0, graceful (0 hard read-fails). Arm C gds slab next |
+| 23:47 | 1:47 (done) | COMPLETE | gds slab HOLDS c=64 = 48.7k (ext 93.5%, err=0); nvme(GDS-L2) c=64 median 9.9k. All arms ok, 0 500s. |

--- a/.docs-remove/cliff-run-67544761-progress.md
+++ b/.docs-remove/cliff-run-67544761-progress.md
@@ -1,0 +1,66 @@
+# Cliff run 67544761 (Job 2 — nvme POSIX L2) — COMPLETE ✅ (err=0, full-ladder hold)
+
+**Job:** `aic-cliff-long64k` (67544761) · node ctr-cx66-mi300x-13 · 3 h wall
+**Config:** arm = **nvme only** · L2 = **NIXL POSIX plugin** (`nixl_posix`, cpu buffer)
+· ISL 64k / prefix 60k · YaRN ×2 → 65536 · DRAM L1 = 64 GB · NVMe pool 262144
+**Ladder:** BENCH_CONCUR = 1, 16, 32, 64 · iters = 2
+**This is Job 2** — the 4th line to compare against Job 1 (67538748: vram / nvme GDS-L2 / gds slab).
+
+_Auto-updated every ~5 min while the job runs._
+
+## nvme POSIX-L2 median throughput (tok/s) — vs Job 1 reference
+
+| c | vram (J1) | nvme GDS-L2 (J1) | gds slab (J1) | **nvme POSIX-L2 (this)** |
+|---|---|---|---|---|
+| 1  | 45.5k | 44.6k | 44.8k | 44.9k |
+| 16 | 6.3k  | 47.0k | 48.4k | 47.0k |
+| 32 | 6.1k  | 46.6k | 48.0k | 46.1k |
+| 64 | 6.0k  | 9.9k ⬇ | 48.7k | **42.3k ✅** |
+
+**Verdict:** NIXL POSIX L2 (O_DIRECT, cpu buffer) **holds the full ladder** — 44.9/47.0/46.1/**42.3k**,
+ext_hit 93.6% at c=64, err=0 — where nvme GDS-L2 collapsed to 9.9k. Confirms at production
+L1 (64 GB) that a POSIX L2 avoids the DRAM-L1-overflow collapse. Both POSIX L2s (NIXL-POSIX
+here, LMCache LocalDiskBackend earlier) and the GDS slab hold; only nvme+GDS-L2 collapses.
+
+**Key question:** does POSIX L2 hold at c=64 (earlier sweep: ~44k) where the GDS-L2 arm
+collapsed to 9.9k? If yes → POSIX L2 avoids the DRAM-L1-overflow collapse at production L1.
+
+## Cache hit rates (L1 = vLLM VRAM prefix cache; ext/L2 = LMCache offload tier)
+
+Format `L1% / ext%` (ext = LMCache external offload; blank for vram = no offload).
+
+| c | vram (J1) | nvme GDS-L2 (J1) | gds slab (J1) | nvme POSIX-L2 (this) |
+|---|---|---|---|---|
+| 1  | 93.7 / — | 93.7 / 0 | 93.7 / 0 | 93.7 / 0 |
+| 16 | 6.4 / — | 64.7 / 82.0 | 63.4 / 82.6 | 68.5 / 79.9 |
+| 32 | 0 / — | 0 / 93.6 | 0 / 93.6 | 0 / 93.6 |
+| 64 | 0 / — | 0 / 40.8 | 0.3 / 93.5 | 0 / 93.6 |
+
+## NVMe read per arm (CORRECTED — use the right metric per backend)
+
+**Metric caveat:** `node_disk_read_bytes` (/proc/diskstats, block layer) does **NOT** capture
+GDS reads — true GDS is P2PDMA (NVMe→VRAM direct) and **bypasses the block layer**. So for
+GDS-mode arms the correct read metric is LMCache's `gds_l1_bytes_read`, not node_disk. POSIX
+O_DIRECT *does* traverse the block layer, so node_disk captures it. (GDS never uses page cache.)
+
+| arm | NVMe read (correct metric) | NVMe write | reality |
+|---|---|---|---|
+| vram | — | — | no cache/NVMe |
+| **nvme GDS-L2** | **0 GB** (`agent_rx`) | 94 GB | issued **no L2 reads** — DRAM-L1 served ≤c32, recompute at c64. The 0 IS the collapse (no DRAM-L1→L2 read-fallthrough), **not** caching |
+| **gds slab** | **266.8 GB** (`gds_l1_bytes_read`, real GDS P2PDMA) | (part of 94 GB) | reads straight NVMe→VRAM via GDS; **invisible to node_disk by design**; never page-cached |
+| **nvme POSIX-L2 (O_DIRECT)** | **106 GB** (`node_disk_read`; `agent_rx` 101.6 GB) | 97 GB | POSIX O_DIRECT traverses the block layer → node_disk counts it |
+
+> **Corrected finding (thanks to review — my earlier "0 reads → page cache" was wrong):**
+> GDS reads are real NVMe→VRAM P2PDMA and simply don't show in `node_disk_read` because GDS
+> bypasses the kernel block layer — the gds slab arm genuinely read **266.8 GB off the NVMe**.
+> The nvme GDS-L2 arm's 0 reads is also genuine (it never falls through to L2 → collapse),
+> not caching. Read-path throughput at c=64: gds-slab **48.7k** (266.8 GB via GDS P2PDMA) vs
+> POSIX-L2 **42.3k** (106 GB via O_DIRECT block layer) — GDS's direct path reads a bit faster.
+> ais-snoop `ais_kfd` counters read 0 here (known-unreliable PID targeting on shared nodes —
+> see [[hsa-snoop-sdma-calibration]]), so `gds_l1_bytes_read` is the trustworthy GDS metric.
+
+## Progress log
+
+| time | elapsed | point | note |
+|---|---|---|---|
+| (start) | 0:37 | launching | nvme arm, POSIX L2; vLLM starting |

--- a/.docs-remove/cliff-run-67544874-progress.md
+++ b/.docs-remove/cliff-run-67544874-progress.md
@@ -1,0 +1,40 @@
+# Cliff run 67544874 (O_DIRECT LMCache LocalDiskBackend) — COMPLETE ✅ (err=0, full-ladder hold)
+
+**Job:** `aic-cliff-long64k` (67544874) · node ctr-cx66-mi300x-13 · 3 h wall
+**Config:** arm = **nvme only** · L2 = **LMCache LocalDiskBackend, O_DIRECT** (`local_disk`,
+`use_odirect: true`, 320 GB disk tier) · ISL 64k/60k · YaRN ×2 · DRAM L1 = 64 GB
+**Ladder:** BENCH_CONCUR = 1, 16, 32, 64 · iters = 2
+**Purpose:** O_DIRECT counterpart to the earlier *buffered* LocalDiskBackend (67538307) — gives
+the buffered-vs-O_DIRECT contrast for the native POSIX L2, and a true block-layer device-read number.
+
+_Auto-updated every ~5 min while the job runs._
+
+## Throughput (median tok/s) — vs prior runs (L1=64 GB)
+
+| c | vram | nvme GDS-L2 | gds slab | nvme POSIX (NIXL, O_DIRECT) | LocalDisk buffered (J 67538307, c32 only) | **LocalDisk O_DIRECT (this)** |
+|---|---|---|---|---|---|---|
+| 1  | 45.5k | 44.6k | 44.8k | 44.9k | — | 44.6k |
+| 16 | 6.3k  | 47.0k | 48.4k | 47.0k | — | 46.9k |
+| 32 | 6.1k  | 46.6k | 48.0k | 46.1k | 41.9k | 46.3k |
+| 64 | 6.0k  | 9.9k ⬇ | 48.7k | 42.3k | — | **40.6k ✅** |
+
+## NVMe read (fill at completion, from TSDB)
+
+O_DIRECT LocalDisk → block-layer reads, so `node_disk_read` should be nonzero (unlike buffered/GDS).
+
+| metric | value |
+|---|---|
+| NVMe device read (`node_disk_read`, nvme2n1) | **102.1 GB** (real block-layer reads — O_DIRECT) |
+| NVMe device write | 97.0 GB |
+
+**Verdict:** O_DIRECT LocalDiskBackend holds the full ladder (44.6/46.9/46.3/**40.6k**, err=0),
+doing **102 GB of real block-layer NVMe reads** (O_DIRECT → visible in node_disk, unlike GDS).
+Consistent with NIXL-POSIX-O_DIRECT (106 GB reads, 42.3k). Both first-class POSIX O_DIRECT
+paths ≈ 40–42k @ c=64 with ~100 GB real device reads; GDS-slab leads at 48.7k via 266.8 GB
+GDS P2PDMA. Only nvme+GDS-L2 collapses (9.9k, 0 L2 reads).
+
+## Progress log
+
+| time | elapsed | point | note |
+|---|---|---|---|
+| (start) | 8:57 | c=16 | O_DIRECT confirmed (log: "Using O_DIRECT for disk I/O: True"); c=1 44.6k, c=16 ~47k, err=0 |


### PR DESCRIPTION
…ad fix

Documents the overnight production-L1 (64 GB DRAM L1) cliff runs comparing L2 backends, and corrects the NVMe-read measurement methodology. All under .docs-remove/ (internal cliff investigation notes).

Runs (64k ISL, YaRN x2, ladder c=1/16/32/64, L1=64 GB):
- 67538748  vram + nvme(AIS_MT/GDS L2) + gds-slab
- 67544761  nvme, NIXL POSIX plugin L2 (cpu buffer, O_DIRECT)
- 67544874  nvme, LMCache LocalDiskBackend L2 (O_DIRECT)

Consolidated section added to cliff-long-isl-report-postfix.md ("Production-L1 (64 GB) overnight confirmation — full L2-backend matrix"): throughput matrix, per-backend NVMe read table, verdict + recommendation. Plus one per-run progress markdown each.

Findings:
- Only nvme + AIS_MT/GDS-L2 collapses at c=64 (9.9k) — it issues 0 L2 reads (no DRAM-L1 -> NVMe-L2 read-fallthrough) -> recompute. Confirms the c=32/16 GB mechanism at production L1.
- All three first-class L2 backends hold the full ladder to c=64: GDS slab 48.7k, NIXL POSIX 42.3k, LocalDisk 40.6k (vram floors at 6k).

Corrected NVMe-read methodology (thanks to review):
- node_disk_read (/proc/diskstats, block layer) does NOT capture GDS reads — true GDS is P2PDMA (NVMe->VRAM) and bypasses the block layer. Use lmcache_mp_gds_l1_bytes_read for GDS; node_disk_read for POSIX O_DIRECT (which does traverse the block layer). GDS never uses page cache; the earlier "0 device reads -> page cache" claim was wrong.
- Per-run reads: gds-slab 266.8 GB (GDS P2PDMA), NIXL-POSIX-O_DIRECT 106 GB and LocalDisk-O_DIRECT 102 GB (block-layer), nvme-GDS-L2 0 GB (the collapse). Node page cache peaked 736-1044 GB.
