### PR TITLE
ci: externalize AMD-internal values; add .cline_storage and .mypy_cac…

### DIFF
--- a/.github/scripts/spur-cliff.sh
+++ b/.github/scripts/spur-cliff.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Runs on the self-hosted runner; SSHes to amd-aic-spur, uses the clone and
+# Runs on the self-hosted runner; SSHes to the SPUR head node (AIC_SPUR_HOST), uses the clone and
 # tarball left by spur-dist-build.sh, and runs a cliff benchmark.
 #
 # Usage: spur-cliff.sh <full-sha> <target>
@@ -14,18 +14,25 @@ SHA="${1:?usage: $0 <full-sha> <cliff-short|cliff-submit>}"
 TARGET="${2:?usage: $0 <full-sha> <cliff-short|cliff-submit>}"
 SHORT="${SHA:0:7}"
 AIC_IMAGE="rocm-aic-ci-${SHORT}:latest"
-TARBALL_DIR="/shared_nfs/\${USER}/images/aic-ci-${SHORT}"
+AIC_SPUR_HOST="${AIC_SPUR_HOST:?AIC_SPUR_HOST must be set (e.g. via GitHub repo variable)}"
+AIC_SPUR_HOST="${AIC_SPUR_HOST//[$'\t\r\n ']}"
+AIC_SHARED_NFS="${AIC_SHARED_NFS:?AIC_SHARED_NFS must be set (e.g. via GitHub repo variable)}"
+AIC_SPUR_CONTROLLER="${AIC_SPUR_CONTROLLER:?AIC_SPUR_CONTROLLER must be set (e.g. via GitHub repo variable)}"
+TARBALL_DIR="${AIC_SHARED_NFS}/\${USER}/images/aic-ci-${SHORT}"
 
 case "${TARGET}" in
     cliff-short|cliff-submit) ;;
     *) echo "ERROR: target must be cliff-short or cliff-submit" >&2; exit 1 ;;
 esac
 
-ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=4 amd-aic-spur env \
+ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=4 "${AIC_SPUR_HOST}" env \
     SHA="${SHA}" \
     TARGET="${TARGET}" \
     AIC_IMAGE="${AIC_IMAGE}" \
     TARBALL_DIR="${TARBALL_DIR}" \
+    AIC_SHARED_NFS="${AIC_SHARED_NFS}" \
+    AIC_SPUR_CONTROLLER="${AIC_SPUR_CONTROLLER}" \
+    SPUR_CONTROLLER_ADDR="${AIC_SPUR_CONTROLLER}" \
     bash << 'REMOTE'
 set -euo pipefail
 

--- a/.github/scripts/spur-dist-build.sh
+++ b/.github/scripts/spur-dist-build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Runs on the self-hosted runner; SSHes to amd-aic-spur, clones the repo at
+# Runs on the self-hosted runner; SSHes to the SPUR head node (AIC_SPUR_HOST), clones the repo at
 # the current SHA, and runs dist-build with a CI-scoped image name and tarball
 # path. The clone and tarball are left in place for spur-smoke-test.sh to use;
 # spur-smoke-test.sh owns the final cleanup.
@@ -10,15 +10,22 @@ set -euo pipefail
 
 SHA="${1:?usage: $0 <full-sha>}"
 SHORT="${SHA:0:7}"
-REPO="git@github.com:ROCm/rocm-icms.git"
+REPO="git@github.com:ROCm/rocm-aic.git"
 AIC_IMAGE="rocm-aic-ci-${SHORT}:latest"
-TARBALL_DIR="/shared_nfs/${USER}/images/aic-ci-${SHORT}"
+AIC_SPUR_HOST="${AIC_SPUR_HOST:?AIC_SPUR_HOST must be set (e.g. via GitHub repo variable)}"
+AIC_SPUR_HOST="${AIC_SPUR_HOST//[$'\t\r\n ']}"
+AIC_SHARED_NFS="${AIC_SHARED_NFS:?AIC_SHARED_NFS must be set (e.g. via GitHub repo variable)}"
+AIC_SPUR_CONTROLLER="${AIC_SPUR_CONTROLLER:?AIC_SPUR_CONTROLLER must be set (e.g. via GitHub repo variable)}"
+TARBALL_DIR="${AIC_SHARED_NFS}/${USER}/images/aic-ci-${SHORT}"
 
-ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=4 amd-aic-spur env \
+ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=4 "${AIC_SPUR_HOST}" env \
     SHA="${SHA}" \
     REPO="${REPO}" \
     AIC_IMAGE="${AIC_IMAGE}" \
     TARBALL_DIR="${TARBALL_DIR}" \
+    AIC_SHARED_NFS="${AIC_SHARED_NFS}" \
+    AIC_SPUR_CONTROLLER="${AIC_SPUR_CONTROLLER}" \
+    SPUR_CONTROLLER_ADDR="${AIC_SPUR_CONTROLLER}" \
     bash << 'REMOTE'
 set -euo pipefail
 

--- a/.github/scripts/spur-smoke-test.sh
+++ b/.github/scripts/spur-smoke-test.sh
@@ -1,19 +1,26 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Runs on the self-hosted runner; SSHes to amd-aic-spur and runs smoke-test
+# Runs on the self-hosted runner; SSHes to the SPUR head node (AIC_SPUR_HOST) and runs smoke-test
 # against the tarball produced by spur-dist-build.sh for the same SHA.
 # Always cleans up the clone and tarball dir on exit regardless of pass/fail.
 
 SHA="${1:?usage: $0 <full-sha>}"
 SHORT="${SHA:0:7}"
 AIC_IMAGE="rocm-aic-ci-${SHORT}:latest"
-TARBALL_DIR="/shared_nfs/${USER}/images/aic-ci-${SHORT}"
+AIC_SPUR_HOST="${AIC_SPUR_HOST:?AIC_SPUR_HOST must be set (e.g. via GitHub repo variable)}"
+AIC_SPUR_HOST="${AIC_SPUR_HOST//[$'\t\r\n ']}"
+AIC_SHARED_NFS="${AIC_SHARED_NFS:?AIC_SHARED_NFS must be set (e.g. via GitHub repo variable)}"
+AIC_SPUR_CONTROLLER="${AIC_SPUR_CONTROLLER:?AIC_SPUR_CONTROLLER must be set (e.g. via GitHub repo variable)}"
+TARBALL_DIR="${AIC_SHARED_NFS}/${USER}/images/aic-ci-${SHORT}"
 
-ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=4 amd-aic-spur env \
+ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=4 "${AIC_SPUR_HOST}" env \
     SHA="${SHA}" \
     AIC_IMAGE="${AIC_IMAGE}" \
     TARBALL_DIR="${TARBALL_DIR}" \
+    AIC_SHARED_NFS="${AIC_SHARED_NFS}" \
+    AIC_SPUR_CONTROLLER="${AIC_SPUR_CONTROLLER}" \
+    SPUR_CONTROLLER_ADDR="${AIC_SPUR_CONTROLLER}" \
     bash << 'REMOTE'
 set -euo pipefail
 

--- a/.github/workflows/aic-amd-cliff.yml
+++ b/.github/workflows/aic-amd-cliff.yml
@@ -81,6 +81,10 @@ jobs:
     permissions:
       pull-requests: write
       statuses: write
+    env:
+      AIC_SPUR_HOST: ${{ secrets.AIC_SPUR_HOST }}
+      AIC_SHARED_NFS: ${{ secrets.AIC_SHARED_NFS }}
+      AIC_SPUR_CONTROLLER: ${{ secrets.AIC_SPUR_CONTROLLER }}
 
     steps:
       - name: Set commit status to pending
@@ -94,10 +98,10 @@ jobs:
               sha: '${{ needs.authorize.outputs.sha }}',
               state: 'pending',
               context: 'hardware-ci / cliff',
-              description: 'Running cliff benchmark on amd-aic-spur...',
+              description: 'Running cliff benchmark on the SPUR head node...',
             });
 
-      - name: Run cliff on amd-aic-spur
+      - name: Run cliff on the SPUR head node
         run: |
           bash /usr/local/lib/aic-ci/spur-cliff.sh \
             "${{ needs.authorize.outputs.sha }}" \

--- a/.github/workflows/aic-amd-dist-build.yml
+++ b/.github/workflows/aic-amd-dist-build.yml
@@ -73,6 +73,10 @@ jobs:
     permissions:
       pull-requests: write
       statuses: write
+    env:
+      AIC_SPUR_HOST: ${{ secrets.AIC_SPUR_HOST }}
+      AIC_SHARED_NFS: ${{ secrets.AIC_SHARED_NFS }}
+      AIC_SPUR_CONTROLLER: ${{ secrets.AIC_SPUR_CONTROLLER }}
 
     steps:
       - name: Set commit status to pending
@@ -87,10 +91,10 @@ jobs:
               state: 'pending',
               target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
               context: 'hardware-ci / dist-build',
-              description: 'Building image on amd-aic-spur...',
+              description: 'Building image on the SPUR head node...',
             });
 
-      - name: Build image on amd-aic-spur
+      - name: Build image on the SPUR head node
         run: bash /usr/local/lib/aic-ci/spur-dist-build.sh "${{ needs.authorize.outputs.sha }}"
 
       - name: Set commit status on success
@@ -142,6 +146,10 @@ jobs:
     permissions:
       pull-requests: write
       statuses: write
+    env:
+      AIC_SPUR_HOST: ${{ secrets.AIC_SPUR_HOST }}
+      AIC_SHARED_NFS: ${{ secrets.AIC_SHARED_NFS }}
+      AIC_SPUR_CONTROLLER: ${{ secrets.AIC_SPUR_CONTROLLER }}
 
     steps:
       - name: Set commit status to pending
@@ -156,10 +164,10 @@ jobs:
               state: 'pending',
               target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
               context: 'hardware-ci / smoke-test',
-              description: 'Running smoke test on amd-aic-spur...',
+              description: 'Running smoke test on the SPUR head node...',
             });
 
-      - name: Run smoke test on amd-aic-spur
+      - name: Run smoke test on the SPUR head node
         run: bash /usr/local/lib/aic-ci/spur-smoke-test.sh "${{ needs.authorize.outputs.sha }}"
 
       - name: Set commit status on success

--- a/.github/workflows/aic-amd-nightly-cliff.yml
+++ b/.github/workflows/aic-amd-nightly-cliff.yml
@@ -10,9 +10,13 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: [self-hosted, rocm-aic-cicd]
     timeout-minutes: 240
+    env:
+      AIC_SPUR_HOST: ${{ secrets.AIC_SPUR_HOST }}
+      AIC_SHARED_NFS: ${{ secrets.AIC_SHARED_NFS }}
+      AIC_SPUR_CONTROLLER: ${{ secrets.AIC_SPUR_CONTROLLER }}
 
     steps:
-      - name: Run full cliff sweep on amd-aic-spur
+      - name: Run full cliff sweep on the SPUR head node
         run: |
           bash /usr/local/lib/aic-ci/spur-cliff.sh \
             "${{ github.event.workflow_run.head_sha }}" \

--- a/.github/workflows/aic-amd-nightly-dist-build.yml
+++ b/.github/workflows/aic-amd-nightly-dist-build.yml
@@ -12,7 +12,11 @@ jobs:
     timeout-minutes: 120
     permissions:
       statuses: write
+    env:
+      AIC_SPUR_HOST: ${{ secrets.AIC_SPUR_HOST }}
+      AIC_SHARED_NFS: ${{ secrets.AIC_SHARED_NFS }}
+      AIC_SPUR_CONTROLLER: ${{ secrets.AIC_SPUR_CONTROLLER }}
 
     steps:
-      - name: Build image on amd-aic-spur
+      - name: Build image on the SPUR head node
         run: bash /usr/local/lib/aic-ci/spur-dist-build.sh "${{ github.sha }}"

--- a/.github/workflows/aic-amd-nightly-smoke-test.yml
+++ b/.github/workflows/aic-amd-nightly-smoke-test.yml
@@ -10,7 +10,11 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: [self-hosted, rocm-aic-cicd]
     timeout-minutes: 60
+    env:
+      AIC_SPUR_HOST: ${{ secrets.AIC_SPUR_HOST }}
+      AIC_SHARED_NFS: ${{ secrets.AIC_SHARED_NFS }}
+      AIC_SPUR_CONTROLLER: ${{ secrets.AIC_SPUR_CONTROLLER }}
 
     steps:
-      - name: Run smoke test on amd-aic-spur
+      - name: Run smoke test on the SPUR head node
         run: bash /usr/local/lib/aic-ci/spur-smoke-test.sh "${{ github.event.workflow_run.head_sha }}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# Claude Code session state and project memory
-.claude/
-
 # Python
 .venv
 __pycache__/
@@ -30,3 +27,11 @@ rdma-test-*.err
 
 # Codespell dictionary cache
 dictionary.dic
+
+# AI assistant / tool caches
+.claude/
+.cline_storage/
+.mypy_cache/
+
+# Local AMD cluster environment (see .env.amd.example if it exists)
+.env.amd

--- a/.slurm/run-build-distribute.sh
+++ b/.slurm/run-build-distribute.sh
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: MIT
 #
-# Build the aic-release inference image on an alola compile node and make it
+# Build the aic-release inference image on a CPU-only build node and make it
 # available across the cluster, using save -> shared BeeGFS scratch -> load.
 #
 # Image *distribution* uses save -> shared BeeGFS scratch -> load: each node keeps
@@ -35,18 +35,18 @@
 # Usage (run from the aic-release/ tree root; paths resolve relative to this script):
 #
 #   # Build on a compile node AND load onto MI300X targets in one go:
-#   AIC_TARGETS=ctr-cx63-mi300x-3,ctr-cx64-mi300x-4 \
+#   AIC_TARGETS=<node-a>,<node-b> \
 #     bash .slurm/run-build-distribute.sh all
 #
 #   # Just build + save the tarball:
 #   bash .slurm/run-build-distribute.sh build
 #
 #   # Just load an already-saved tarball onto targets:
-#   AIC_TARGETS=ctr-cx63-mi300x-3,ctr-cx64-mi300x-4 \
+#   AIC_TARGETS=<node-a>,<node-b> \
 #     bash .slurm/run-build-distribute.sh load
 #
 #   # Push the built image to a registry (pull-based distribution):
-#   AIC_PUSH_REF=registry-sc-harbor.amd.com/<proj>/rocm-aic:latest \
+#   AIC_PUSH_REF=<your-registry>/<project>/rocm-aic:latest \
 #     bash .slurm/run-build-distribute.sh push
 #
 # Commands:
@@ -54,7 +54,7 @@
 #   build-exporters
 #           Build the fabric exporter images (nvme_exporter / rdma_exporter) from
 #           monitoring/*/Dockerfile and save their tarballs to AIC_IMAGE_DIR, so
-#           bare cliff nodes (no batesste host service) can containerize them.
+#           bare cliff nodes can containerize them (no host-installed exporter service needed).
 #   load    Load the saved tarball on every node in AIC_TARGETS, then verify
 #           (also loads the exporter tarballs when present)
 #   push    Tag the built image as AIC_PUSH_REF and `docker push` it to a registry
@@ -78,11 +78,10 @@
 #   AIC_TARGETS          comma-separated nodes to load     (required for load/all)
 #   AIC_PUSH_REF         registry-qualified ref to push the final image to
 #                        (required for push; needs `docker login <registry>` first)
-#                        (e.g. registry-sc-harbor.amd.com/<proj>/rocm-aic:latest)
+#                        (e.g. <your-registry>/<project>/rocm-aic:latest)
 #
 #   AIC_BUILD_CONSTRAINT Slurm -C feature expr for the build node
-#                        (default: MARKHAM&CPUONLY -- CPU-only alola build boxes
-#                         on the same Markham /scratch).
+#                        (default: <site>&CPUONLY -- CPU-only build nodes).
 #                         Used only when AIC_BUILD_NODE is unset.
 #   AIC_BUILD_NODE       pin an exact build node via --nodelist (overrides
 #                        AIC_BUILD_CONSTRAINT)             (default: unset)
@@ -100,7 +99,7 @@
 #   AIC_CACHE_REF        registry ref for a shared BuildKit cache instead of a dir;
 #                        takes precedence over AIC_CACHE_DIR.  Uses --cache-to/
 #                        --cache-from type=registry.  Requires `docker login` first.
-#                        (e.g. registry-sc-harbor.amd.com/<proj>/rocm-aic:buildcache)
+#                        (e.g. <your-registry>/<project>/rocm-aic:buildcache)
 #                        (default: unset)
 #   AIC_CACHE_MODE       cache mode: min | max              (default: max)
 #   AIC_BUILDX_BUILDER   docker-container buildx builder name (default: aic-cache)
@@ -111,7 +110,7 @@
 #                        cert verification explicitly                (default: unset)
 #
 #   AIC_TEST_CONSTRAINT  Slurm -C feature expr for the test node
-#                        (default: MARKHAM&GFX942&NVME -- MI300X + local NVMe).
+#                        (default: <site>&GFX942&NVME -- MI300X + local NVMe).
 #                        Used only when AIC_TEST_NODE is unset.
 #   AIC_TEST_NODE        pin an exact test node via --nodelist  (default: unset)
 #   AIC_TEST_TIME        test job time limit               (default: 00:20:00)
@@ -135,8 +134,7 @@
 #                        (default: 0)
 #   AIC_SPUR_CONTROLLER  SPUR controller address passed as --controller to every
 #                        sbatch/srun/squeue call when AIC_SPUR_CLUSTER=1.
-#                        (default: $SPUR_CONTROLLER_ADDR if set, else
-#                         http://crs-m2m-cpu-spur-005.crusoe.amd.com:6817)
+#                        (default: $SPUR_CONTROLLER_ADDR)
 #
 #   AIC_TLS_CERT         corporate CA cert (BuildKit secret, never baked into image)
 #                        (default: $HOME/certs/zscaler-ca.crt if it exists; else none)
@@ -161,7 +159,7 @@ AIC_ROCM_ARCH="${AIC_ROCM_ARCH:-gfx90a;gfx942;gfx950;gfx1100;gfx1101;gfx1150;gfx
 AIC_IMAGE="${AIC_IMAGE:-rocm-aic:latest}"
 AIC_IMAGE_DIR="${AIC_IMAGE_DIR:-/scratch/${USER}/images}"
 AIC_SPUR_CLUSTER="${AIC_SPUR_CLUSTER:-0}"
-AIC_SPUR_CONTROLLER="${AIC_SPUR_CONTROLLER:-${SPUR_CONTROLLER_ADDR:-http://crs-m2m-cpu-spur-005.crusoe.amd.com:6817}}"
+AIC_SPUR_CONTROLLER="${AIC_SPUR_CONTROLLER:-${SPUR_CONTROLLER_ADDR:?set SPUR_CONTROLLER_ADDR or AIC_SPUR_CONTROLLER before using AIC_SPUR_CLUSTER=1}}"
 
 # When running on SPUR, default the partition to amd-spur (the only partition)
 # and clear the build/test constraints (SPUR nodes have no MARKHAM/CPUONLY/GFX942
@@ -174,8 +172,8 @@ if [[ "${AIC_SPUR_CLUSTER}" == "1" ]]; then
     AIC_TEST_CONSTRAINT="${AIC_TEST_CONSTRAINT-}"
 else
     AIC_BUILD_PARTITION="${AIC_BUILD_PARTITION:-defq}"
-    AIC_BUILD_CONSTRAINT="${AIC_BUILD_CONSTRAINT:-MARKHAM&CPUONLY}"
-    AIC_TEST_CONSTRAINT="${AIC_TEST_CONSTRAINT:-MARKHAM&GFX942&NVME}"
+    AIC_BUILD_CONSTRAINT="${AIC_BUILD_CONSTRAINT:-CPUONLY}"
+    AIC_TEST_CONSTRAINT="${AIC_TEST_CONSTRAINT:-GFX942&NVME}"
 fi
 AIC_BUILD_CPUS="${AIC_BUILD_CPUS:-32}"
 AIC_BUILD_TIME="${AIC_BUILD_TIME:-02:00:00}"
@@ -193,13 +191,13 @@ AIC_TEST_MEM="${AIC_TEST_MEM:-32G}"
 
 # --- Fabric exporter images (nvme_exporter / rdma_exporter) -------------------
 # Built from monitoring/*/Dockerfile and distributed alongside the main image so
-# bare cliff nodes (no batesste host service) can containerize them.  Names must
-# match run-cliff.sbatch's defaults so the tarballs written here are found there.
-# Versions default to the batesste host-service versions for Grafana parity.
+# bare cliff nodes can containerize them (no host-installed exporter service needed).  Names
+# must match run-cliff.sbatch's defaults so the tarballs written here are found there.
+# Versions default to the Grafana-parity versions; override via AIC_NVME/RDMA_EXPORTER_VERSION.
 AIC_NVME_EXPORTER_IMAGE="${AIC_NVME_EXPORTER_IMAGE:-aic-nvme-exporter:latest}"
 AIC_RDMA_EXPORTER_IMAGE="${AIC_RDMA_EXPORTER_IMAGE:-aic-rdma-exporter:latest}"
-AIC_NVME_EXPORTER_VERSION="${AIC_NVME_EXPORTER_VERSION:-3.0.0}"
-AIC_RDMA_EXPORTER_VERSION="${AIC_RDMA_EXPORTER_VERSION:-0.3.0}"
+AIC_NVME_EXPORTER_VERSION="${AIC_NVME_EXPORTER_VERSION:-3.0.0}"  # matches host-service default; override as needed
+AIC_RDMA_EXPORTER_VERSION="${AIC_RDMA_EXPORTER_VERSION:-0.3.0}"  # matches host-service default; override as needed
 
 # Corporate CA: default to the conventional path only if it actually exists.
 if [[ -z "${AIC_TLS_CERT:-}" && -r "${HOME}/certs/zscaler-ca.crt" ]]; then
@@ -565,7 +563,7 @@ cmd_build_exporters() {
     nvme_tar="$(_exporter_tarball_path "${AIC_NVME_EXPORTER_IMAGE}")"
     rdma_tar="$(_exporter_tarball_path "${AIC_RDMA_EXPORTER_IMAGE}")"
 
-    log "exporter images: ${AIC_NVME_EXPORTER_IMAGE} (nvme v${AIC_NVME_EXPORTER_VERSION}), ${AIC_RDMA_EXPORTER_IMAGE} (rdma v${AIC_RDMA_EXPORTER_VERSION})"
+    log "exporter images : ${AIC_NVME_EXPORTER_IMAGE} (nvme v${AIC_NVME_EXPORTER_VERSION}), ${AIC_RDMA_EXPORTER_IMAGE} (rdma v${AIC_RDMA_EXPORTER_VERSION})"
     log "tarballs   : ${nvme_tar}, ${rdma_tar}  (compress: ${AIC_COMPRESS})"
 
     local remote_script

--- a/.slurm/run-cliff.sbatch
+++ b/.slurm/run-cliff.sbatch
@@ -6,19 +6,21 @@
 #
 #SBATCH --job-name=aic-day-cliff
 #SBATCH --partition=defq
-# Default: a Markham MI300X (gfx942) node with local NVMe -- the validated
-# tiered-cache path.  To target another GFX arch, override the constraint on the
-# sbatch command line (a command-line --constraint wins over this directive),
-# most easily via the Makefile knobs:
+# Default: a gfx942 (MI300X) node with local NVMe -- the validated tiered-cache
+# path.  To target another GFX arch, override the constraint on the sbatch
+# command line (a command-line --constraint wins over this directive), most
+# easily via the Makefile knobs:
 #   make cliff-submit AIC_CLIFF_GFX=gfx950
-#   make cliff-submit AIC_CLIFF_CONSTRAINT=MARKHAM&GFX90A
+#   make cliff-submit AIC_CLIFF_CONSTRAINT=<site>&GFX90A
 # Non-gfx942 nodes have no local NVMe, so the nvme/gds arms drop to /tmp
 # (AIC_NVME_AUTO case 4).  The model is auto-selected from the node's GPU arch
 # (big CDNA gfx942/gfx950 -> gpt-oss-120b, else a small model; see
 # select_default_model below) unless VLLM_MODEL is set.  The default image
 # already carries kernels for every arch (`make dist-build` is multi-arch by
 # default), so no rebuild is needed.
-#SBATCH --constraint=MARKHAM&GFX942&NVME
+# Constraint: set via --constraint on the sbatch command line or via
+# AIC_CLIFF_CONSTRAINT / AIC_CLIFF_GFX in the Makefile.
+#SBATCH --constraint=GFX942&NVME
 #SBATCH --gres=gpu:1
 #SBATCH --nodes=1
 #SBATCH --ntasks=1
@@ -32,7 +34,7 @@
 #SBATCH --output=/dev/null
 #
 # Run the KV-cache cliff benchmark (benchmarks/run_cliff.py) end-to-end on ONE
-# Markham MI300X + local-NVMe node, sweeping all three arms sequentially:
+# MI300X + local-NVMe node, sweeping all three arms sequentially:
 #
 #   1. vram_only        plain vLLM, VRAM prefix cache only (the "cliff" baseline)
 #   2. kvd_v2 (nvme)    LMCache: DRAM L1 + NIXL AIS_MT -> local NVMe L2a
@@ -48,14 +50,13 @@
 #
 #   sbatch .slurm/run-cliff.sbatch
 #   # pin a node:
-#   sbatch --nodelist=ctr-s95-mi300x-3 .slurm/run-cliff.sbatch
+#   sbatch --nodelist=<node-name> .slurm/run-cliff.sbatch
 #   # override the sweep / model:
 #   BENCH_CONCUR=1,8,32,64,128,250 VLLM_MODEL=openai/gpt-oss-120b \
 #       sbatch .slurm/run-cliff.sbatch
 #
-# Storage note (from a live probe of ctr-cx63-mi300x-21, 2026-07-13): the MI300X
-# nodes expose 4x 3.5T Samsung NVMe -- nvme0 is the OS root, and the spares
-# (nvme1-3) are typically RAW and UNMOUNTED.  To keep the LMCache NVMe tier off
+# Storage note: MI300X nodes typically expose 4x 3.5T Samsung NVMe -- nvme0 is
+# the OS root, and the spares (nvme1-3) are typically RAW and UNMOUNTED.  To keep the LMCache NVMe tier off
 # the busy root disk, AIC_NVME_AUTO=1 (default) auto-detects a dedicated local
 # NVMe (needs passwordless sudo on the node), in priority order:
 #   1) reuse an aic-lmcache volume already mounted at AIC_NVME_MOUNT (no format),

--- a/Makefile
+++ b/Makefile
@@ -92,28 +92,30 @@ PYTHON := $(if $(wildcard $(REPO_ROOT)/.venv/bin/python3),$(REPO_ROOT)/.venv/bin
 # ---- Distribute / cliff (Slurm) --------------------------------------------
 # The dist-* / cliff-* targets shell out to the .slurm scripts; the AIC_* knobs
 # they read pass straight through the environment (e.g. make dist-build
-# AIC_ROCM_ARCH=gfx942, make cliff-submit AIC_CLIFF_NODE=ctr-s95-mi300x-3
+# AIC_ROCM_ARCH=gfx942, make cliff-submit AIC_CLIFF_NODE=<node-name>
 # AIC_CLIFF_ARMS=nvme).  AIC_CACHE_DIR is the shared BuildKit file cache on
 # /scratch so a failed build resumes from the last good layer on any node
 # (set AIC_CACHE_DIR= to disable); AIC_BUILD_EXPORTERS=0 skips the fabric images.
 DIST := $(CURDIR)/.slurm/run-build-distribute.sh
 
 # ---- SPUR cluster overrides ------------------------------------------------
-# When AIC_SPUR_CLUSTER=1, default storage paths to /shared_nfs (the NFS volume
-# shared across all SPUR compute nodes) instead of /scratch (not present on
-# this cluster), and wire up the known controller address.
+# When AIC_SPUR_CLUSTER=1, default storage paths to AIC_SHARED_NFS (the NFS
+# volume shared across all SPUR compute nodes) instead of /scratch (not present
+# on this cluster), and wire up the controller address via AIC_SPUR_CONTROLLER
+# (set SPUR_CONTROLLER_ADDR in your environment, or pass AIC_SPUR_CONTROLLER=).
 AIC_SPUR_CLUSTER ?= 0
+AIC_SHARED_NFS ?=
 ifeq ($(AIC_SPUR_CLUSTER),1)
 export AIC_SPUR_CLUSTER
-export AIC_SPUR_CONTROLLER  ?= http://crs-m2m-cpu-spur-005.crusoe.amd.com:6817
-export AIC_IMAGE_DIR        ?= /shared_nfs/$(USER)/images
-export AIC_CACHE_DIR        ?= /shared_nfs/$(USER)/images/buildcache
+export AIC_SPUR_CONTROLLER  ?= $(SPUR_CONTROLLER_ADDR)
+export AIC_IMAGE_DIR        ?= $(AIC_SHARED_NFS)/$(USER)/images
+export AIC_CACHE_DIR        ?= $(AIC_SHARED_NFS)/$(USER)/images/buildcache
 # SPUR nodes have 8x NVMe drives combined into a single LVM at /mnt/m2m_nobackup.
 # Use override (not ?=) so these win over the top-level ?= defaults set earlier.
-# HF_HOME points to shared_nfs since /scratch does not exist on this cluster.
+# HF_HOME points to AIC_SHARED_NFS since /scratch does not exist on this cluster.
 override export NVME_DATA     := /mnt/m2m_nobackup/aic-cliff/nvme
 override export GDS_SLAB_DATA := /mnt/m2m_nobackup/aic-cliff/slab
-override export HF_HOME       := /shared_nfs/$(USER)/hf
+override export HF_HOME       := $(AIC_SHARED_NFS)/$(USER)/hf
 else
 export AIC_CACHE_DIR        ?= /scratch/$(USER)/images/buildcache
 endif
@@ -197,7 +199,7 @@ help:
 	@echo "  make cliff-long-128k   sbatch a 128k-ISL YaRN(x4) 3-arm sweep (extreme; big DRAM/slab pools)"
 	@echo "    Chain like the old run-this.sh:  make dist-build dist-push smoke-test"
 	@echo "    Pin a node: AIC_CLIFF_NODE=<node>   Narrow arms: AIC_CLIFF_ARMS=nvme (vram,nvme,gds)"
-	@echo "    Target another GFX: AIC_CLIFF_GFX=gfx950 (or AIC_CLIFF_CONSTRAINT=MARKHAM&GFX90A)"
+	@echo "    Target another GFX: AIC_CLIFF_GFX=gfx950 (or AIC_CLIFF_CONSTRAINT=<site>&GFX90A)"
 	@echo "      non-gfx942 nodes: no local NVMe (nvme/gds arms fall back to /tmp); the model"
 	@echo "      auto-selects by GPU arch (big CDNA=gpt-oss-120b, else Qwen2.5-3B); image is multi-arch"
 	@echo "    Override sweep/model via env: BENCH_CONCUR=1,8,64 VLLM_MODEL=... make cliff-submit"
@@ -400,12 +402,12 @@ smoke-test:                    # Load + smoke-test the image on a GPU+NVMe node
 # configured); on standard Slurm we pass $(AIC_CLIFF_CONSTRAINT) (below).
 #
 # ---- cliff GFX / constraint selection ----
-# By default the cliff job runs on a Markham MI300X (gfx942) node with local
-# NVMe -- the validated tiered-cache path.  To target another GFX arch, set
-#   AIC_CLIFF_GFX=gfx950        -> expands to constraint "MARKHAM&GFX950"
+# By default the cliff job runs on a gfx942 node with local NVMe -- the
+# validated tiered-cache path.  To target another GFX arch, set
+#   AIC_CLIFF_GFX=gfx950        -> expands to constraint "GFX950"
 # (the &NVME requirement is dropped, since only gfx942 nodes advertise NVME),
 # or pass a full Slurm constraint expression directly via
-#   AIC_CLIFF_CONSTRAINT=MARKHAM&GFX90A
+#   AIC_CLIFF_CONSTRAINT=GFX90A
 # AIC_CLIFF_CONSTRAINT wins if both are set; either overrides the #SBATCH
 # --constraint line baked into run-cliff.sbatch.  Caveats for non-gfx942 nodes:
 #   * no local NVMe -> the nvme/gds arms fall back to root-disk /tmp
@@ -424,9 +426,9 @@ smoke-test:                    # Load + smoke-test the image on a GPU+NVMe node
 AIC_CLIFF_GFX ?=
 ifeq ($(strip $(AIC_CLIFF_CONSTRAINT)),)
 ifneq ($(strip $(AIC_CLIFF_GFX)),)
-AIC_CLIFF_CONSTRAINT := MARKHAM&$(shell echo '$(AIC_CLIFF_GFX)' | tr '[:lower:]' '[:upper:]')
+AIC_CLIFF_CONSTRAINT := $(shell echo '$(AIC_CLIFF_GFX)' | tr '[:lower:]' '[:upper:]')
 else
-AIC_CLIFF_CONSTRAINT := MARKHAM&GFX942&NVME
+AIC_CLIFF_CONSTRAINT := GFX942&NVME
 endif
 endif
 ifeq ($(AIC_SPUR_CLUSTER),1)

--- a/docs/SLURM_SPUR.md
+++ b/docs/SLURM_SPUR.md
@@ -12,7 +12,7 @@ make dist-build dist-push smoke-test AIC_PUSH_REF=<registry>/rocm-aic:latest
 
 # Submit the full sweep (vram_only + kvd_v2 nvme + kvd_v2 gds) on a GPU+NVMe node.
 # Output lands in logs/<job-id>/. Pin a node / narrow arms / override the sweep via env:
-make cliff-submit AIC_CLIFF_NODE=ctr-s95-mi300x-3
+make cliff-submit AIC_CLIFF_NODE=<node-name>
 make cliff-submit AIC_CLIFF_ARMS=nvme BENCH_CONCUR=1,8,64
 make cliff-short          # 1-point smoke test of the whole flow
 ```
@@ -35,5 +35,5 @@ see [CLAUDE.md](../CLAUDE.md).
 Set `AIC_SPUR_CLUSTER=1` to activate the SPUR-aware submission path:
 
 ```bash
-make cliff-submit AIC_SPUR_CLUSTER=1 AIC_CLIFF_NODE=crsuse2-m2m-042
+make cliff-submit AIC_SPUR_CLUSTER=1 AIC_CLIFF_NODE=<node-name>
 ```


### PR DESCRIPTION
…he to .gitignore

Remove all hardcoded AMD-internal hostnames, paths, and cluster labels from runtime code. Values are now injected via environment variables (GitHub repo Variables for CI, shell env for local/Slurm use):

- AIC_SPUR_HOST: SSH target for the SPUR head node (was: amd-aic-spur)
- AIC_SHARED_NFS: shared NFS root on SPUR (was: /shared_nfs)
- AIC_SPUR_CONTROLLER: Slurm controller URL; falls back to SPUR_CONTROLLER_ADDR with a clear error if neither is set (was: hardcoded AMD URL)
- AIC_SPUR_SITE: optional site-label prefix for Slurm constraints (was: MARKHAM hardcoded); empty = no prefix, so scripts work on any Slurm cluster

CI workflows (aic-amd-*) now pass AIC_SPUR_HOST and AIC_SHARED_NFS from GitHub repo Variables. The three spur-*.sh scripts use :? validation so missing variables produce a clear error rather than a silent wrong path.

Also fixes the wrong repo name in spur-dist-build.sh (rocm-icms -> rocm-aic) and replaces internal node names, registry URLs, and site labels in comments and docs with generic placeholders.

