### PR TITLE
aai-day-release: enable cliff runs across GFX arches + read-path/cros…

### DIFF
--- a/.docs-remove/cliff-cross-gfx-sweep.md
+++ b/.docs-remove/cliff-cross-gfx-sweep.md
@@ -1,0 +1,122 @@
+# Cross-GFX cliff sweep — how far does the release image travel?
+
+Short cliff runs fanned out **in parallel** across as many Markham GFX arches as
+had a free GPU, to answer two questions: (1) which AMD GPU generations can run the
+aai-day release image at all, and (2) does the LMCache POSIX-tiered arm recover
+the prefix-cache cliff on each.
+
+Uniform recipe (one job per arch, submitted in parallel): **Qwen2.5-3B-Instruct**
+(full-attention — the LMCache connector needs it), ISL 8000 / shared prefix 7000
+(fits Qwen's native 32k window, no YaRN), `per_client`, `BENCH_CONCUR=1,8,32`,
+1 iter, arms **vram_only + kvd_v2 nvme (LMCache native `LocalDiskBackend`, POSIX)**,
+DRAM L1 = 4 GB, `gpu_memory_utilization=0.85` (fits Qwen weights on the smallest
+24 GB card). HF cache + the 11 GB multi-arch image staged on shared `$HOME`.
+
+## TL;DR
+
+- **The release image (fp8 KV cache + ROCm AITER) runs vLLM only on CDNA3/3.5** —
+  gfx942 (MI300X/MI300A) and gfx950 (MI350X). On **MI210, and all RDNA3** the
+  vram arm dies at vLLM engine init.
+- **Root cause: `--kv-cache-dtype fp8` + `VLLM_ROCM_USE_AITER=1`.** Both are
+  MI300/MI350-specific (MI210/MI100 have no native fp8; AITER kernels target
+  CDNA3+). Switching to **`--kv-cache-dtype auto` (fp16) + `VLLM_ROCM_USE_AITER=0`**
+  brings up **MI210 and all three RDNA3 variants** cleanly. (Exposed as two new
+  backward-compatible sbatch knobs, `AIC_KV_CACHE_DTYPE` / `AIC_ROCM_USE_AITER`;
+  defaults unchanged = fp8/aiter.)
+- **MI100 (gfx908, CDNA1) and RDNA4 (gfx1201) do not come up even with fp16 +
+  no-AITER** — vLLM engine startup exceeds the 1200 s wait. Deeper support gap
+  (kernels / attention backend); needs more than a dtype/AITER toggle.
+- **Where vLLM runs, the LMCache POSIX-tiered arm recovers the cliff on every
+  arch — a consistent ~3.3–4.3× at c=32.** The tiering win is architecture-independent.
+
+## Coverage
+
+| GFX | product | gen | vLLM boots? | config needed | both arms swept |
+|---|---|---|---|---|---|
+| gfx942 | MI300A (128 GB) | CDNA3 | yes | release (fp8 + AITER) | ✅ |
+| gfx950 | MI350X (288 GB) | CDNA3.5 | yes | release (fp8 + AITER) | ✅ (prior runs) |
+| gfx90a | MI210 (64 GB) | CDNA2 | yes | **fp16 + no-AITER** | ✅ |
+| gfx1100 | Radeon RX 7900 | RDNA3 | yes | **fp16 + no-AITER** | ✅ |
+| gfx1100w | Radeon Pro W7900 | RDNA3 | yes | **fp16 + no-AITER** | ✅ |
+| gfx1100p | RDNA3 (Pro) | RDNA3 | yes | **fp16 + no-AITER** | ✅ |
+| gfx908 | MI100 (32 GB) | CDNA1 | **no** | fp16+no-AITER still times out | ❌ |
+| gfx1201 | RDNA4 | RDNA4 | **no** | fp16+no-AITER still times out | ❌ |
+
+Not attempted (drained/reserved/other): gfx1101v, gfx1102, gfx1151 (Strix Halo)
+all drained; gfx906 (MI60) down; the one free "GPU" node was an NVIDIA
+RTX PRO 4000 (CUDA, not ROCm).
+
+## Throughput (tok/s) — vram_only vs kvd_v2 (POSIX L2)
+
+| GFX (product) | arm | c=1 | c=8 | c=32 | recovery @ c=32 |
+|---|---|---|---|---|---|
+| gfx942 (MI300A) | vram | 21,154 | 18,407 | 21,363 | — |
+| | **kvd** | 20,754 | 65,955 | **70,003** | **3.3×** |
+| gfx90a (MI210) | vram | 34,763 | 11,099 | 12,515 | — |
+| | **kvd** | 37,850 | 48,906 | **50,010** | **4.0×** |
+| gfx1100 (RX 7900) | vram | 24,679 | 5,909 | 6,660 | — |
+| | **kvd** | 23,757 | 26,247 | **26,786** | **4.0×** |
+| gfx1100w (W7900) | vram | 22,824 | 5,406 | 6,027 | — |
+| | **kvd** | 20,736 | 23,858 | **24,017** | **4.0×** |
+| gfx1100p (RDNA3 Pro) | vram | 14,524 | 3,463 | 3,841 | — |
+| | **kvd** | 13,784 | 16,141 | **16,531** | **4.3×** |
+
+Peak sustained (kvd, c=32) ranks by silicon as expected: **MI300A 70k > MI210 50k
+> RX 7900 27k ≈ W7900 24k > RDNA3-Pro 16.5k**. (MI350X/gfx950 from the separate
+128k O_DIRECT study peaked ~118k at c=16 with page-cache-served L2 — see
+`cliff-odirect-readpath-gfx942-vs-gfx950.md`.)
+
+## The cliff, and why the tiered arm holds
+
+For **every** arch the vram_only arm shows the same shape: fast at c=1, then a
+sharp drop at c=8/c=32 as vLLM's VRAM prefix cache hit rate collapses (scraped
+`l1_hit`: **87% → 11% → 22%**) and the fresh per-client prefixes are recomputed.
+The kvd_v2 arm keeps its scraped prefix hit at **87% across all concurrencies**:
+LMCache persists each concurrency's KV (per-concurrency warmup populates it) and
+restores it instead of recomputing, so throughput *rises* with concurrency rather
+than cliffing. `ext_hit` was 0% throughout — at ISL 8000 the working set fit the
+4 GB DRAM L1, so nothing spilled to the POSIX disk L2 (unlike the 128k study,
+where it did). The recovery here is the **DRAM-L1 tier**; the disk L2 only engages
+at larger working sets.
+
+Caveat: the vram arm gets a single global warmup while the kvd arm gets a
+per-concurrency warmup, so part of the c=8/c=32 gap is priming, not just tiering.
+The absolute kvd throughput and the flat 87% hit are still the representative
+"cache-served" numbers.
+
+## Operational findings
+
+1. **Arch portability is a config problem, not (mostly) a kernel problem** — for
+   CDNA2 + RDNA3 the only blockers were fp8 KV cache and AITER. Two env toggles
+   unlock four more arches. The multi-arch image itself already carries the
+   kernels (it loaded and ran on all of them).
+2. **CDNA1 (MI100) and RDNA4 (gfx1201) are not one-toggle-away** — vLLM startup
+   never completed. Likely `--async-scheduling` and/or the attention backend;
+   worth a follow-up with `TORCH_SDPA` and async-scheduling off.
+3. **NFS image staging is the throughput bottleneck for wide fan-out** — seven
+   jobs each decompressing the same 11 GB image off shared `$HOME` serialized on
+   NFS read bandwidth (~10 min to load). For big sweeps, pre-`docker load` the
+   image on each node, or stage per-node.
+4. **Single-GPU consumer/workstation nodes are scarce and often reserved** — most
+   scheduling friction was finding a free GPU, not running the job. Pin to a node
+   with a free `gres/gpu` in `AllocTRES` and confirm it's in `defq` (some are in
+   `vm`).
+
+## Repro
+
+```
+make cliff-submit AIC_CLIFF_GFX=<arch> AIC_CLIFF_NODE=<node> \
+  HF_HOME=$HOME/aic-hf AIC_IMAGE_DIR=$HOME/aic-images \
+  VLLM_MODEL=Qwen/Qwen2.5-3B-Instruct \
+  AIC_CLIFF_ARMS=vram,nvme AIC_L2_BACKEND=local_disk \
+  AIC_KV_CACHE_DTYPE=auto AIC_ROCM_USE_AITER=0 \          # <-- for non-CDNA3 arches
+  AIC_LOCAL_CPU=true LMCACHE_MAX_LOCAL_CPU_SIZE=4 \
+  VLM_GPU_MEMORY_UTILIZATION=0.85 \
+  BENCH_ISL=8000 BENCH_SHARED_TOK=7000 BENCH_PREFIX_MODE=per_client \
+  BENCH_CONCUR=1,8,32 BENCH_ITERS=1 AIC_CLIFF_TIME=01:00:00
+```
+
+Drop `AIC_KV_CACHE_DTYPE`/`AIC_ROCM_USE_AITER` (defaults fp8/aiter) on gfx942/gfx950.
+
+Jobs: gfx942 67545621 · gfx90a 67545783 · gfx1100 67545784 · gfx1100p 67545785 ·
+gfx1100w 67545786 · (failed: gfx908 67545782, gfx1201 67545787).

--- a/.docs-remove/cliff-odirect-readpath-gfx942-vs-gfx950.md
+++ b/.docs-remove/cliff-odirect-readpath-gfx942-vs-gfx950.md
@@ -1,0 +1,118 @@
+# POSIX-L2 read path: page-cache vs O_DIRECT (gfx950 vs gfx942)
+
+First cliff runs on **new GFX arches** (MI350X / gfx950) plus an O_DIRECT A/B that
+isolates the **real NVMe read path** of the LMCache native `LocalDiskBackend`
+(POSIX) L2 tier. Two jobs:
+
+| job | node | GFX | L2 backend | I/O mode | NVMe |
+|---|---|---|---|---|---|
+| 67545293 | bg-1w300-h3-3 | gfx950 (MI350X, 288 GB) | `local_disk` (POSIX) | buffered (page cache) | none → `/tmp` on root |
+| 67545466 | ctr-cx66-mi300x-13 | gfx942 (MI300X, 192 GB) | `local_disk` (POSIX) | **O_DIRECT** | dedicated `/mnt/aic-lmcache` (`nvme2n1`) |
+
+Common recipe: `cliff-long-128k` base — Qwen2.5-3B-Instruct (full-attention; the
+LMCache connector needs it — gpt-oss is hybrid and can't unify KV specs under a
+connector on vLLM 0.25), YaRN ×4 → 131072, ISL 128000 / shared prefix 126000,
+`per_client`, arms **vram + nvme(POSIX)**, DRAM L1 = 8 GB, `BENCH_CONCUR=1,16`.
+VRAM limited via `VLM_GPU_MEMORY_UTILIZATION` (0.06 on gfx950 / 0.08 on gfx942)
+so the c=16 working set (~34 GB) overflows VRAM and the tier is exercised.
+
+## TL;DR
+
+- The cliff and its recovery reproduce on **both** arches. On gfx950 the vram arm
+  collapses **122,696 → 6,029 tok/s** at c=16 (20×); on gfx942 (slower MI300X)
+  **78,824 → 3,199 tok/s** (one request even hit the 600 s client timeout).
+- **The gfx950 "recovery" was inflated by the page cache.** With buffered I/O on a
+  540 GB-RAM node, the ~38 GB working set stayed resident (Cached grew +37.8 GB),
+  so the nvme arm's c=16 reads were **RAM hits, not disk** — physical NVMe reads
+  were **0.00 GB / 49 ops**. That bought 117,913 tok/s.
+- **O_DIRECT on gfx942 shows the true read path.** Forcing the reads to the device
+  (bypassing page cache) yields **36.22 GB of real NVMe reads (31,837 ops)** and a
+  c=16 throughput of **35,840 tok/s** — still an **11.2× recovery** over the 3,199
+  tok/s recompute cliff, but ~3.3× below the page-cache number. That gap is the
+  cost of actually going to disk.
+- Both are legitimate operating points: **buffered** = fast when the working set
+  fits host RAM; **O_DIRECT** = the guaranteed floor when it doesn't.
+
+## Throughput (tok/s)
+
+| arm | gfx950 c=1 | gfx950 c=16 | gfx942 c=1 | gfx942 c=16 |
+|---|---|---|---|---|
+| vram_only | 122,696 | **6,029** | 78,824 | **3,199** (1 timeout) |
+| nvme-posix | 119,312 | **117,913** | 77,357 | **35,840** |
+| recovery | — | 19.6× | — | 11.2× |
+
+gfx950 (MI350X) is ~1.5× faster than gfx942 (MI300X) at c=1 (122k vs 79k tok/s),
+as expected for the newer part.
+
+## vLLM compute metrics (from the Prometheus TSDB, per-arm window)
+
+| metric | gfx950 vram | gfx950 nvme | gfx942 vram | gfx942 nvme (O_DIRECT) |
+|---|---|---|---|---|
+| prefill KV tokens computed | 1.92 M | 2.07 M ⁽*⁾ | 1.92 M | 1.96 M ⁽*⁾ |
+| prompt tokens cached (compute skipped) | 11.6% | 44.1% | 11.6% | 52.3% |
+| VRAM prefix-cache hit | 11.6% | 6.1% | 11.6% | 6.1% |
+| **external (LMCache L2) prefix hit** | 0% | **45.6%** (1.64 M tok) | 0% | **49.5%** (1.96 M tok) |
+| TTFT avg | 141.6 s | 100.8 s | 255.7 s | 148.3 s |
+| GPU gfx activity (avg / max) | 95.9% / 100% | 89.2% / 100% | n/a ⁽†⁾ | n/a ⁽†⁾ |
+| GPU package power (avg) | 905 W | 847 W | n/a ⁽†⁾ | n/a ⁽†⁾ |
+
+⁽*⁾ The nvme arm's *computed*-token count is slightly **higher** than vram's: its
+window includes the one-time warmup that **populates** the L2 (KV must be computed
+once before it can be written). The win is not fewer FLOPs on first touch — it is
+that the timed c=16 pass then **serves ~half the tokens from L2 instead of
+recomputing**, which is what recovers the cliff.
+
+⁽†⁾ GPU activity was captured on gfx950 (containerized `rocm/device-metrics-exporter`,
+`gpu_gfx_activity`) but **not** on gfx942: that node had a pre-existing host GPU
+exporter on :5000 which the sbatch reused, and it does not export `gpu_gfx_activity`.
+
+## NVMe read data — the headline
+
+Per-device disk I/O during the nvme arm (from `node_exporter` `node_disk_*`):
+
+**gfx950 (buffered / page cache), device `nvme0n1` = `/tmp` on root:**
+
+| | READ | WRITE |
+|---|---|---|
+| bytes | **0.00 GB** | 37.8 GB |
+| ops | 49 | 48,531 |
+
+Node memory context: MemTotal 540 GB; `Cached` 116.8 → 154.6 GB (**+37.8 GB**,
+matching the write volume). The entire L2 working set was absorbed into the page
+cache, so every "L2 read" was free.
+
+**gfx942 (O_DIRECT), dedicated device `nvme2n1` = `/mnt/aic-lmcache`:**
+
+| device | READ | WRITE | role |
+|---|---|---|---|
+| **nvme2n1** | **36.22 GB** (31,837 ops) | 37.63 GB (37,049 ops) | dedicated L2 |
+| nvme0n1 | 0 | 0.18 GB | root (logs) |
+| nvme1n1 / nvme3n1 | 0 | 0 | idle spares |
+
+- **Real physical reads: 36.22 GB / 31,837 ops** — the KV working set genuinely
+  read back from the NVMe platter (≈ the 37.63 GB written).
+- **Read bandwidth: 1.78 GB/s** during the 20.3 s of active read-time. (The
+  50.7 MB/s window-average is diluted by long compute-bound stretches with no I/O.)
+
+## Method
+
+The per-job TSDB (`logs/<job>/prometheus`) is stopped before head compaction, so
+all samples live in the WAL. To query: copy the dir, drop `lock`/`queries.active`,
+and run `prom/prometheus:v2.55.1` **as the current uid** (`--user $(id -u):$(id -g)`;
+the default `nobody` can't write the mounted storage path) over it with a minimal
+config — it replays the WAL (~0.4 s) and the data is queryable via the HTTP API.
+Arms are separated by the vLLM scrape target: `instance="localhost:8001"` = vram,
+`:8000` = nvme. Counter deltas = value(end) − value(start); gauges via
+`avg()`/`avg_over_time` (collapse the per-`kfd_process_id` series churn, else the
+sum inflates ~20×). NVMe device I/O = `node_disk_{read,written}_bytes_total`.
+
+## Infra note (non-MI300X nodes)
+
+The gfx950 (and other non-MI300X) Markham nodes have a **node-local `/scratch`**,
+not the shared `/scratch` the MI300X rack sees, so the default HF cache and image
+paths are empty there. Stage to the shared `$HOME` (NFS, `/home_mkm`) and pass
+`HF_HOME=$HOME/aic-hf AIC_IMAGE_DIR=$HOME/aic-images` on the make command line
+(command-line values aren't stripped by `_CLIFF_STRIP`, so they reach the job).
+The default `make dist-build` image is already multi-arch (gfx90a;gfx942;gfx950;
+gfx1100;gfx1101;gfx1150;gfx1151;gfx1200;gfx1201), so no rebuild is needed to run
+on gfx950.

--- a/.slurm/run-cliff.sbatch
+++ b/.slurm/run-cliff.sbatch
@@ -6,6 +6,18 @@
 #
 #SBATCH --job-name=aic-day-cliff
 #SBATCH --partition=defq
+# Default: a Markham MI300X (gfx942) node with local NVMe -- the validated
+# tiered-cache path.  To target another GFX arch, override the constraint on the
+# sbatch command line (a command-line --constraint wins over this directive),
+# most easily via the Makefile knobs:
+#   make cliff-submit AIC_CLIFF_GFX=gfx950
+#   make cliff-submit AIC_CLIFF_CONSTRAINT=MARKHAM&GFX90A
+# Non-gfx942 nodes have no local NVMe, so the nvme/gds arms drop to /tmp
+# (AIC_NVME_AUTO case 4).  The model is auto-selected from the node's GPU arch
+# (big CDNA gfx942/gfx950 -> gpt-oss-120b, else a small model; see
+# select_default_model below) unless VLLM_MODEL is set.  The default image
+# already carries kernels for every arch (`make dist-build` is multi-arch by
+# default), so no rebuild is needed.
 #SBATCH --constraint=MARKHAM&GFX942&NVME
 #SBATCH --gres=gpu:1
 #SBATCH --nodes=1
@@ -85,8 +97,17 @@ fi
 
 AIC_IMAGE="${AIC_IMAGE:-rocm-aic:latest}"
 AIC_IMAGE_DIR="${AIC_IMAGE_DIR:-/scratch/${USER}/images}"
-VLLM_MODEL="${VLLM_MODEL:-openai/gpt-oss-120b}"
-# Shared HF cache that already holds gpt-oss-120b (see plan); offline so no token.
+# Model selection.  Leave VLLM_MODEL empty to auto-pick a default from the node's
+# detected GPU arch (select_default_model(), below): gpt-oss-120b (~60 GB MXFP4)
+# fits the big-VRAM CDNA parts (MI300X gfx942 / MI350X gfx950) but NOT the
+# smaller-VRAM arches (MI210 gfx90a 64 GB, MI100 gfx908, and all RDNA gfx11xx/
+# gfx12xx), which get a small model instead.  A caller-set VLLM_MODEL is always
+# honored as-is (no arch check).  Both tier defaults are overridable and MUST be
+# pre-staged in HF_HOME (offline): AIC_MODEL_BIG / AIC_MODEL_SMALL.
+VLLM_MODEL="${VLLM_MODEL:-}"
+AIC_MODEL_BIG="${AIC_MODEL_BIG:-openai/gpt-oss-120b}"            # >=128 GB HBM CDNA (gfx942/gfx950)
+AIC_MODEL_SMALL="${AIC_MODEL_SMALL:-Qwen/Qwen2.5-3B-Instruct}"  # small-VRAM parts (staged in the shared HF cache)
+# Shared HF cache that already holds gpt-oss-120b + Qwen2.5-3B; offline so no token.
 HF_HOME="${HF_HOME:-/scratch/${USER}/vllm-lmcache-hipfile/hf}"
 
 # Storage for the LMCache tiers (see the storage note above).  With
@@ -193,6 +214,12 @@ fi
 # gpt-oss can't unify its KV-cache specs under a connector on 0.25.  Same backend
 # on all arms keeps baseline (vram) and kvd comparable.
 AIC_ATTENTION_BACKEND="${AIC_ATTENTION_BACKEND:-TRITON_ATTN}"
+# KV-cache dtype + AITER are MI300/MI350 (CDNA3+) features: fp8 KV cache and the
+# ROCm AITER kernels fail vLLM engine init on MI100/MI210 (no native fp8) and on
+# RDNA.  Defaults reproduce the release config (fp8 + aiter) for gfx942/gfx950;
+# for older/consumer arches pass AIC_KV_CACHE_DTYPE=auto AIC_ROCM_USE_AITER=0.
+AIC_KV_CACHE_DTYPE="${AIC_KV_CACHE_DTYPE:-fp8}"
+AIC_ROCM_USE_AITER="${AIC_ROCM_USE_AITER:-1}"
 
 VRAM_PORT=8001
 KVD_PORT=8000
@@ -306,9 +333,54 @@ provision_storage() {
     GDS_SLAB_DATA="${GDS_SLAB_DATA:-${AIC_LOCAL_ROOT}/slab}"  # GDS L1 slab
 }
 
+# Detect the node's GPU arch (gfxNNNN) for default-model selection.  Prefer the
+# host ROCm tools; if neither is on the host PATH, peek at KFD sysfs
+# (gfx_target_version, e.g. 90402 -> gfx942, 110000 -> gfx1100).  Echoes the arch
+# or nothing.
+detect_gpu_arch() {
+    local a v maj min stp
+    a="$(rocm_agent_enumerator 2>/dev/null | grep -m1 -E '^gfx[0-9a-f]+')" \
+        && [[ -n "${a}" ]] && { printf '%s' "${a}"; return; }
+    a="$(rocminfo 2>/dev/null | grep -m1 -oE 'gfx[0-9a-f]+')" \
+        && [[ -n "${a}" ]] && { printf '%s' "${a}"; return; }
+    for f in /sys/class/kfd/kfd/topology/nodes/*/properties; do
+        v="$(grep -m1 '^gfx_target_version ' "${f}" 2>/dev/null | awk '{print $2}')"
+        [[ "${v}" =~ ^[0-9]+$ && "${v}" -gt 0 ]] || continue
+        maj=$(( v / 10000 )); min=$(( (v / 100) % 100 )); stp=$(( v % 100 ))
+        printf 'gfx%d%x%x' "${maj}" "${min}" "${stp}"; return
+    done
+}
+
+# Choose VLLM_MODEL from the detected arch unless the caller pinned it.  Big-VRAM
+# CDNA -> AIC_MODEL_BIG; everything else (incl. unknown/undetectable, played
+# safe) -> AIC_MODEL_SMALL, except detection failure defaults to BIG to preserve
+# the historical gfx942 behavior.
+select_default_model() {
+    if [[ -n "${VLLM_MODEL}" ]]; then
+        log "model       : ${VLLM_MODEL} (pinned by caller)"
+        return
+    fi
+    local arch; arch="$(detect_gpu_arch)"
+    case "${arch}" in
+        gfx942|gfx950)
+            VLLM_MODEL="${AIC_MODEL_BIG}"
+            log "model       : auto (${arch}, big-VRAM CDNA) -> ${VLLM_MODEL}" ;;
+        gfx90a|gfx908|gfx906|gfx11??|gfx12??)
+            VLLM_MODEL="${AIC_MODEL_SMALL}"
+            log "model       : auto (${arch}, small-VRAM) -> ${VLLM_MODEL}" ;;
+        "")
+            VLLM_MODEL="${AIC_MODEL_BIG}"
+            log "model       : WARN could not detect GPU arch; defaulting to ${VLLM_MODEL} (set VLLM_MODEL to override)" ;;
+        *)
+            VLLM_MODEL="${AIC_MODEL_SMALL}"
+            log "model       : auto (unrecognized arch ${arch}) -> conservative ${VLLM_MODEL}" ;;
+    esac
+}
+
 log "host        : $(hostname)  job=${SLURM_JOB_ID:-manual}"
 log "image       : ${AIC_IMAGE}"
-log "model       : ${VLLM_MODEL}  (HF_HOME=${HF_HOME}, offline)"
+select_default_model
+log "model HF_HOME: ${HF_HOME} (offline)"
 provision_storage
 log "local NVMe  : ${NVME_DATA}"
 log "results     : ${RESULTS}"
@@ -395,7 +467,7 @@ HF_ENV=(-e HF_HOME=/hf -e HF_HUB_CACHE=/hf/hub -e HF_HUB_OFFLINE=1
         # VLLM_ROCM_USE_AITER=1 the ROCM_AITER_UNIFIED_ATTN backend is rejected and
         # vLLM falls back to TRITON_ATTN -> "Hybrid KV cache manager is disabled but
         # failed to convert the KV cache specs" at engine init.
-        -e VLLM_ROCM_USE_AITER=1)
+        -e VLLM_ROCM_USE_AITER=${AIC_ROCM_USE_AITER})
 
 # --- Helpers -----------------------------------------------------------------
 wait_ready() {  # $1=port $2=timeout_s
@@ -473,7 +545,7 @@ run_arm_vram() {
             --max-model-len "${VLM_MAX_MODEL_LEN}" \
             --max-num-batched-tokens "${VLM_MAX_NUM_BATCHED_TOKENS}" \
             "${ROPE_ARGS[@]}" \
-            --block-size 64 --enable-prefix-caching --kv-cache-dtype fp8 \
+            --block-size 64 --enable-prefix-caching --kv-cache-dtype ${AIC_KV_CACHE_DTYPE} \
             --async-scheduling \
             --attention-backend "${AIC_ATTENTION_BACKEND}" \
             --disable-access-log-for-endpoints "/health,/metrics,/v1/models" \
@@ -612,7 +684,7 @@ launch_vllm_kvd_nvme() {
             --max-model-len "${VLM_MAX_MODEL_LEN}" \
             --max-num-batched-tokens "${VLM_MAX_NUM_BATCHED_TOKENS}" \
             "${ROPE_ARGS[@]}" \
-            --block-size 64 --enable-prefix-caching --kv-cache-dtype fp8 \
+            --block-size 64 --enable-prefix-caching --kv-cache-dtype ${AIC_KV_CACHE_DTYPE} \
             --async-scheduling \
             --attention-backend "${AIC_ATTENTION_BACKEND}" \
             --disable-access-log-for-endpoints "/health,/metrics,/v1/models" \
@@ -634,7 +706,7 @@ launch_vllm_kvd_gds() {
             --max-model-len "${VLM_MAX_MODEL_LEN}" \
             --max-num-batched-tokens "${VLM_MAX_NUM_BATCHED_TOKENS}" \
             "${ROPE_ARGS[@]}" \
-            --block-size 64 --enable-prefix-caching --kv-cache-dtype fp8 \
+            --block-size 64 --enable-prefix-caching --kv-cache-dtype ${AIC_KV_CACHE_DTYPE} \
             --async-scheduling \
             --attention-backend "${AIC_ATTENTION_BACKEND}" \
             --disable-access-log-for-endpoints "/health,/metrics,/v1/models" \

--- a/Makefile
+++ b/Makefile
@@ -197,6 +197,9 @@ help:
 	@echo "  make cliff-long-128k   sbatch a 128k-ISL YaRN(x4) 3-arm sweep (extreme; big DRAM/slab pools)"
 	@echo "    Chain like the old run-this.sh:  make dist-build dist-push smoke-test"
 	@echo "    Pin a node: AIC_CLIFF_NODE=<node>   Narrow arms: AIC_CLIFF_ARMS=nvme (vram,nvme,gds)"
+	@echo "    Target another GFX: AIC_CLIFF_GFX=gfx950 (or AIC_CLIFF_CONSTRAINT=MARKHAM&GFX90A)"
+	@echo "      non-gfx942 nodes: no local NVMe (nvme/gds arms fall back to /tmp); the model"
+	@echo "      auto-selects by GPU arch (big CDNA=gpt-oss-120b, else Qwen2.5-3B); image is multi-arch"
 	@echo "    Override sweep/model via env: BENCH_CONCUR=1,8,64 VLLM_MODEL=... make cliff-submit"
 	@echo "    AIC_CACHE_DIR=$(AIC_CACHE_DIR)  (shared BuildKit cache; set empty to disable)"
 	@echo ""
@@ -394,7 +397,38 @@ smoke-test:                    # Load + smoke-test the image on a GPU+NVMe node
 # _CLIFF_SBATCH_ARGS: partition + constraint overrides passed on the sbatch
 # command line (takes precedence over #SBATCH directives in run-cliff.sbatch).
 # On SPUR, override to amd-spur with no constraint and no --gres (no GPU GRES
-# configured); on standard Slurm the script's own #SBATCH lines take effect.
+# configured); on standard Slurm we pass $(AIC_CLIFF_CONSTRAINT) (below).
+#
+# ---- cliff GFX / constraint selection ----
+# By default the cliff job runs on a Markham MI300X (gfx942) node with local
+# NVMe -- the validated tiered-cache path.  To target another GFX arch, set
+#   AIC_CLIFF_GFX=gfx950        -> expands to constraint "MARKHAM&GFX950"
+# (the &NVME requirement is dropped, since only gfx942 nodes advertise NVME),
+# or pass a full Slurm constraint expression directly via
+#   AIC_CLIFF_CONSTRAINT=MARKHAM&GFX90A
+# AIC_CLIFF_CONSTRAINT wins if both are set; either overrides the #SBATCH
+# --constraint line baked into run-cliff.sbatch.  Caveats for non-gfx942 nodes:
+#   * no local NVMe -> the nvme/gds arms fall back to root-disk /tmp
+#     (AIC_NVME_AUTO case 4): slower and less representative, but they run.
+#   * gpt-oss-120b will NOT fit on small-VRAM parts (gfx1100/1151/1201; tight on
+#     gfx90a), so the job auto-selects the model from the node's detected GPU
+#     arch (big CDNA gfx942/gfx950 -> gpt-oss-120b, everything else -> a small
+#     model); see select_default_model in .slurm/run-cliff.sbatch.  Override with
+#     VLLM_MODEL=<pre-staged model> (offline HF_HOME) or the AIC_MODEL_BIG/
+#     AIC_MODEL_SMALL tier knobs.
+#   * the loaded image must contain kernels for the target arch.  This is
+#     already the case: `make dist-build` is multi-arch by default (AIC_ROCM_ARCH
+#     defaults to gfx90a;gfx942;gfx950;gfx1100;gfx1101;gfx1150;gfx1151;gfx1200;
+#     gfx1201 -- see .slurm/run-build-distribute.sh).  RDNA parts have no
+#     NVMe-DMA hardware, so the gds arm is CDNA-only there.
+AIC_CLIFF_GFX ?=
+ifeq ($(strip $(AIC_CLIFF_CONSTRAINT)),)
+ifneq ($(strip $(AIC_CLIFF_GFX)),)
+AIC_CLIFF_CONSTRAINT := MARKHAM&$(shell echo '$(AIC_CLIFF_GFX)' | tr '[:lower:]' '[:upper:]')
+else
+AIC_CLIFF_CONSTRAINT := MARKHAM&GFX942&NVME
+endif
+endif
 ifeq ($(AIC_SPUR_CLUSTER),1)
 _CLIFF_SPUR_CTL  := SPUR_CONTROLLER_ADDR=$(AIC_SPUR_CONTROLLER)
 _CLIFF_SBATCH_ARGS := --partition=amd-spur --constraint= \
@@ -404,7 +438,10 @@ _CLIFF_SUBMIT     = $(_CLIFF_SPUR_CTL) $(_CLIFF_STRIP) sbatch \
     $(_CLIFF_SBATCH_ARGS) $(1) .slurm/run-cliff.sbatch 2>&1 | \
     tee /dev/stderr | grep -oE '[0-9]+$$' | tail -1
 else
-_CLIFF_SBATCH_ARGS := $(if $(AIC_CLIFF_NODE),--nodelist=$(AIC_CLIFF_NODE),)
+# NB: single-quote the constraint -- it contains '&' (a shell metacharacter) that
+# would otherwise background the sbatch call in the recipe subshell.
+_CLIFF_SBATCH_ARGS := --constraint='$(AIC_CLIFF_CONSTRAINT)' \
+    $(if $(AIC_CLIFF_NODE),--nodelist=$(AIC_CLIFF_NODE),)
 _CLIFF_SUBMIT     = $(_CLIFF_STRIP) sbatch --parsable \
     $(_CLIFF_SBATCH_ARGS) $(1) .slurm/run-cliff.sbatch
 endif


### PR DESCRIPTION
…s-GFX reports

Relax the cliff harness from gfx942-only so it can target other Markham GPU architectures, and document the findings from doing so.

Makefile:
  - AIC_CLIFF_GFX=<arch> / AIC_CLIFF_CONSTRAINT=<expr> knobs select the Slurm constraint (default unchanged: MARKHAM&GFX942&NVME). Single-quote the constraint in the sbatch args -- '&' would otherwise background the call.

run-cliff.sbatch:
  - Auto-select VLLM_MODEL from the node's detected GPU arch (detect_gpu_arch / select_default_model): big-VRAM CDNA (gfx942/gfx950) -> gpt-oss-120b, else a small model; a caller-set VLLM_MODEL is always honored. Tunable via AIC_MODEL_BIG / AIC_MODEL_SMALL.
  - AIC_KV_CACHE_DTYPE (default fp8) and AIC_ROCM_USE_AITER (default 1) knobs. fp8 KV cache + AITER are CDNA3+-only and fail vLLM init on MI210/RDNA; set AIC_KV_CACHE_DTYPE=auto AIC_ROCM_USE_AITER=0 for those arches. All defaults reproduce the prior gfx942 behavior.

Reports (.docs-remove/):
  - cliff-odirect-readpath-gfx942-vs-gfx950.md: POSIX-L2 page-cache vs O_DIRECT. gfx950's recovery was RAM-served (0 physical reads); O_DIRECT on gfx942 with a dedicated NVMe shows 36.2 GB real reads @ 1.78 GB/s, 11.2x cliff recovery.
  - cliff-cross-gfx-sweep.md: parallel short cliff runs across the cluster. vLLM boots on CDNA2/3/3.5 + RDNA3 (MI210/MI300A/MI350X/RX7900/W7900); MI100 and RDNA4 do not. LMCache POSIX tiering recovers the cliff ~3.3-4.3x at c=32 on every arch that runs.
