### PR TITLE
ci: use jlumbroso/free-disk-space to fix out-of-disk failures

### DIFF
--- a/.github/workflows/aic-docker.yml
+++ b/.github/workflows/aic-docker.yml
@@ -49,19 +49,15 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Free disk space on runner
-        run: |
-          set -euo pipefail
-          echo "Disk before cleanup:"
-          df -h /
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /opt/hostedtoolcache
-          sudo rm -rf /usr/local/share/boost
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY" || true
-          sudo docker system prune -af --volumes || true
-          echo "Disk after cleanup:"
-          df -h /
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
 
       - name: Log in to Docker Hub
         if: github.event.inputs.push_image == 'true'

--- a/.github/workflows/aic-nightly-wheels.yml
+++ b/.github/workflows/aic-nightly-wheels.yml
@@ -111,14 +111,15 @@ jobs:
           fetch-depth: 1
 
       - name: Free disk space on runner
-        run: |
-          set -euo pipefail
-          echo "Disk before cleanup:"; df -h /
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
-                      /opt/hostedtoolcache /usr/local/share/boost || true
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY" || true
-          sudo docker system prune -af --volumes || true
-          echo "Disk after cleanup:"; df -h /
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
 
       - uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
The nightly wheels build was failing with "No space left on device" while extracting the amd-aiter wheel (~487 MB) during the Docker build. The manual rm -rf cleanup only freed ~8 GB; the jlumbroso action reclaims ~30 GB by also removing large apt packages (libllvm*, libclang*, mono*), the Haskell/GHC toolchain, tool caches, Docker images, and the swap file.

Apply the same fix to the Docker build workflow for consistency.
