### PR TITLE
ci: fix AIC_IMAGE variable name in dist-build and smoke-test scripts

### DIFF
--- a/.github/scripts/spur-dist-build.sh
+++ b/.github/scripts/spur-dist-build.sh
@@ -11,13 +11,13 @@ set -euo pipefail
 SHA="${1:?usage: $0 <full-sha>}"
 SHORT="${SHA:0:7}"
 REPO="git@github.com:ROCm/rocm-icms.git"
-IMAGE_NAME="rocm-aic-ci-${SHORT}"
+AIC_IMAGE="rocm-aic-ci-${SHORT}:latest"
 TARBALL_DIR="/tmp/aic-ci-${SHORT}"
 
 ssh amd-aic-spur env \
     SHA="${SHA}" \
     REPO="${REPO}" \
-    IMAGE_NAME="${IMAGE_NAME}" \
+    AIC_IMAGE="${AIC_IMAGE}" \
     TARBALL_DIR="${TARBALL_DIR}" \
     bash << 'REMOTE'
 set -euo pipefail
@@ -38,9 +38,9 @@ git checkout "${SHA}"
 
 mkdir -p "${TARBALL_DIR}"
 
-echo "=== Running dist-build (AIC_SPUR_CLUSTER=1, image=${IMAGE_NAME}) ==="
+echo "=== Running dist-build (AIC_SPUR_CLUSTER=1, AIC_IMAGE=${AIC_IMAGE}) ==="
 AIC_SPUR_CLUSTER=1 \
-    IMAGE_NAME="${IMAGE_NAME}" \
+    AIC_IMAGE="${AIC_IMAGE}" \
     AIC_IMAGE_DIR="${TARBALL_DIR}" \
     make dist-build
 

--- a/.github/scripts/spur-smoke-test.sh
+++ b/.github/scripts/spur-smoke-test.sh
@@ -7,12 +7,12 @@ set -euo pipefail
 
 SHA="${1:?usage: $0 <full-sha>}"
 SHORT="${SHA:0:7}"
-IMAGE_NAME="rocm-aic-ci-${SHORT}"
+AIC_IMAGE="rocm-aic-ci-${SHORT}:latest"
 TARBALL_DIR="/tmp/aic-ci-${SHORT}"
 
 ssh amd-aic-spur env \
     SHA="${SHA}" \
-    IMAGE_NAME="${IMAGE_NAME}" \
+    AIC_IMAGE="${AIC_IMAGE}" \
     TARBALL_DIR="${TARBALL_DIR}" \
     bash << 'REMOTE'
 set -euo pipefail
@@ -26,9 +26,9 @@ cleanup() {
 }
 trap cleanup EXIT
 
-echo "=== Running smoke-test (image=${IMAGE_NAME}) ==="
+echo "=== Running smoke-test (AIC_IMAGE=${AIC_IMAGE}) ==="
 AIC_SPUR_CLUSTER=1 \
-    IMAGE_NAME="${IMAGE_NAME}" \
+    AIC_IMAGE="${AIC_IMAGE}" \
     AIC_IMAGE_DIR="${TARBALL_DIR}" \
     make -C "${WORKDIR}" smoke-test
 


### PR DESCRIPTION
run-build-distribute.sh uses AIC_IMAGE (not IMAGE_NAME) to derive the tarball path. Both scripts now pass AIC_IMAGE=rocm-aic-ci-<short>:latest so the smoke-test can locate the tarball produced by dist-build.
