### PR TITLE
ci: use shared NFS for CI tarball dir instead of /tmp

### DIFF
--- a/.github/scripts/spur-dist-build.sh
+++ b/.github/scripts/spur-dist-build.sh
@@ -12,7 +12,7 @@ SHA="${1:?usage: $0 <full-sha>}"
 SHORT="${SHA:0:7}"
 REPO="git@github.com:ROCm/rocm-icms.git"
 AIC_IMAGE="rocm-aic-ci-${SHORT}:latest"
-TARBALL_DIR="/tmp/aic-ci-${SHORT}"
+TARBALL_DIR="/shared_nfs/${USER}/images/aic-ci-${SHORT}"
 
 ssh amd-aic-spur env \
     SHA="${SHA}" \

--- a/.github/scripts/spur-smoke-test.sh
+++ b/.github/scripts/spur-smoke-test.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 SHA="${1:?usage: $0 <full-sha>}"
 SHORT="${SHA:0:7}"
 AIC_IMAGE="rocm-aic-ci-${SHORT}:latest"
-TARBALL_DIR="/tmp/aic-ci-${SHORT}"
+TARBALL_DIR="/shared_nfs/${USER}/images/aic-ci-${SHORT}"
 
 ssh amd-aic-spur env \
     SHA="${SHA}" \


### PR DESCRIPTION
dist-build runs via sbatch on a compute node, so /tmp is local to that node and invisible to the login node where smoke-test runs. Switch AIC_IMAGE_DIR to /shared_nfs/$USER/images/aic-ci-<short> which is visible to all nodes.
