### PR TITLE
diff --git a/.github/workflows/aic-docker.yml b/.github/workflows/aic…

### DIFF
--- a/.github/workflows/aic-docker.yml
+++ b/.github/workflows/aic-docker.yml
@@ -16,7 +16,7 @@
 #   Optional: pass TLS_CERT_SECRET=true to inject a corp CA cert via
 #   the CORP_CA_CERT repository secret (see step below).
 #
-name: AIC Docker build
+name: AIC Docker Build
 
 on:
   workflow_dispatch:

--- a/.github/workflows/aic-export.yml
+++ b/.github/workflows/aic-export.yml
@@ -7,7 +7,7 @@
 # artifacts leaked in, key sources present), and uploads it as a downloadable
 # workflow artifact.  No Docker build required.
 #
-name: AIC export tarball
+name: AIC Export Tarball
 
 on:
   push:

--- a/.github/workflows/aic-nightly-wheels.yml
+++ b/.github/workflows/aic-nightly-wheels.yml
@@ -22,7 +22,7 @@
 # ships.  If a future component pin fails to build for the RDNA archs
 # (gfx11xx/gfx12xx), narrow it to the CDNA set "gfx90a;gfx942;gfx950" via the
 # rocm_arch input.
-name: AIC nightly wheels
+name: AIC Nightly Wheels
 
 on:
   schedule:

--- a/.github/workflows/aic-patches.yml
+++ b/.github/workflows/aic-patches.yml
@@ -6,7 +6,7 @@
 # Validates that all LMCache and NIXL patches apply cleanly against their
 # pinned upstream SHAs without requiring a full Docker build.
 #
-name: AIC patch validation
+name: AIC Nightly Patch Validation
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -6,10 +6,15 @@
 [![vLLM](https://img.shields.io/badge/vLLM-0.25.0+rocm723-blue.svg)](https://github.com/vllm-project/vllm)
 [![LMCache](https://img.shields.io/badge/LMCache-v0.5.1-blue.svg)](https://github.com/LMCache/LMCache)
 [![NIXL](https://img.shields.io/badge/NIXL-v1.3.1-blue.svg)](https://github.com/ai-dynamo/nixl)
+[![hsa-snoop](https://img.shields.io/badge/hsa--snoop-v1.0.0-blue.svg)](https://github.com/sbates130272/hsa-snoop)
 [![Spelling](https://github.com/ROCm/rocm-aic/actions/workflows/aic-spellcheck.yml/badge.svg)](https://github.com/ROCm/rocm-aic/actions/workflows/aic-spellcheck.yml)
+[![Lint](https://github.com/ROCm/rocm-aic/actions/workflows/aic-lint.yml/badge.svg)](https://github.com/ROCm/rocm-aic/actions/workflows/aic-lint.yml)
+[![Export Tarball](https://github.com/ROCm/rocm-aic/actions/workflows/aic-export.yml/badge.svg)](https://github.com/ROCm/rocm-aic/actions/workflows/aic-export.yml)
 [![Nightly Dist Build](https://github.com/ROCm/rocm-aic/actions/workflows/aic-amd-nightly-dist-build.yml/badge.svg)](https://github.com/ROCm/rocm-aic/actions/workflows/aic-amd-nightly-dist-build.yml)
 [![Nightly Smoke Test](https://github.com/ROCm/rocm-aic/actions/workflows/aic-amd-nightly-smoke-test.yml/badge.svg)](https://github.com/ROCm/rocm-aic/actions/workflows/aic-amd-nightly-smoke-test.yml)
 [![Nightly Cliff](https://github.com/ROCm/rocm-aic/actions/workflows/aic-amd-nightly-cliff.yml/badge.svg)](https://github.com/ROCm/rocm-aic/actions/workflows/aic-amd-nightly-cliff.yml)
+[![Nightly Wheels](https://github.com/ROCm/rocm-aic/actions/workflows/aic-nightly-wheels.yml/badge.svg)](https://github.com/ROCm/rocm-aic/actions/workflows/aic-nightly-wheels.yml)
+[![Nightly Patch Validation](https://github.com/ROCm/rocm-aic/actions/workflows/aic-patches.yml/badge.svg)](https://github.com/ROCm/rocm-aic/actions/workflows/aic-patches.yml)
 
 > [!CAUTION]
 > This release is an *early-access* software technology preview. Running


### PR DESCRIPTION
Add GitHub Actions badges to README.md for four previously unbadged continuous workflows (Lint, Export Tarball, Nightly Wheels, Nightly Patch Validation), grouped with existing CI and nightly badges. Also add a hsa-snoop v1.0.0 version badge after NIXL.

Normalize the `name:` field in four workflow files to title case for consistency with the rest of the workflow suite:
- AIC nightly wheels → AIC Nightly Wheels
- AIC patch validation → AIC Nightly Patch Validation
- AIC export tarball → AIC Export Tarball
- AIC Docker build → AIC Docker Build
