### PR TITLE
ci: remove checkout steps, call CI scripts from runner-local path, bu…

### DIFF
--- a/.github/workflows/aic-amd-internal-cicd.yml
+++ b/.github/workflows/aic-amd-internal-cicd.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Check commenter is a maintainer or admin
         if: github.event_name == 'issue_comment'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
@@ -41,7 +41,7 @@ jobs:
 
       - name: Resolve SHA and PR number
         id: resolve
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             if (context.eventName === 'issue_comment') {
@@ -59,7 +59,7 @@ jobs:
 
       - name: React to comment with eyes
         if: github.event_name == 'issue_comment'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.reactions.createForIssueComment({
@@ -80,7 +80,7 @@ jobs:
     steps:
       - name: Set commit status to pending
         if: needs.authorize.outputs.pr_number != ''
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.repos.createCommitStatus({
@@ -92,14 +92,12 @@ jobs:
               description: 'Building image on amd-aic-spur...',
             });
 
-      - uses: actions/checkout@v4
-
       - name: Build image on amd-aic-spur
-        run: bash .github/scripts/spur-dist-build.sh "${{ needs.authorize.outputs.sha }}"
+        run: bash /usr/local/lib/aic-ci/spur-dist-build.sh "${{ needs.authorize.outputs.sha }}"
 
       - name: Set commit status on success
         if: success() && needs.authorize.outputs.pr_number != ''
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.repos.createCommitStatus({
@@ -113,7 +111,7 @@ jobs:
 
       - name: Set commit status on failure
         if: failure() && needs.authorize.outputs.pr_number != ''
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.repos.createCommitStatus({
@@ -127,7 +125,7 @@ jobs:
 
       - name: Post failure comment on PR
         if: failure() && needs.authorize.outputs.pr_number != ''
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.issues.createComment({
@@ -148,7 +146,7 @@ jobs:
     steps:
       - name: Set commit status to pending
         if: needs.authorize.outputs.pr_number != ''
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.repos.createCommitStatus({
@@ -160,14 +158,12 @@ jobs:
               description: 'Running smoke test on amd-aic-spur...',
             });
 
-      - uses: actions/checkout@v4
-
       - name: Run smoke test on amd-aic-spur
-        run: bash .github/scripts/spur-smoke-test.sh "${{ needs.authorize.outputs.sha }}"
+        run: bash /usr/local/lib/aic-ci/spur-smoke-test.sh "${{ needs.authorize.outputs.sha }}"
 
       - name: Set commit status on success
         if: success() && needs.authorize.outputs.pr_number != ''
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.repos.createCommitStatus({
@@ -181,7 +177,7 @@ jobs:
 
       - name: Set commit status on failure
         if: failure() && needs.authorize.outputs.pr_number != ''
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.repos.createCommitStatus({
@@ -195,7 +191,7 @@ jobs:
 
       - name: Post result comment on PR
         if: always() && needs.authorize.outputs.pr_number != ''
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const success = '${{ job.status }}' === 'success';


### PR DESCRIPTION
…mp github-script to v9

actions/checkout fails on self-hosted runner (repo not accessible via HTTPS token). Scripts moved to /usr/local/lib/aic-ci/ on the runner and called by absolute path instead. Adds spur-dist-build and spur-smoke-test scripts and splits hardware-test into two sequential jobs. Bumps github-script to v9 (Node 24 native, eliminates deprecation warning).
