### PR TITLE
ci: split nightly CI into dedicated workflows, add version badges to …

### DIFF
--- a/.github/scripts/spur-cliff.sh
+++ b/.github/scripts/spur-cliff.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Runs on the self-hosted runner; SSHes to amd-aic-spur, uses the clone and
+# tarball left by spur-dist-build.sh, and runs a cliff benchmark.
+#
+# Usage: spur-cliff.sh <full-sha> <target>
+#   target: cliff-short  -- 1-point sweep, quick PR gate
+#           cliff-submit -- full 3-arm sweep, nightly/post-merge
+#
+# Always cleans up the clone and tarball dir on exit.
+
+SHA="${1:?usage: $0 <full-sha> <cliff-short|cliff-submit>}"
+TARGET="${2:?usage: $0 <full-sha> <cliff-short|cliff-submit>}"
+SHORT="${SHA:0:7}"
+AIC_IMAGE="rocm-aic-ci-${SHORT}:latest"
+TARBALL_DIR="/shared_nfs/\${USER}/images/aic-ci-${SHORT}"
+
+case "${TARGET}" in
+    cliff-short|cliff-submit) ;;
+    *) echo "ERROR: target must be cliff-short or cliff-submit" >&2; exit 1 ;;
+esac
+
+ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=4 amd-aic-spur env \
+    SHA="${SHA}" \
+    TARGET="${TARGET}" \
+    AIC_IMAGE="${AIC_IMAGE}" \
+    TARBALL_DIR="${TARBALL_DIR}" \
+    bash << 'REMOTE'
+set -euo pipefail
+
+SHORT="${SHA:0:7}"
+WORKDIR="$HOME/Projects/rocm-aic.${SHORT}"
+
+cleanup() {
+    echo "=== Cleaning up ==="
+    rm -rf "${WORKDIR}" "${TARBALL_DIR}"
+}
+trap cleanup EXIT
+
+if [[ ! -d "${WORKDIR}" ]]; then
+    echo "ERROR: ${WORKDIR} not found — did dist-build run first?" >&2
+    exit 1
+fi
+
+if [[ ! -d "${TARBALL_DIR}" ]]; then
+    echo "ERROR: ${TARBALL_DIR} not found — did dist-build run first?" >&2
+    exit 1
+fi
+
+echo "=== Running ${TARGET} (AIC_IMAGE=${AIC_IMAGE}) ==="
+cd "${WORKDIR}"
+
+JOB_ID=$(AIC_SPUR_CLUSTER=1 \
+    AIC_IMAGE="${AIC_IMAGE}" \
+    AIC_IMAGE_DIR="${TARBALL_DIR}" \
+    make "${TARGET}" 2>&1 | grep -oP '(?<=submitted (cliff-short|aic-cliff) job )\d+|(?<=Submitted batch job )\d+' | tail -1)
+
+if [[ -z "${JOB_ID}" ]]; then
+    echo "ERROR: could not determine Slurm job ID from make ${TARGET} output" >&2
+    exit 1
+fi
+
+echo "=== Cliff job ${JOB_ID} submitted — polling for completion ==="
+LOG="logs/${JOB_ID}/cliff.out"
+
+while squeue -j "${JOB_ID}" -h 2>/dev/null | grep -q "${JOB_ID}"; do
+    sleep 30
+done
+
+STATE=$(sacct -j "${JOB_ID}" --format=State --noheader 2>/dev/null | head -1 | tr -d ' ')
+echo "=== Job ${JOB_ID} finished with state: ${STATE} ==="
+
+if [[ -f "${LOG}" ]]; then
+    echo "=== Cliff output (${LOG}) ==="
+    cat "${LOG}"
+fi
+
+[[ "${STATE}" == "COMPLETED" ]] || { echo "ERROR: job ${JOB_ID} ended in state ${STATE}" >&2; exit 1; }
+echo "=== ${TARGET} complete ==="
+REMOTE
+
+echo "Cliff run passed for ${SHORT}"

--- a/.github/scripts/spur-dist-build.sh
+++ b/.github/scripts/spur-dist-build.sh
@@ -14,7 +14,7 @@ REPO="git@github.com:ROCm/rocm-icms.git"
 AIC_IMAGE="rocm-aic-ci-${SHORT}:latest"
 TARBALL_DIR="/shared_nfs/${USER}/images/aic-ci-${SHORT}"
 
-ssh amd-aic-spur env \
+ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=4 amd-aic-spur env \
     SHA="${SHA}" \
     REPO="${REPO}" \
     AIC_IMAGE="${AIC_IMAGE}" \

--- a/.github/scripts/spur-smoke-test.sh
+++ b/.github/scripts/spur-smoke-test.sh
@@ -10,7 +10,7 @@ SHORT="${SHA:0:7}"
 AIC_IMAGE="rocm-aic-ci-${SHORT}:latest"
 TARBALL_DIR="/shared_nfs/${USER}/images/aic-ci-${SHORT}"
 
-ssh amd-aic-spur env \
+ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=4 amd-aic-spur env \
     SHA="${SHA}" \
     AIC_IMAGE="${AIC_IMAGE}" \
     TARBALL_DIR="${TARBALL_DIR}" \

--- a/.github/workflows/aic-amd-cliff.yml
+++ b/.github/workflows/aic-amd-cliff.yml
@@ -1,20 +1,17 @@
-name: AIC AMD Internal CI/CD
+name: AIC AMD Cliff Benchmark
 
 on:
   workflow_dispatch:
-  schedule:
-    # 1am PST = 09:00 UTC (UTC-8 in winter; adjust to 08:00 UTC during PDT)
-    - cron: '0 9 * * *'
   issue_comment:
     types: [created]
 
 jobs:
-  # Validate /run-ci slash command on PRs; skipped for schedule and manual triggers
+  # Validate /run-cliff slash command on PRs; skipped for other triggers
   authorize:
     if: >
       github.event_name != 'issue_comment' || (
         github.event.issue.pull_request != null &&
-        contains(github.event.comment.body, '/run-ci')
+        contains(github.event.comment.body, '/run-cliff')
       )
     runs-on: ubuntu-latest
     permissions:
@@ -22,6 +19,8 @@ jobs:
     outputs:
       sha: ${{ steps.resolve.outputs.sha }}
       pr_number: ${{ steps.resolve.outputs.pr_number }}
+      target: ${{ steps.resolve.outputs.target }}
+      should_run: ${{ steps.resolve.outputs.should_run }}
 
     steps:
       - name: Check commenter is a maintainer or admin
@@ -39,7 +38,7 @@ jobs:
               core.setFailed(`@${context.actor} does not have write/maintain/admin permission (got: ${level})`);
             }
 
-      - name: Resolve SHA and PR number
+      - name: Resolve SHA, PR number, and cliff target
         id: resolve
         uses: actions/github-script@v9
         with:
@@ -52,9 +51,14 @@ jobs:
               });
               core.setOutput('sha', pr.head.sha);
               core.setOutput('pr_number', String(context.issue.number));
+              core.setOutput('target', 'cliff-short');
+              core.setOutput('should_run', 'true');
             } else {
+              // workflow_dispatch
               core.setOutput('sha', context.sha);
               core.setOutput('pr_number', '');
+              core.setOutput('target', 'cliff-short');
+              core.setOutput('should_run', 'true');
             }
 
       - name: React to comment with eyes
@@ -69,10 +73,11 @@ jobs:
               content: 'eyes',
             });
 
-  dist-build:
+  cliff:
     needs: authorize
+    if: needs.authorize.outputs.should_run == 'true'
     runs-on: [self-hosted, rocm-aic-cicd]
-    timeout-minutes: 120
+    timeout-minutes: 240
     permissions:
       pull-requests: write
       statuses: write
@@ -88,12 +93,15 @@ jobs:
               repo: context.repo.repo,
               sha: '${{ needs.authorize.outputs.sha }}',
               state: 'pending',
-              context: 'hardware-ci / dist-build',
-              description: 'Building image on amd-aic-spur...',
+              context: 'hardware-ci / cliff',
+              description: 'Running cliff benchmark on amd-aic-spur...',
             });
 
-      - name: Build image on amd-aic-spur
-        run: bash /usr/local/lib/aic-ci/spur-dist-build.sh "${{ needs.authorize.outputs.sha }}"
+      - name: Run cliff on amd-aic-spur
+        run: |
+          bash /usr/local/lib/aic-ci/spur-cliff.sh \
+            "${{ needs.authorize.outputs.sha }}" \
+            "${{ needs.authorize.outputs.target }}"
 
       - name: Set commit status on success
         if: success() && needs.authorize.outputs.pr_number != ''
@@ -105,8 +113,8 @@ jobs:
               repo: context.repo.repo,
               sha: '${{ needs.authorize.outputs.sha }}',
               state: 'success',
-              context: 'hardware-ci / dist-build',
-              description: 'Image built successfully',
+              context: 'hardware-ci / cliff',
+              description: 'Cliff benchmark passed',
             });
 
       - name: Set commit status on failure
@@ -119,74 +127,8 @@ jobs:
               repo: context.repo.repo,
               sha: '${{ needs.authorize.outputs.sha }}',
               state: 'failure',
-              context: 'hardware-ci / dist-build',
-              description: 'Image build failed — check the run logs',
-            });
-
-      - name: Post failure comment on PR
-        if: failure() && needs.authorize.outputs.pr_number != ''
-        uses: actions/github-script@v9
-        with:
-          script: |
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: ${{ needs.authorize.outputs.pr_number || 0 }},
-              body: `❌ dist-build failed for ${{ needs.authorize.outputs.sha }}. [View logs](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}).`,
-            });
-
-  smoke-test:
-    needs: [authorize, dist-build]
-    runs-on: [self-hosted, rocm-aic-cicd]
-    timeout-minutes: 60
-    permissions:
-      pull-requests: write
-      statuses: write
-
-    steps:
-      - name: Set commit status to pending
-        if: needs.authorize.outputs.pr_number != ''
-        uses: actions/github-script@v9
-        with:
-          script: |
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: '${{ needs.authorize.outputs.sha }}',
-              state: 'pending',
-              context: 'hardware-ci / smoke-test',
-              description: 'Running smoke test on amd-aic-spur...',
-            });
-
-      - name: Run smoke test on amd-aic-spur
-        run: bash /usr/local/lib/aic-ci/spur-smoke-test.sh "${{ needs.authorize.outputs.sha }}"
-
-      - name: Set commit status on success
-        if: success() && needs.authorize.outputs.pr_number != ''
-        uses: actions/github-script@v9
-        with:
-          script: |
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: '${{ needs.authorize.outputs.sha }}',
-              state: 'success',
-              context: 'hardware-ci / smoke-test',
-              description: 'Smoke test passed',
-            });
-
-      - name: Set commit status on failure
-        if: failure() && needs.authorize.outputs.pr_number != ''
-        uses: actions/github-script@v9
-        with:
-          script: |
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: '${{ needs.authorize.outputs.sha }}',
-              state: 'failure',
-              context: 'hardware-ci / smoke-test',
-              description: 'Smoke test failed — check the run logs',
+              context: 'hardware-ci / cliff',
+              description: 'Cliff benchmark failed — check the run logs',
             });
 
       - name: Post result comment on PR
@@ -200,6 +142,6 @@ jobs:
               repo: context.repo.repo,
               issue_number: ${{ needs.authorize.outputs.pr_number || 0 }},
               body: success
-                ? `✅ Hardware CI passed for ${{ needs.authorize.outputs.sha }}.`
-                : `❌ Smoke test failed for ${{ needs.authorize.outputs.sha }}. [View logs](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}).`,
+                ? `✅ Cliff benchmark passed for ${{ needs.authorize.outputs.sha }}.`
+                : `❌ Cliff benchmark failed for ${{ needs.authorize.outputs.sha }}. [View logs](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}).`,
             });

--- a/.github/workflows/aic-amd-dist-build.yml
+++ b/.github/workflows/aic-amd-dist-build.yml
@@ -1,0 +1,208 @@
+name: AIC AMD Dist Build
+
+on:
+  workflow_dispatch:
+  issue_comment:
+    types: [created]
+
+jobs:
+  # Validate /run-ci slash command on PRs; skipped for manual triggers
+  authorize:
+    if: >
+      github.event_name != 'issue_comment' || (
+        github.event.issue.pull_request != null &&
+        contains(github.event.comment.body, '/run-ci')
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    outputs:
+      sha: ${{ steps.resolve.outputs.sha }}
+      pr_number: ${{ steps.resolve.outputs.pr_number }}
+
+    steps:
+      - name: Check commenter is a maintainer or admin
+        if: github.event_name == 'issue_comment'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.actor,
+            });
+            const level = data.permission;
+            if (level !== 'admin' && level !== 'maintain' && level !== 'write') {
+              core.setFailed(`@${context.actor} does not have write/maintain/admin permission (got: ${level})`);
+            }
+
+      - name: Resolve SHA and PR number
+        id: resolve
+        uses: actions/github-script@v9
+        with:
+          script: |
+            if (context.eventName === 'issue_comment') {
+              const { data: pr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number,
+              });
+              core.setOutput('sha', pr.head.sha);
+              core.setOutput('pr_number', String(context.issue.number));
+            } else {
+              core.setOutput('sha', context.sha);
+              core.setOutput('pr_number', '');
+            }
+
+      - name: React to comment with eyes
+        if: github.event_name == 'issue_comment'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'eyes',
+            });
+
+  dist-build:
+    needs: authorize
+    runs-on: [self-hosted, rocm-aic-cicd]
+    timeout-minutes: 120
+    permissions:
+      pull-requests: write
+      statuses: write
+
+    steps:
+      - name: Set commit status to pending
+        if: needs.authorize.outputs.pr_number != ''
+        uses: actions/github-script@v9
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: '${{ needs.authorize.outputs.sha }}',
+              state: 'pending',
+              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              context: 'hardware-ci / dist-build',
+              description: 'Building image on amd-aic-spur...',
+            });
+
+      - name: Build image on amd-aic-spur
+        run: bash /usr/local/lib/aic-ci/spur-dist-build.sh "${{ needs.authorize.outputs.sha }}"
+
+      - name: Set commit status on success
+        if: success() && needs.authorize.outputs.pr_number != ''
+        uses: actions/github-script@v9
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: '${{ needs.authorize.outputs.sha }}',
+              state: 'success',
+              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              context: 'hardware-ci / dist-build',
+              description: 'Image built successfully',
+            });
+
+      - name: Set commit status on failure
+        if: failure() && needs.authorize.outputs.pr_number != ''
+        uses: actions/github-script@v9
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: '${{ needs.authorize.outputs.sha }}',
+              state: 'failure',
+              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              context: 'hardware-ci / dist-build',
+              description: 'Image build failed — check the run logs',
+            });
+
+      - name: Post failure comment on PR
+        if: failure() && needs.authorize.outputs.pr_number != ''
+        uses: actions/github-script@v9
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ needs.authorize.outputs.pr_number || 0 }},
+              body: `❌ dist-build failed for ${{ needs.authorize.outputs.sha }}. [View logs](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}).`,
+            });
+
+  smoke-test:
+    needs: [authorize, dist-build]
+    runs-on: [self-hosted, rocm-aic-cicd]
+    timeout-minutes: 60
+    permissions:
+      pull-requests: write
+      statuses: write
+
+    steps:
+      - name: Set commit status to pending
+        if: needs.authorize.outputs.pr_number != ''
+        uses: actions/github-script@v9
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: '${{ needs.authorize.outputs.sha }}',
+              state: 'pending',
+              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              context: 'hardware-ci / smoke-test',
+              description: 'Running smoke test on amd-aic-spur...',
+            });
+
+      - name: Run smoke test on amd-aic-spur
+        run: bash /usr/local/lib/aic-ci/spur-smoke-test.sh "${{ needs.authorize.outputs.sha }}"
+
+      - name: Set commit status on success
+        if: success() && needs.authorize.outputs.pr_number != ''
+        uses: actions/github-script@v9
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: '${{ needs.authorize.outputs.sha }}',
+              state: 'success',
+              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              context: 'hardware-ci / smoke-test',
+              description: 'Smoke test passed',
+            });
+
+      - name: Set commit status on failure
+        if: failure() && needs.authorize.outputs.pr_number != ''
+        uses: actions/github-script@v9
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: '${{ needs.authorize.outputs.sha }}',
+              state: 'failure',
+              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              context: 'hardware-ci / smoke-test',
+              description: 'Smoke test failed — check the run logs',
+            });
+
+      - name: Post result comment on PR
+        if: always() && needs.authorize.outputs.pr_number != ''
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const success = '${{ job.status }}' === 'success';
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ needs.authorize.outputs.pr_number || 0 }},
+              body: success
+                ? `✅ Hardware CI passed for ${{ needs.authorize.outputs.sha }}.`
+                : `❌ Smoke test failed for ${{ needs.authorize.outputs.sha }}. [View logs](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}).`,
+            });

--- a/.github/workflows/aic-amd-nightly-cliff.yml
+++ b/.github/workflows/aic-amd-nightly-cliff.yml
@@ -1,0 +1,19 @@
+name: AIC Nightly Cliff
+
+on:
+  workflow_run:
+    workflows: ["AIC Nightly Smoke Test"]
+    types: [completed]
+
+jobs:
+  cliff:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: [self-hosted, rocm-aic-cicd]
+    timeout-minutes: 240
+
+    steps:
+      - name: Run full cliff sweep on amd-aic-spur
+        run: |
+          bash /usr/local/lib/aic-ci/spur-cliff.sh \
+            "${{ github.event.workflow_run.head_sha }}" \
+            cliff-submit

--- a/.github/workflows/aic-amd-nightly-dist-build.yml
+++ b/.github/workflows/aic-amd-nightly-dist-build.yml
@@ -1,0 +1,18 @@
+name: AIC Nightly Dist Build
+
+on:
+  schedule:
+    # 1am PST = 09:00 UTC (UTC-8 in winter; adjust to 08:00 UTC during PDT)
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+
+jobs:
+  dist-build:
+    runs-on: [self-hosted, rocm-aic-cicd]
+    timeout-minutes: 120
+    permissions:
+      statuses: write
+
+    steps:
+      - name: Build image on amd-aic-spur
+        run: bash /usr/local/lib/aic-ci/spur-dist-build.sh "${{ github.sha }}"

--- a/.github/workflows/aic-amd-nightly-smoke-test.yml
+++ b/.github/workflows/aic-amd-nightly-smoke-test.yml
@@ -1,0 +1,16 @@
+name: AIC Nightly Smoke Test
+
+on:
+  workflow_run:
+    workflows: ["AIC Nightly Dist Build"]
+    types: [completed]
+
+jobs:
+  smoke-test:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: [self-hosted, rocm-aic-cicd]
+    timeout-minutes: 60
+
+    steps:
+      - name: Run smoke test on amd-aic-spur
+        run: bash /usr/local/lib/aic-ci/spur-smoke-test.sh "${{ github.event.workflow_run.head_sha }}"

--- a/.slurm/run-build-distribute.sh
+++ b/.slurm/run-build-distribute.sh
@@ -307,32 +307,46 @@ PROLOGUE
         log "submitted ${jobname} as job ${jobid} (partition ${AIC_BUILD_PARTITION})"
         log "log: ${logfile}"
 
-        # Live-tail the log while polling squeue for job completion.
-        local tail_pid=""
-        ( tail -F "${logfile}" 2>/dev/null ) & tail_pid=$!
+        # Poll squeue until the job leaves the queue, printing new log lines each
+        # iteration. Avoids tail -F which hangs on SPUR when the background
+        # subshell cannot be reliably killed inside an SSH heredoc.
+        # SPUR squeue ignores -j; filter by job ID in awk.
+        local last_line=0
 
-        # Wait for the job to appear in the queue before polling for its exit;
-        # a fast scheduler may dequeue it before the first squeue check fires.
+        _print_new_lines() {
+            if [[ -f "${logfile}" ]]; then
+                local total; total=$(wc -l < "${logfile}" 2>/dev/null || echo 0)
+                if (( total > last_line )); then
+                    tail -n +"$((last_line + 1))" "${logfile}" 2>/dev/null
+                    last_line=${total}
+                fi
+            fi
+        }
+
+        # Wait up to 60s for the job to appear.
         local appear_tries=0
-        until squeue --controller="${AIC_SPUR_CONTROLLER}" -j "${jobid}" -h 2>/dev/null | grep -q . \
+        until squeue --controller="${AIC_SPUR_CONTROLLER}" -j "${jobid}" -h 2>/dev/null | awk '{print $1}' | grep -qx "${jobid}" \
               || (( appear_tries >= 60 )); do
             sleep 1; appear_tries=$((appear_tries + 1))
         done
-        # Poll until the job leaves the queue.
-        while squeue --controller="${AIC_SPUR_CONTROLLER}" -j "${jobid}" -h 2>/dev/null | grep -q .; do
+
+        # Poll until the job leaves the queue, streaming new log lines.
+        while squeue --controller="${AIC_SPUR_CONTROLLER}" -j "${jobid}" -h 2>/dev/null | awk '{print $1}' | grep -qx "${jobid}"; do
+            _print_new_lines
             sleep 10
         done
 
-        # Give the log a moment to flush its last lines.
+        # Flush any remaining lines after job completes.
         sleep 2
-        kill "${tail_pid}" >/dev/null 2>&1 || true
-        wait "${tail_pid}" 2>/dev/null || true
+        _print_new_lines
 
         # Read the real exit code from sacct ("<code>:<signal>" format).
+        # SPUR sacct ignores -j and returns all jobs; grep for the exact job ID
+        # in JobID+ExitCode output to avoid picking up an unrelated row.
         local acct_exit
         acct_exit="$(sacct --controller="${AIC_SPUR_CONTROLLER}" -j "${jobid}" \
-            --format=ExitCode --noheader 2>/dev/null \
-            | awk 'NR==1{split($1,a,":"); print a[1]}')"
+            --format=JobID,ExitCode --noheader 2>/dev/null \
+            | awk -v id="${jobid}" '$1==id{split($2,a,":"); print a[1]; exit}')"
         rc="${acct_exit:-1}"
     else
         # Standard Slurm path: --parsable prints the bare job id; --wait blocks

--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # ROCm AMD Infinity Context
 
+[![MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/ROCm/rocm-aic/blob/main/LICENSE.md)
+[![Platform](https://img.shields.io/badge/platform-linux-lightgrey.svg)](README.md)
+[![ROCm](https://img.shields.io/badge/ROCm-7.2.4-green.svg)](https://rocm.docs.amd.com)
+[![vLLM](https://img.shields.io/badge/vLLM-0.25.0+rocm723-blue.svg)](https://github.com/vllm-project/vllm)
+[![LMCache](https://img.shields.io/badge/LMCache-v0.5.1-blue.svg)](https://github.com/LMCache/LMCache)
+[![NIXL](https://img.shields.io/badge/NIXL-v1.3.1-blue.svg)](https://github.com/ai-dynamo/nixl)
+[![Spelling](https://github.com/ROCm/rocm-aic/actions/workflows/spellcheck.yml/badge.svg)](https://github.com/ROCm/rocm-aic/actions/workflows/spellcheck.yml)
+[![Nightly Dist Build](https://github.com/ROCm/rocm-aic/actions/workflows/aic-amd-nightly-dist-build.yml/badge.svg)](https://github.com/ROCm/rocm-aic/actions/workflows/aic-amd-nightly-dist-build.yml)
+[![Nightly Smoke Test](https://github.com/ROCm/rocm-aic/actions/workflows/aic-amd-nightly-smoke-test.yml/badge.svg)](https://github.com/ROCm/rocm-aic/actions/workflows/aic-amd-nightly-smoke-test.yml)
+[![Nightly Cliff](https://github.com/ROCm/rocm-aic/actions/workflows/aic-amd-nightly-cliff.yml/badge.svg)](https://github.com/ROCm/rocm-aic/actions/workflows/aic-amd-nightly-cliff.yml)
+
 > [!CAUTION]
 > This release is an *early-access* software technology preview. Running
 > production workloads is *not* recommended.


### PR DESCRIPTION
…README

Adds three nightly-only workflows that chain via workflow_run:
  aic-amd-nightly-dist-build.yml (cron 1am PST)
    -> aic-amd-nightly-smoke-test.yml (on dist-build success)
      -> aic-amd-nightly-cliff.yml (cliff-submit on smoke-test success)

PR /run-ci and /run-cliff workflows retain workflow_dispatch only. README badges now reflect nightly run health exclusively, plus static version badges for ROCm 7.2.4, vLLM 0.25.0+rocm723, LMCache v0.5.1, and NIXL v1.3.1.
