### PR TITLE
LMCache gfx1201 fixes

### DIFF
--- a/.github/scripts/spur-smoke-test.sh
+++ b/.github/scripts/spur-smoke-test.sh
@@ -3,7 +3,9 @@ set -euo pipefail
 
 # Runs on the self-hosted runner; SSHes to the SPUR head node (AIC_SPUR_HOST) and runs smoke-test
 # against the tarball produced by spur-dist-build.sh for the same SHA.
-# Always cleans up the clone and tarball dir on exit regardless of pass/fail.
+# The clone and tarball are left in place for spur-tiny-test.sh (the next stage)
+# to use; spur-tiny-test.sh owns the final cleanup.  On failure, cleans up
+# immediately so no stale state is left behind.
 
 SHA="${1:?usage: $0 <full-sha>}"
 SHORT="${SHA:0:7}"
@@ -27,11 +29,11 @@ set -euo pipefail
 SHORT="${SHA:0:7}"
 WORKDIR="$HOME/Projects/rocm-aic.${SHORT}"
 
-cleanup() {
-    echo "=== Cleaning up ==="
+cleanup_on_fail() {
+    echo "=== Smoke test failed — cleaning up ==="
     rm -rf "${WORKDIR}" "${TARBALL_DIR}"
 }
-trap cleanup EXIT
+trap cleanup_on_fail ERR
 
 echo "=== Running smoke-test (AIC_IMAGE=${AIC_IMAGE}) ==="
 AIC_SPUR_CLUSTER=1 \

--- a/.github/scripts/spur-tiny-test.sh
+++ b/.github/scripts/spur-tiny-test.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Runs on the self-hosted runner; SSHes to amd-aic-spur and runs tiny-test
+# against the tarball produced by spur-dist-build.sh for the same SHA (the stage
+# after spur-smoke-test.sh).  tiny-test brings up the compose MP stack
+# (standalone lmcache server + vLLM LMCacheMPConnector) with a tiny model and
+# asserts one non-empty chat completion.
+#
+# Cleanup ownership depends on whether a cliff stage follows:
+#   * PR flow (dist-build -> smoke-test -> tiny-test): tiny-test is terminal, so
+#     it owns the final cleanup (removes the clone + tarball on exit).
+#   * Nightly (dist-build -> smoke -> tiny -> cliff): cliff runs next and needs
+#     the artifacts, so the nightly tiny-test step sets KEEP_ARTIFACTS=1 and this
+#     script only cleans up on failure (spur-cliff.sh does the final cleanup).
+# The tiny model is cached in a persistent shared HF dir (outside the tarball
+# dir) so it is downloaded once and reused across runs.
+
+SHA="${1:?usage: $0 <full-sha>}"
+SHORT="${SHA:0:7}"
+AIC_IMAGE="rocm-aic-ci-${SHORT}:latest"
+TARBALL_DIR="/shared_nfs/${USER}/images/aic-ci-${SHORT}"
+TINY_HF_HOME="/shared_nfs/${USER}/tiny-hf"
+KEEP_ARTIFACTS="${KEEP_ARTIFACTS:-0}"
+
+ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=4 amd-aic-spur env \
+    SHA="${SHA}" \
+    AIC_IMAGE="${AIC_IMAGE}" \
+    TARBALL_DIR="${TARBALL_DIR}" \
+    TINY_HF_HOME="${TINY_HF_HOME}" \
+    KEEP_ARTIFACTS="${KEEP_ARTIFACTS}" \
+    bash << 'REMOTE'
+set -euo pipefail
+
+SHORT="${SHA:0:7}"
+WORKDIR="$HOME/Projects/rocm-aic.${SHORT}"
+
+_cleanup() {
+    echo "=== Cleaning up ==="
+    rm -rf "${WORKDIR}" "${TARBALL_DIR}"
+}
+if [[ "${KEEP_ARTIFACTS}" == "1" ]]; then
+    # A cliff stage follows and reuses the artifacts; only clean up on failure.
+    cleanup_on_fail() { echo "=== Tiny test failed — cleaning up ==="; _cleanup; }
+    trap cleanup_on_fail ERR
+else
+    # Terminal stage: always clean up.
+    trap _cleanup EXIT
+fi
+
+echo "=== Running tiny-test (AIC_IMAGE=${AIC_IMAGE}) ==="
+AIC_SPUR_CLUSTER=1 \
+    AIC_IMAGE="${AIC_IMAGE}" \
+    AIC_IMAGE_DIR="${TARBALL_DIR}" \
+    AIC_TINY_HF_HOME="${TINY_HF_HOME}" \
+    make -C "${WORKDIR}" tiny-test
+
+echo "=== tiny-test complete ==="
+REMOTE
+
+echo "Tiny test passed for ${SHORT}"

--- a/.github/workflows/aic-amd-dist-build.yml
+++ b/.github/workflows/aic-amd-dist-build.yml
@@ -200,6 +200,75 @@ jobs:
               description: 'Smoke test failed — check the run logs',
             });
 
+      - name: Post failure comment on PR
+        if: failure() && needs.authorize.outputs.pr_number != ''
+        uses: actions/github-script@v9
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ needs.authorize.outputs.pr_number || 0 }},
+              body: `❌ Smoke test failed for ${{ needs.authorize.outputs.sha }}. [View logs](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}).`,
+            });
+
+  tiny-test:
+    needs: [authorize, dist-build, smoke-test]
+    runs-on: [self-hosted, rocm-aic-cicd]
+    timeout-minutes: 60
+    permissions:
+      pull-requests: write
+      statuses: write
+
+    steps:
+      - name: Set commit status to pending
+        if: needs.authorize.outputs.pr_number != ''
+        uses: actions/github-script@v9
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: '${{ needs.authorize.outputs.sha }}',
+              state: 'pending',
+              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              context: 'hardware-ci / tiny-test',
+              description: 'Running tiny-model end-to-end serve on amd-aic-spur...',
+            });
+
+      - name: Run tiny-test on amd-aic-spur
+        run: bash /usr/local/lib/aic-ci/spur-tiny-test.sh "${{ needs.authorize.outputs.sha }}"
+
+      - name: Set commit status on success
+        if: success() && needs.authorize.outputs.pr_number != ''
+        uses: actions/github-script@v9
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: '${{ needs.authorize.outputs.sha }}',
+              state: 'success',
+              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              context: 'hardware-ci / tiny-test',
+              description: 'Tiny-model end-to-end serve passed',
+            });
+
+      - name: Set commit status on failure
+        if: failure() && needs.authorize.outputs.pr_number != ''
+        uses: actions/github-script@v9
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: '${{ needs.authorize.outputs.sha }}',
+              state: 'failure',
+              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              context: 'hardware-ci / tiny-test',
+              description: 'Tiny-test failed — check the run logs',
+            });
+
       - name: Post result comment on PR
         if: always() && needs.authorize.outputs.pr_number != ''
         uses: actions/github-script@v9
@@ -211,6 +280,6 @@ jobs:
               repo: context.repo.repo,
               issue_number: ${{ needs.authorize.outputs.pr_number || 0 }},
               body: success
-                ? `✅ Hardware CI passed for ${{ needs.authorize.outputs.sha }}.`
-                : `❌ Smoke test failed for ${{ needs.authorize.outputs.sha }}. [View logs](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}).`,
+                ? `✅ Hardware CI passed for ${{ needs.authorize.outputs.sha }} (dist-build + smoke-test + tiny-test).`
+                : `❌ Tiny-test failed for ${{ needs.authorize.outputs.sha }}. [View logs](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}).`,
             });

--- a/.github/workflows/aic-amd-nightly-cliff.yml
+++ b/.github/workflows/aic-amd-nightly-cliff.yml
@@ -2,7 +2,7 @@ name: AIC Nightly Cliff
 
 on:
   workflow_run:
-    workflows: ["AIC Nightly Smoke Test"]
+    workflows: ["AIC Nightly Tiny Test"]
     types: [completed]
 
 jobs:

--- a/.github/workflows/aic-amd-nightly-tiny-test.yml
+++ b/.github/workflows/aic-amd-nightly-tiny-test.yml
@@ -1,0 +1,18 @@
+name: AIC Nightly Tiny Test
+
+on:
+  workflow_run:
+    workflows: ["AIC Nightly Smoke Test"]
+    types: [completed]
+
+jobs:
+  tiny-test:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: [self-hosted, rocm-aic-cicd]
+    timeout-minutes: 60
+
+    steps:
+      - name: Run tiny-test on amd-aic-spur
+        # Keep the clone + tarball so the following nightly cliff stage can reuse
+        # them (spur-cliff.sh owns the final cleanup in the nightly chain).
+        run: KEEP_ARTIFACTS=1 bash /usr/local/lib/aic-ci/spur-tiny-test.sh "${{ github.event.workflow_run.head_sha }}"

--- a/.slurm/run-build-distribute.sh
+++ b/.slurm/run-build-distribute.sh
@@ -63,6 +63,10 @@
 #           checks GPU visibility + arch, vLLM / LMCache / hipFile, ais-check
 #           (HIP+amdgpu AIS support), and the NIXL AIS_MT plugin (hard fail if
 #           AIS_MT or ais-check fail)
+#   tiny-test  End-to-end serve check on a GPU node: brings up the compose MP
+#           stack (standalone lmcache server + vLLM LMCacheMPConnector) with a tiny
+#           model (Qwen/Qwen2.5-0.5B-Instruct) and asserts one non-empty chat
+#           completion.  Exercises the full connector path a smoke-test cannot.
 #   all     build, build-exporters, then load   (default)
 #
 # Key environment:
@@ -188,6 +192,18 @@ AIC_CACHE_INSECURE="${AIC_CACHE_INSECURE:-}"
 AIC_TEST_TIME="${AIC_TEST_TIME:-00:20:00}"
 AIC_TEST_CPUS="${AIC_TEST_CPUS:-8}"
 AIC_TEST_MEM="${AIC_TEST_MEM:-32G}"
+
+# --- tiny-test: end-to-end serve check with a tiny model ---------------------
+# Brings up the compose MP stack (standalone lmcache + vLLM LMCacheMPConnector)
+# with a small model and asserts one non-empty chat completion.  A fast functional
+# gate that exercises the connector path a smoke-test cannot.  The model is
+# downloaded once into AIC_TINY_HF_HOME (a persistent shared HF cache) and reused.
+AIC_TINY_MODEL="${AIC_TINY_MODEL:-Qwen/Qwen2.5-0.5B-Instruct}"
+AIC_TINY_HF_HOME="${AIC_TINY_HF_HOME:-${AIC_IMAGE_DIR}/tiny-hf}"
+AIC_TINY_TIME="${AIC_TINY_TIME:-00:25:00}"
+AIC_TINY_CPUS="${AIC_TINY_CPUS:-8}"
+AIC_TINY_MEM="${AIC_TINY_MEM:-32G}"
+AIC_TINY_READY_TIMEOUT="${AIC_TINY_READY_TIMEOUT:-120}"   # x5s = up to 10 min for weights + download
 
 # --- Fabric exporter images (nvme_exporter / rdma_exporter) -------------------
 # Built from monitoring/*/Dockerfile and distributed alongside the main image so
@@ -948,6 +964,131 @@ REMOTE
     log "test complete"
 }
 
+# --- tiny-test: end-to-end serve check (compose MP stack + a tiny model) ------
+# Loads the image on a GPU node if needed, brings up the SAME compose stack the
+# cliff/`make up` use (standalone lmcache server + vLLM LMCacheMPConnector), waits
+# for the endpoint, and asserts one non-empty chat completion.  Unlike smoke-test
+# (which validates the image in isolation) this exercises the full MP connector
+# path end-to-end -- the functional gate wired into CI after smoke-test.
+cmd_tiny_test() {
+    _pick_compress
+    local tarball; tarball="$(_tarball_path)"
+    command -v sbatch >/dev/null 2>&1 || die "sbatch not found; cannot run the GPU tiny-test job"
+    [[ -r "${tarball}" ]] || die "tarball not found: ${tarball} (run 'build' first)"
+
+    local -a _sel
+    if [[ -n "${AIC_TEST_NODE:-}" ]]; then
+        _sel=(--nodelist="${AIC_TEST_NODE}")
+        log "tiny-test on ${AIC_TEST_NODE} via sbatch (partition ${AIC_BUILD_PARTITION})"
+    else
+        _sel=(--constraint="${AIC_TEST_CONSTRAINT}")
+        log "tiny-test via sbatch (partition ${AIC_BUILD_PARTITION}, constraint ${AIC_TEST_CONSTRAINT})"
+    fi
+    log "image: ${AIC_IMAGE}  model: ${AIC_TINY_MODEL}  hf: ${AIC_TINY_HF_HOME}"
+
+    local remote_script
+    remote_script="$(cat <<REMOTE
+set -uo pipefail
+command -v docker >/dev/null 2>&1 || { echo "\$(hostname): docker not found" >&2; exit 1; }
+echo "[tiny-test] host=\$(hostname) docker=\$(docker --version)"
+
+# Load the image from the shared tarball only when needed (same marker logic as
+# smoke-test): reload when forced, absent, or the tarball is newer.
+_marker="/var/tmp/aic-loaded-\$(id -u)-\$(echo '${AIC_IMAGE}' | tr '/:' '__').mtime"
+_tar_mtime="\$(stat -c %Y '${tarball}' 2>/dev/null || echo 0)"
+_have_img="\$(docker images -q '${AIC_IMAGE}')"
+_loaded_mtime="\$(cat "\${_marker}" 2>/dev/null || echo 0)"
+if [ "${AIC_FORCE_LOAD:-0}" = "1" ] || [ -z "\${_have_img}" ] || [ "\${_tar_mtime}" -gt "\${_loaded_mtime}" ]; then
+    echo "[tiny-test] loading ${AIC_IMAGE} from ${tarball}"
+    ${DECOMPRESS_CMD} '${tarball}' | docker load >/dev/null
+    echo "\${_tar_mtime}" > "\${_marker}" 2>/dev/null || true
+else
+    echo "[tiny-test] image up to date on \$(hostname) (id \${_have_img})"
+fi
+
+cd '${AIC_DAY_DIR}'
+# docker compose v2 only -- install user-locally if the node lacks the plugin.
+# shellcheck source=/dev/null
+source '${AIC_DAY_DIR}/monitoring/monitoring-lib.sh'
+ensure_compose || { echo "[tiny-test] docker compose unavailable and could not be installed" >&2; exit 1; }
+
+# Tiny-model MP stack env.  Small footprint; the tiny model is downloaded online
+# into the persistent AIC_TINY_HF_HOME (Qwen2.5-0.5B is ungated -- no HF token).
+export IMAGE_NAME='${AIC_IMAGE}'
+export ROCM_ARCH='${AIC_ROCM_ARCH}'
+export GPU=0
+export VLLM_MODEL='${AIC_TINY_MODEL}'
+export HF_HOME='${AIC_TINY_HF_HOME}'
+export HF_HUB_OFFLINE=0 TRANSFORMERS_OFFLINE=0
+export LOG="\${_logdir}"
+export NVME_DATA=/tmp/aic-tiny-nvme NFS_DATA=/tmp/aic-tiny-nfs
+export VLM_GPU_MEMORY_UTILIZATION=0.30
+export VLM_MAX_MODEL_LEN=4096
+export VLM_MAX_NUM_BATCHED_TOKENS=4096
+export VLM_ATTENTION_BACKEND=TRITON_ATTN
+export VLM_KV_CACHE_DTYPE=auto
+export LMCACHE_L1_SIZE_GB=4
+export KV_TRANSFER_ARG="--kv-transfer-config '{\"kv_connector\":\"LMCacheMPConnector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"lmcache.mp.host\":\"tcp://lmcache\",\"lmcache.mp.port\":6555}}'"
+mkdir -p "\${HF_HOME}" /tmp/aic-tiny-nvme /tmp/aic-tiny-nfs
+
+compose() { docker compose -f '${AIC_DAY_DIR}/docker/docker-compose.yml' "\$@"; }
+cleanup() {
+    local svc
+    for svc in vllm lmcache; do
+        compose logs --no-color --no-log-prefix "\$svc" > "\${_logdir}/tiny-\${svc}.log" 2>&1 || true
+    done
+    compose --profile cache down --remove-orphans >/dev/null 2>&1 || true
+    rm -rf /tmp/aic-tiny-nvme /tmp/aic-tiny-nfs 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "[tiny-test] bringing up compose MP stack (model=${AIC_TINY_MODEL}) ..."
+if ! compose --profile cache up -d; then
+    echo "[tiny-test] FAIL: compose up failed" >&2
+    compose logs --tail 60 --no-color lmcache 2>&1 | sed 's/^/  [lmcache] /'
+    compose logs --tail 60 --no-color vllm    2>&1 | sed 's/^/  [vllm]    /'
+    exit 1
+fi
+
+# Wait for the vLLM endpoint (weights load + one-time model download).
+ready=0
+for _i in \$(seq 1 ${AIC_TINY_READY_TIMEOUT}); do
+    if curl -fsS http://localhost:8000/v1/models >/dev/null 2>&1; then ready=1; break; fi
+    sleep 5
+done
+if [ "\${ready}" != "1" ]; then
+    echo "[tiny-test] FAIL: vLLM never became ready" >&2
+    compose logs --tail 80 --no-color vllm 2>&1 | sed 's/^/  [vllm] /'
+    exit 1
+fi
+echo "[tiny-test] endpoint ready; sending one chat completion ..."
+
+# One real completion; assert a NON-EMPTY assistant content came back through the
+# LMCacheMPConnector path.
+resp="\$(curl -fsS http://localhost:8000/v1/chat/completions \
+    -H 'Content-Type: application/json' \
+    -d '{"model":"${AIC_TINY_MODEL}","messages":[{"role":"user","content":"Reply with the single word: pong"}],"max_tokens":16,"temperature":0}' 2>&1)" || {
+    echo "[tiny-test] FAIL: completion request failed: \${resp}" >&2; exit 1; }
+echo "[tiny-test] response: \${resp}"
+if printf '%s' "\${resp}" | grep -qE '"content"[[:space:]]*:[[:space:]]*"[^"]+'; then
+    echo "[tiny-test] OK: got a non-empty completion via LMCacheMPConnector"
+    exit 0
+fi
+echo "[tiny-test] FAIL: empty or missing completion content" >&2
+exit 1
+REMOTE
+)"
+
+    local -a _gres_arg=(); [[ "${AIC_SPUR_CLUSTER}" != "1" ]] && _gres_arg=(--gres=gpu:1)
+    _sbatch_run aic-tiny-test tiny-test "${remote_script}" \
+        "${_sel[@]}" \
+        "${_gres_arg[@]}" \
+        --nodes=1 --ntasks=1 \
+        --cpus-per-task="${AIC_TINY_CPUS}" --mem="${AIC_TINY_MEM}" \
+        --time="${AIC_TINY_TIME}"
+    log "tiny-test complete"
+}
+
 # --- main --------------------------------------------------------------------
 main() {
     local sub="${1:-all}"
@@ -957,11 +1098,12 @@ main() {
         load)            cmd_load ;;
         push)            cmd_push ;;
         test)            cmd_test ;;
+        tiny-test)       cmd_tiny_test ;;
         all)             cmd_build; cmd_build_exporters; cmd_load ;;
         -h|--help|help)
             sed -n '2,70p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
             ;;
-        *) die "unknown command '${sub}' (use: build | build-exporters | load | push | test | all | help)" ;;
+        *) die "unknown command '${sub}' (use: build | build-exporters | load | push | test | tiny-test | all | help)" ;;
     esac
 }
 

--- a/.slurm/run-cliff.sbatch
+++ b/.slurm/run-cliff.sbatch
@@ -37,14 +37,17 @@
 # MI300X + local-NVMe node, sweeping all three arms sequentially:
 #
 #   1. vram_only        plain vLLM, VRAM prefix cache only (the "cliff" baseline)
-#   2. kvd_v2 (nvme)    LMCache: DRAM L1 + NIXL AIS_MT -> local NVMe L2a
-#   3. kvd_v2 (gds)     LMCache: hipFile GDS NVMe slab as L1 (no L2)
+#   2. kvd_v2 (nvme)    LMCache MP: DRAM L1 + NIXL AIS_MT -> local NVMe L2a (+POSIX L2b)
+#   3. kvd_v2 (gds)     LMCache MP: hipFile GDS NVMe slab as L1
 #
-# Each arm launches its own container stack via `docker run` (no compose/make
-# dependency -- mirrors .slurm/run-build-distribute.sh's cmd_test), waits for the
-# endpoint, runs the sweep in a sidecar container, then tears the stack down.
-# The two kvd_v2 arms are plotted separately against the shared vram_only
-# baseline so the NVMe-L2 and GDS-L1 backends can be compared.
+# ALL arms drive the SAME docker/docker-compose.yml (docker compose v2, installed
+# by ensure_compose if the node lacks it).  The kvd arms run LMCache MP mode: a
+# standalone lmcache server + a vLLM that connects to it with LMCacheMPConnector
+# over ZMQ (identical to `make up`); the vram baseline starts vLLM alone via the
+# compose `cache` profile toggle.  Each arm waits for the endpoint, runs the sweep
+# in a bench container, then `compose down`s the stack.  The two kvd_v2 arms are
+# plotted separately against the shared vram_only baseline so the NVMe-L2 and
+# GDS-L1 backends can be compared.
 #
 # Submit from the aic-day-release/ tree root:
 #
@@ -153,8 +156,8 @@ VLM_YARN_ORIG_LEN="${VLM_YARN_ORIG_LEN:-32768}"
 if [[ -z "${VLM_ROPE_SCALING}" && -n "${VLM_YARN_FACTOR}" ]]; then
     VLM_ROPE_SCALING="{\"rope_type\":\"yarn\",\"factor\":${VLM_YARN_FACTOR},\"original_max_position_embeddings\":${VLM_YARN_ORIG_LEN}}"
 fi
-ROPE_ARGS=()
-[[ -n "${VLM_ROPE_SCALING}" ]] && ROPE_ARGS=(--hf-overrides "{\"rope_scaling\": ${VLM_ROPE_SCALING}}")
+# The RoPE override is passed to every arm through the compose ${VLLM_EXTRA_ARGS}
+# knob (built in the compose-stack setup block below).  Empty => no scaling.
 LMCACHE_L1_SIZE_GB="${LMCACHE_L1_SIZE_GB:-20}"
 LMCACHE_NVME_POOL="${LMCACHE_NVME_POOL:-4096}"
 # CPU DRAM (L1) tier for the nvme arm.  Default 'false' = KV flows GPU VRAM
@@ -227,8 +230,9 @@ AIC_ROCM_USE_AITER="${AIC_ROCM_USE_AITER:-1}"
 # Raise for big models / slow shared storage.
 AIC_VLLM_READY_TIMEOUT="${AIC_VLLM_READY_TIMEOUT:-1200}"
 
-VRAM_PORT=8001
-KVD_PORT=8000
+# Every arm now serves vLLM on the compose-published :8000 (arms run sequentially,
+# each stack torn down before the next), so one endpoint port suffices.
+VLLM_ENDPOINT_PORT=8000
 LMCACHE_PORT=6555
 STAMP="$(date +%Y%m%d-%H%M%S)"
 # CSVs and plots go under the per-job logs dir so the run is self-contained and
@@ -396,7 +400,10 @@ command -v docker >/dev/null 2>&1 || die "docker not found on $(hostname)"
 [[ -f "${REPO}/benchmarks/run_cliff.py" ]] || \
     die "benchmarks/run_cliff.py not found under REPO=${REPO}; submit from the aic-day-release/ dir (SLURM_SUBMIT_DIR)"
 
-mkdir -p "${RESULTS}" "${PLOTS}" "${NVME_DATA}" "${NFS_DATA}" "${GDS_SLAB_DATA}"
+# Pre-create the compose log-mount dirs too, so docker doesn't auto-create them
+# as root under the per-job logs tree (the lmcache/vllm services bind-mount these).
+mkdir -p "${RESULTS}" "${PLOTS}" "${NVME_DATA}" "${NFS_DATA}" "${GDS_SLAB_DATA}" \
+         "${LOGDIR}/lmcache" "${LOGDIR}/vllm"
 [[ -d "${HF_HOME}/hub" ]] || die "HF cache not found at ${HF_HOME}/hub"
 
 # --- Load images from shared tarballs when needed ----------------------------
@@ -458,12 +465,11 @@ if [[ "${AIC_EXPORTERS}" == "1" ]]; then
     fi
 fi
 
-# --- Container / GPU flags (mirror docker-compose.yml + cmd_test) -------------
-GPU_FLAGS=(--device /dev/kfd --device /dev/dri --ipc host
-           --cap-add SYS_PTRACE --cap-add CAP_SYS_ADMIN
-           --security-opt seccomp=unconfined)
-# --network host: the sidecar bench + the ZMQ connector reach services at
-# localhost, so no compose bridge / service DNS is needed.
+# --- Benchmark client env (offline HF cache) ---------------------------------
+# The bench + plot containers run with --network host and reach the vLLM endpoint
+# at localhost:<published port>.  The inference stack itself is launched via
+# docker/docker-compose.yml (see the compose-stack setup block below), not raw
+# docker run -- all container/GPU/cap flags now live in that compose file.
 HF_ENV=(-e HF_HOME=/hf -e HF_HUB_CACHE=/hf/hub -e HF_HUB_OFFLINE=1
         -e TRANSFORMERS_OFFLINE=1 -e VLLM_CACHE_ROOT=/hf/vllm
         -e ROCR_VISIBLE_DEVICES=0 -e PYTHONHASHSEED=0
@@ -474,6 +480,46 @@ HF_ENV=(-e HF_HOME=/hf -e HF_HUB_CACHE=/hf/hub -e HF_HUB_OFFLINE=1
         # vLLM falls back to TRITON_ATTN -> "Hybrid KV cache manager is disabled but
         # failed to convert the KV cache specs" at engine init.
         -e VLLM_ROCM_USE_AITER=${AIC_ROCM_USE_AITER})
+
+# --- Compose stack (single source of truth: docker/docker-compose.yml) --------
+# Every arm drives the SAME compose file.  The plain vram baseline starts only the
+# `vllm` service (empty KV_TRANSFER_ARG; lmcache is skipped via its `cache`
+# profile, and vllm's depends_on uses required:false so it can run alone).  The
+# nvme/gds arms add `--profile cache`, so the standalone lmcache server runs and
+# vllm connects to it with LMCacheMPConnector -- i.e. LMCache MP mode on every
+# kvd arm.  Per-arm topology (GDS slab vs AIS_MT NVMe L2 vs local_disk) is
+# selected through the env exported below; the arm functions flip GDS_MODE /
+# AIC_L2_BACKEND / LMCACHE_L1_SIZE_GB / KV_TRANSFER_ARG before `compose up`.
+COMPOSE_FILE="${REPO}/docker/docker-compose.yml"
+compose() { docker compose -f "${COMPOSE_FILE}" "$@"; }
+
+# Knobs the compose file interpolates (already resolved above).  ROCM_ARCH is only
+# read by build.args, but compose interpolates it even on `up`, so keep it set.
+export IMAGE_NAME="${AIC_IMAGE}"
+export ROCM_ARCH="${ROCM_ARCH:-$(detect_gpu_arch)}"
+export GPU=0
+export HF_HOME NVME_DATA NFS_DATA GDS_SLAB_DATA
+export LOG="${LOGDIR}"                       # lmcache/vllm container logs land under the job dir
+export HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1
+export VLLM_MODEL TENSOR_PARALLEL_SIZE
+export VLM_GPU_MEMORY_UTILIZATION VLM_MAX_MODEL_LEN VLM_MAX_NUM_BATCHED_TOKENS
+export VLM_ATTENTION_BACKEND="${AIC_ATTENTION_BACKEND}"
+export VLM_KV_CACHE_DTYPE="${AIC_KV_CACHE_DTYPE}"
+export AIC_ROCM_USE_AITER
+export LMCACHE_PORT LMCACHE_NVME_POOL LMCACHE_NFS_POOL
+export LMCACHE_NVME_SLOT_SIZE="${LMCACHE_NVME_SLOT_SIZE:-268435456}"
+export AIC_NIXL_USE_DIRECT_IO
+export NIXL_METRICS_PORT="${NIXL_METRICS_PORT:-19090}"
+# RoPE override (YaRN etc.) applied to ALL arms via vLLM --hf-overrides.  Single-
+# quote the JSON so compose's shlex splitting keeps the inner double quotes.
+VLLM_EXTRA_ARGS=""
+[[ -n "${VLM_ROPE_SCALING}" ]] && VLLM_EXTRA_ARGS="--hf-overrides '{\"rope_scaling\": ${VLM_ROPE_SCALING}}'"
+export VLLM_EXTRA_ARGS
+# The MP server's --l1-size-gb is the DRAM L1 (nvme arm) OR the hipFile slab size
+# (gds arm).  The cliff sizes these from two different knobs, so preserve the
+# original LMCACHE_L1_SIZE_GB (the gds slab) here and derive the nvme DRAM L1 from
+# LMCACHE_MAX_LOCAL_CPU_SIZE per arm (see run_arm_kvd).
+AIC_GDS_SLAB_GB="${LMCACHE_L1_SIZE_GB}"
 
 # --- Helpers -----------------------------------------------------------------
 wait_ready() {  # $1=port $2=timeout_s
@@ -513,17 +559,18 @@ run_bench() {  # $1=arm $2=endpoint_port $3=out_csv $4=extra args...
 # with a stale container-<name>.log (until the real teardown overwrites it).
 rm_containers() { docker rm -f "$@" >/dev/null 2>&1 || true; }
 
-# Teardown: capture each container's full stdout/stderr into the per-job logs dir
-# before removing it.  The compute node is ephemeral, so `docker logs` is lost at
-# teardown otherwise -- and Prometheus captures metrics, not container stdout
+# Teardown: capture the compose services' full stdout/stderr into the per-job logs
+# dir before tearing the stack down.  The compute node is ephemeral, so the logs
+# are lost otherwise -- and Prometheus captures metrics, not container stdout
 # (vLLM/LMCache/NIXL startup errors, stack traces, AIS debug lines live here).
-stop_containers() {
-    local c
-    for c in "$@"; do
-        docker inspect "${c}" >/dev/null 2>&1 || continue
-        docker logs "${c}" > "${LOGDIR}/container-${c}.log" 2>&1 || true
+# `compose logs` for a service not started (e.g. lmcache on the vram arm) is a
+# harmless empty capture.  `compose down` removes containers + the bridge network.
+stop_stack() {
+    local svc
+    for svc in vllm lmcache; do
+        compose logs --no-color --no-log-prefix "${svc}" > "${LOGDIR}/container-aic-${svc}.log" 2>&1 || true
     done
-    docker rm -f "$@" >/dev/null 2>&1 || true
+    compose --profile cache down --remove-orphans >/dev/null 2>&1 || true
 }
 
 # --- Metrics-capture sidecar (Prometheus + optional exporters) ---------------
@@ -532,101 +579,57 @@ stop_containers() {
 # metrics identically.  The lib's functions read log(), AIC_IMAGE, MON_DIR,
 # AIC_METRICS_DIR, MON_COMPOSE, AIC_EXPORTERS, AIC_MONITORING -- all defined above.
 source "${REPO}/monitoring/monitoring-lib.sh"
+# The whole stack (arms + metrics) is docker compose v2 only -- install the plugin
+# user-locally if the node lacks it (ensure_compose lives in monitoring-lib.sh).
+ensure_compose || die "docker compose unavailable and could not be installed"
 # Guarantee teardown (containers only; the NFS TSDB is retained) on any exit.
 trap stop_monitoring EXIT
 
 # =============================================================================
-# Arm A — vram_only : plain vLLM, no LMCache connector
+# Arm A — vram_only : plain vLLM baseline, no LMCache connector
 # =============================================================================
+# `compose up vllm` with an empty KV_TRANSFER_ARG starts vLLM alone -- lmcache is
+# behind the `cache` profile (skipped) and vllm's depends_on is required:false.
 VRAM_CSV="${RESULTS}/cliff-vram_only-${STAMP}.csv"
 run_arm_vram() {
-    rm_containers aic-cliff-vram
-    log "=== Arm A (vram_only): launching plain vLLM on :${VRAM_PORT} ==="
-    docker run -d --name aic-cliff-vram --network host "${GPU_FLAGS[@]}" \
-        -v "${HF_HOME}":/hf "${HF_ENV[@]}" \
-        "${AIC_IMAGE}" \
-            --model "${VLLM_MODEL}" --host 0.0.0.0 --port "${VRAM_PORT}" \
-            --tensor-parallel-size "${TENSOR_PARALLEL_SIZE}" \
-            --gpu-memory-utilization "${VLM_GPU_MEMORY_UTILIZATION}" \
-            --max-model-len "${VLM_MAX_MODEL_LEN}" \
-            --max-num-batched-tokens "${VLM_MAX_NUM_BATCHED_TOKENS}" \
-            "${ROPE_ARGS[@]}" \
-            --block-size 64 --enable-prefix-caching --kv-cache-dtype ${AIC_KV_CACHE_DTYPE} \
-            --async-scheduling \
-            --attention-backend "${AIC_ATTENTION_BACKEND}" \
-            --disable-access-log-for-endpoints "/health,/metrics,/v1/models" \
-        >/dev/null || { log "Arm A: docker run failed"; return 1; }
-    if ! wait_ready "${VRAM_PORT}"; then
-        log "Arm A: server never became ready; last logs:"; docker logs --tail 40 aic-cliff-vram 2>&1 | sed 's/^/    /'
-        stop_containers aic-cliff-vram; return 1
+    rm_containers aic-vllm-gpu0 aic-lmcache
+    log "=== Arm A (vram_only): plain vLLM (no LMCache) on :${VLLM_ENDPOINT_PORT} ==="
+    export KV_TRANSFER_ARG=""     # no connector -> plain VRAM-prefix-cache-only vLLM
+    export GDS_MODE=""
+    if ! compose up -d vllm; then
+        log "Arm A: compose up vllm failed"; stop_stack; return 1
     fi
-    run_bench vram_only "${VRAM_PORT}" "${VRAM_CSV}"
+    if ! wait_ready "${VLLM_ENDPOINT_PORT}"; then
+        log "Arm A: server never became ready; last logs:"
+        compose logs --tail 40 --no-color vllm 2>&1 | sed 's/^/    /'
+        stop_stack; return 1
+    fi
+    run_bench vram_only "${VLLM_ENDPOINT_PORT}" "${VRAM_CSV}"
     local rc=$?
-    stop_containers aic-cliff-vram
+    stop_stack
     return $rc
 }
 
 # =============================================================================
-# Arm B — kvd_v2 : LMCache KV offload
-#   mode "nvme" -> connector-side NIXL AIS_MT storage with a VRAM staging buffer
-#                  (nixl_buffer_device=cuda) so hipFileBufRegister does TRUE GDS;
-#                  in-process LMCacheConnectorV1, no standalone server, no L2b.
-#                  Models recipies/vllm-lmcache-nixl (the proven AIS_MT path).
-#                  A DRAM staging buffer -- what the old l2-adapter server used --
-#                  makes hipFileBufRegister fail err 5013; cuda VRAM is required.
-#   mode "gds"  -> hipFile GDS NVMe slab as L1 via a standalone lmcache-server
-#                  (LMCache-native GDS; unchanged).
+# Arm B — kvd_v2 : LMCache MP mode (standalone lmcache server + LMCacheMPConnector)
+#   mode "nvme" -> DRAM L1 + NIXL AIS_MT NVMe L2 (hipFile P2PDMA) [+ POSIX L2b].
+#                  AIC_L2_BACKEND=local_disk swaps the L2 for LMCache's native
+#                  LocalDiskBackend (POSIX .pt-per-chunk) via a mounted config.
+#   mode "gds"  -> hipFile GDS NVMe slab as L1 (GDS_MODE=1).
+# Both arms run the SAME compose stack (--profile cache): a standalone lmcache
+# server and a vLLM that reaches it over ZMQ with LMCacheMPConnector -- the
+# canonical MP topology, identical to `make up`.  The kernel mounts, IPC_LOCK,
+# memlock/nofile ulimits, and NIXL telemetry env all live in the compose file.
 # =============================================================================
-# hipFile/GDS extras any container doing hipFileBufRegister needs: kernel headers/
-# modules + debugfs/tracefs for the ftrace kprobe, IPC_LOCK + unlimited memlock
-# for pinning the registered buffer.
-HIPFILE_FLAGS=(--cap-add IPC_LOCK --ulimit memlock=-1 --ulimit nofile=1048576:1048576
-               -v /lib/modules:/lib/modules:ro -v /usr/src:/usr/src:ro
-               -v /sys/kernel/debug:/sys/kernel/debug)
-[[ -d /sys/kernel/tracing ]] && HIPFILE_FLAGS+=(-v /sys/kernel/tracing:/sys/kernel/tracing)
 
-# Write the connector-side LMCache config for the nvme (AIS_MT) arm into the
-# per-job logs dir (so it's captured), for mounting into the vLLM container.  The
-# VRAM staging buffer (nixl_buffer_device=cuda) is the key to true GDS.
-write_lmcache_nixl_config() {
-    # nixl_buffer_size is REQUIRED for a cuda (VRAM/GDS) staging buffer, but LMCache
-    # REJECTS it for a cpu buffer -- in CPU/POSIX mode NIXL shares LocalCPUBackend's
-    # pinned DRAM pool (sized by max_local_cpu_size), so it must be omitted.
-    local _bufsize_line=""
-    [[ "${AIC_NIXL_BUFFER_DEVICE}" == cuda ]] && _bufsize_line="nixl_buffer_size: ${AIC_NIXL_BUFFER_SIZE}"
-    cat > "${LOGDIR}/lmcache-nixl-ais.yml" <<YML
-# Generated by run-cliff.sbatch (kvd_v2 nvme arm) -- connector-side NIXL AIS_MT.
-chunk_size: 256
-# CPU DRAM (L1) tier: local_cpu=true adds an LMCache host-DRAM L1 in front of the
-# NIXL NVMe L2 (max_local_cpu_size = DRAM L1 GB, ignored when local_cpu=false).
-local_cpu: ${AIC_LOCAL_CPU}
-max_local_cpu_size: ${LMCACHE_MAX_LOCAL_CPU_SIZE}
-save_decode_cache: true
-# Deterministic, seed-independent chunk hashing.  The 'builtin' default uses
-# Python hash() (PYTHONHASHSEED-dependent) and doesn't match across LMCache's
-# separate lookup subprocess -> external lookups miss -> ext_hit stays 0 even
-# under L1 overflow.  sha256_cbor (as in recipies/vllm-lmcache-nixl) is stable.
-pre_caching_hash_algorithm: sha256_cbor
-${_bufsize_line}
-nixl_buffer_device: ${AIC_NIXL_BUFFER_DEVICE}
-extra_config:
-  enable_nixl_storage: true
-  nixl_backend: ${AIC_NIXL_BACKEND}
-  nixl_pool_size: ${LMCACHE_NVME_POOL}
-  use_direct_io: ${AIC_NIXL_USE_DIRECT_IO}
-  nixl_path: /data/nvme/lmcache
-YML
-}
-
-# nvme arm, AIC_L2_BACKEND=local_disk: LMCache NATIVE POSIX LocalDiskBackend as L2
-# (no NIXL).  DRAM L1 (local_cpu) in front of a .pt-file-per-chunk disk tier at
-# /data/nvme/lmcache-disk.  use_odirect=false -> buffered (page cache); true -> O_DIRECT.
+# local_disk L2 config for the MP lmcache server (mounted at /config/lmcache.yml
+# via LMCACHE_CONFIG_FILE_HOST).  DRAM L1 is set by --l1-size-gb (compose), so the
+# file carries only the disk tier + hashing.  use_odirect=false -> buffered
+# (page cache); true -> O_DIRECT.
 write_lmcache_localdisk_config() {
-    cat > "${LOGDIR}/lmcache-nixl-ais.yml" <<YML
-# Generated by run-cliff.sbatch (kvd_v2 nvme arm) -- NATIVE LocalDiskBackend (POSIX), no NIXL.
+    cat > "${LOGDIR}/lmcache-localdisk.yml" <<YML
+# Generated by run-cliff.sbatch (kvd_v2 nvme arm, local_disk L2) -- native LocalDiskBackend (POSIX).
 chunk_size: 256
-local_cpu: ${AIC_LOCAL_CPU}
-max_local_cpu_size: ${LMCACHE_MAX_LOCAL_CPU_SIZE}
 local_disk: "file:///data/nvme/lmcache-disk"
 max_local_disk_size: ${AIC_LOCAL_DISK_SIZE_GB}
 save_decode_cache: true
@@ -636,118 +639,64 @@ extra_config:
 YML
 }
 
-# gds arm only: standalone lmcache-server with a hipFile GDS L1 slab.
-launch_lmcache_gds() {
-    rm_containers aic-cliff-lmcache
-    log "launching lmcache-server (gds L1 slab) on :${LMCACHE_PORT}"
-    docker run -d --name aic-cliff-lmcache --network host \
-        --device /dev/kfd --device /dev/dri --ipc host \
-        --cap-add CAP_SYS_ADMIN --cap-add SYS_PTRACE --security-opt seccomp=unconfined \
-        "${HIPFILE_FLAGS[@]}" -v "${GDS_SLAB_DATA}":/data/slab \
-        -e LMCACHE_PORT="${LMCACHE_PORT}" -e HIPFILE_ALLOW_COMPAT_MODE="${HIPFILE_ALLOW_COMPAT_MODE}" \
-        -e HIPFILE_UNSUPPORTED_FILE_SYSTEMS=true -e PYTHONHASHSEED=0 \
-        --entrypoint /bin/bash "${AIC_IMAGE}" -o pipefail -c \
-        "exec lmcache server --host 0.0.0.0 --port ${LMCACHE_PORT} \
-             --l1-size-gb ${LMCACHE_L1_SIZE_GB} --eviction-policy LRU --gds-l1-path /data/slab" >/dev/null
-}
-
-# nvme arm: in-process LMCacheConnectorV1 with connector-side NIXL AIS_MT storage
-# (VRAM staging buffer -> true GDS).  No standalone server.  NIXL telemetry runs
-# in this process, so its exporter env lives here.
-launch_vllm_kvd_nvme() {
-    rm_containers aic-cliff-kvd-vllm
-    local _l2desc
-    case "${AIC_L2_BACKEND}" in
-      local_disk)
-        mkdir -p "${NVME_DATA}/lmcache-disk"          # host path -> /data/nvme/lmcache-disk in container
-        write_lmcache_localdisk_config
-        _l2desc="LMCache native LocalDiskBackend (POSIX, $([[ "${AIC_L2_ODIRECT}" == true ]] && echo O_DIRECT || echo buffered/page-cache))" ;;
-      nixl_posix)
-        # NIXL's first-class POSIX plugin (normalized to POSIX + cpu buffer up top).
-        # cpu buffer shares LocalCPUBackend's pool (nixl_buffer_size omitted for cpu).
-        write_lmcache_nixl_config
-        _l2desc="NIXL POSIX plugin (cpu buffer, shares DRAM pool)" ;;
-      *)
-        write_lmcache_nixl_config
-        local _iomode; [[ "${AIC_NIXL_BUFFER_DEVICE}" == cuda ]] && _iomode="GDS/GPU-direct" || _iomode="POSIX/compat"
-        _l2desc="NIXL ${AIC_NIXL_BACKEND}, ${AIC_NIXL_BUFFER_DEVICE} buffer -> ${_iomode}" ;;
-    esac
-    local _fp=""; [[ -n "${AIC_KV_LOAD_FAILURE_POLICY}" ]] && _fp=",\"kv_load_failure_policy\":\"${AIC_KV_LOAD_FAILURE_POLICY}\""
-    local kvcfg="{\"kv_connector\":\"LMCacheConnectorV1\",\"kv_role\":\"kv_both\"${_fp}}"
-    log "launching connector'd vLLM (LMCacheConnectorV1 + ${_l2desc}) on :${KVD_PORT}"
-    docker run -d --name aic-cliff-kvd-vllm --network host "${GPU_FLAGS[@]}" "${HIPFILE_FLAGS[@]}" \
-        -v "${HF_HOME}":/hf "${HF_ENV[@]}" \
-        -v "${NVME_DATA}":/data/nvme \
-        -v "${LOGDIR}/lmcache-nixl-ais.yml":/config/lmcache-nixl-ais.yml:ro \
-        -e LMCACHE_CONFIG_FILE=/config/lmcache-nixl-ais.yml \
-        -e HIPFILE_ALLOW_COMPAT_MODE="${HIPFILE_ALLOW_COMPAT_MODE}" -e HIPFILE_UNSUPPORTED_FILE_SYSTEMS=true \
-        -e NIXL_TELEMETRY_ENABLE=y -e NIXL_TELEMETRY_EXPORTER=prometheus \
-        -e NIXL_TELEMETRY_PROMETHEUS_PORT="${NIXL_METRICS_PORT:-19090}" -e PYTHONHASHSEED=0 \
-        "${AIC_IMAGE}" \
-            --model "${VLLM_MODEL}" --host 0.0.0.0 --port "${KVD_PORT}" \
-            --tensor-parallel-size "${TENSOR_PARALLEL_SIZE}" \
-            --gpu-memory-utilization "${VLM_GPU_MEMORY_UTILIZATION}" \
-            --max-model-len "${VLM_MAX_MODEL_LEN}" \
-            --max-num-batched-tokens "${VLM_MAX_NUM_BATCHED_TOKENS}" \
-            "${ROPE_ARGS[@]}" \
-            --block-size 64 --enable-prefix-caching --kv-cache-dtype ${AIC_KV_CACHE_DTYPE} \
-            --async-scheduling \
-            --attention-backend "${AIC_ATTENTION_BACKEND}" \
-            --disable-access-log-for-endpoints "/health,/metrics,/v1/models" \
-            --kv-transfer-config "${kvcfg}" >/dev/null
-}
-
-# gds arm: connector'd vLLM pointing at the standalone lmcache-server (MP).
-launch_vllm_kvd_gds() {
-    rm_containers aic-cliff-kvd-vllm
-    local _fp=""; [[ -n "${AIC_KV_LOAD_FAILURE_POLICY}" ]] && _fp=",\"kv_load_failure_policy\":\"${AIC_KV_LOAD_FAILURE_POLICY}\""
-    local kvcfg="{\"kv_connector\":\"LMCacheMPConnector\",\"kv_role\":\"kv_both\"${_fp},\"kv_connector_extra_config\":{\"lmcache.mp.host\":\"tcp://localhost\",\"lmcache.mp.port\":${LMCACHE_PORT}}}"
-    log "launching connector'd vLLM (LMCacheMPConnector) on :${KVD_PORT}"
-    docker run -d --name aic-cliff-kvd-vllm --network host "${GPU_FLAGS[@]}" \
-        -v "${HF_HOME}":/hf "${HF_ENV[@]}" \
-        "${AIC_IMAGE}" \
-            --model "${VLLM_MODEL}" --host 0.0.0.0 --port "${KVD_PORT}" \
-            --tensor-parallel-size "${TENSOR_PARALLEL_SIZE}" \
-            --gpu-memory-utilization "${VLM_GPU_MEMORY_UTILIZATION}" \
-            --max-model-len "${VLM_MAX_MODEL_LEN}" \
-            --max-num-batched-tokens "${VLM_MAX_NUM_BATCHED_TOKENS}" \
-            "${ROPE_ARGS[@]}" \
-            --block-size 64 --enable-prefix-caching --kv-cache-dtype ${AIC_KV_CACHE_DTYPE} \
-            --async-scheduling \
-            --attention-backend "${AIC_ATTENTION_BACKEND}" \
-            --disable-access-log-for-endpoints "/health,/metrics,/v1/models" \
-            --kv-transfer-config "${kvcfg}" >/dev/null
-}
-
 run_arm_kvd() {  # $1=mode(nvme|gds) $2=out_csv
     local mode="$1" out="$2"
-    log "=== Arm B (kvd_v2, mode=${mode}) ==="
+    log "=== Arm B (kvd_v2, mode=${mode}) — LMCache MP connector ==="
+    rm_containers aic-vllm-gpu0 aic-lmcache
+
+    # MP connector arg for vLLM (+ optional kv_load_failure_policy).  Single-quote
+    # the JSON so compose's shlex splitting preserves the inner double quotes.
+    local _fp=""; [[ -n "${AIC_KV_LOAD_FAILURE_POLICY}" ]] && _fp=",\"kv_load_failure_policy\":\"${AIC_KV_LOAD_FAILURE_POLICY}\""
+    export KV_TRANSFER_ARG="--kv-transfer-config '{\"kv_connector\":\"LMCacheMPConnector\",\"kv_role\":\"kv_both\"${_fp},\"kv_connector_extra_config\":{\"lmcache.mp.host\":\"tcp://lmcache\",\"lmcache.mp.port\":${LMCACHE_PORT}}}'"
+
+    local _l2desc
     if [[ "${mode}" == "gds" ]]; then
-        launch_lmcache_gds || { log "kvd/gds: lmcache failed to start"; return 1; }
-        sleep 5
-        launch_vllm_kvd_gds || { log "kvd/gds: vllm failed to start"; stop_containers aic-cliff-lmcache; return 1; }
-        if ! wait_ready "${KVD_PORT}"; then
-            log "kvd/gds: server never became ready; last logs:"
-            docker logs --tail 40 aic-cliff-lmcache 2>&1 | sed 's/^/  [lmcache] /'
-            docker logs --tail 40 aic-cliff-kvd-vllm 2>&1 | sed 's/^/  [vllm]    /'
-            stop_containers aic-cliff-kvd-vllm aic-cliff-lmcache; return 1
+        export GDS_MODE=1
+        export AIC_L2_BACKEND=nixl                       # unused in GDS mode
+        export LMCACHE_L1_SIZE_GB="${AIC_GDS_SLAB_GB}"   # hipFile slab size
+        unset LMCACHE_CONFIG_FILE LMCACHE_CONFIG_FILE_HOST
+        _l2desc="hipFile GDS NVMe slab L1 (${LMCACHE_L1_SIZE_GB}GB)"
+    else
+        export GDS_MODE=""
+        export AIC_L2_BACKEND="${AIC_L2_BACKEND}"
+        # DRAM L1 for the MP server: the tuned DRAM-L1 size when local_cpu is on,
+        # else the default L1 (a modest server-side DRAM tier in front of the L2).
+        if [[ "${AIC_LOCAL_CPU}" == "true" ]]; then
+            export LMCACHE_L1_SIZE_GB="${LMCACHE_MAX_LOCAL_CPU_SIZE}"
+        else
+            export LMCACHE_L1_SIZE_GB="${AIC_GDS_SLAB_GB}"
         fi
-        run_bench kvd_v2 "${KVD_PORT}" "${out}" --warmup-at-each-c --post-warmup-sleep-s 5
-        local rc=$?
-        stop_containers aic-cliff-kvd-vllm aic-cliff-lmcache
-        return $rc
+        if [[ "${AIC_L2_BACKEND}" == "local_disk" ]]; then
+            mkdir -p "${NVME_DATA}/lmcache-disk"
+            write_lmcache_localdisk_config
+            export LMCACHE_CONFIG_FILE_HOST="${LOGDIR}/lmcache-localdisk.yml"
+            export LMCACHE_CONFIG_FILE=/config/lmcache.yml
+            _l2desc="LMCache native LocalDiskBackend L2 (POSIX, $([[ "${AIC_L2_ODIRECT}" == true ]] && echo O_DIRECT || echo buffered), DRAM L1 ${LMCACHE_L1_SIZE_GB}GB)"
+        else
+            unset LMCACHE_CONFIG_FILE LMCACHE_CONFIG_FILE_HOST
+            _l2desc="NIXL AIS_MT NVMe L2 + POSIX L2b (DRAM L1 ${LMCACHE_L1_SIZE_GB}GB, pool ${LMCACHE_NVME_POOL})"
+        fi
     fi
-    # nvme: in-process LMCacheConnectorV1, no standalone server.
-    launch_vllm_kvd_nvme || { log "kvd/nvme: vllm failed to start"; return 1; }
-    if ! wait_ready "${KVD_PORT}"; then
-        log "kvd/nvme: server never became ready; last logs:"
-        docker logs --tail 60 aic-cliff-kvd-vllm 2>&1 | sed 's/^/  [vllm] /'
-        stop_containers aic-cliff-kvd-vllm; return 1
+    log "  stack: standalone lmcache server (${_l2desc}) + vLLM LMCacheMPConnector on :${VLLM_ENDPOINT_PORT}"
+
+    # `compose up` waits for lmcache's healthcheck before starting vllm
+    # (depends_on: service_healthy), so no manual inter-container sleep is needed.
+    if ! compose --profile cache up -d; then
+        log "kvd/${mode}: compose up failed; last logs:"
+        compose logs --tail 40 --no-color lmcache 2>&1 | sed 's/^/  [lmcache] /'
+        compose logs --tail 40 --no-color vllm    2>&1 | sed 's/^/  [vllm]    /'
+        stop_stack; return 1
+    fi
+    if ! wait_ready "${VLLM_ENDPOINT_PORT}"; then
+        log "kvd/${mode}: server never became ready; last logs:"
+        compose logs --tail 40 --no-color lmcache 2>&1 | sed 's/^/  [lmcache] /'
+        compose logs --tail 60 --no-color vllm    2>&1 | sed 's/^/  [vllm]    /'
+        stop_stack; return 1
     fi
     # Per-c warmup + drain: required for per_client mode and async-save kvd.
-    run_bench kvd_v2 "${KVD_PORT}" "${out}" --warmup-at-each-c --post-warmup-sleep-s 5
+    run_bench kvd_v2 "${VLLM_ENDPOINT_PORT}" "${out}" --warmup-at-each-c --post-warmup-sleep-s 5
     local rc=$?
-    stop_containers aic-cliff-kvd-vllm
+    stop_stack
     return $rc
 }
 
@@ -770,10 +719,12 @@ done
 log "arms        : ${AIC_CLIFF_ARMS}"
 log "isl/prefix  : ISL=${BENCH_ISL} shared=${BENCH_SHARED_TOK} max_model_len=${VLM_MAX_MODEL_LEN}${VLM_ROPE_SCALING:+ rope_scaling=${VLM_ROPE_SCALING}}"
 # Tier sizing — echo the EFFECTIVE values so a mis-propagated override is visible.
-# nixl_pool_size is a SLOT count (~4.5 MiB/slot for Qwen2.5-3B); 4096 slots ≈ 18 GiB
+# LMCACHE_NVME_POOL is a SLOT count (~4.5 MiB/slot for Qwen2.5-3B); 4096 slots ≈ 18 GiB
 # is far too small for long-ISL working sets (a silent 4096 caused the c>=32 cliff
 # collapse in jobs 67536798/67537066 — the LMCACHE_NVME_POOL override didn't land).
-log "tiers       : l2_backend=${AIC_L2_BACKEND} nixl_backend=${AIC_NIXL_BACKEND} local_cpu=${AIC_LOCAL_CPU} max_local_cpu_size=${LMCACHE_MAX_LOCAL_CPU_SIZE}GB nixl_pool_size=${LMCACHE_NVME_POOL} slots (~$(( LMCACHE_NVME_POOL * 45 / 10 / 1024 )) GiB) nixl_buffer_device=${AIC_NIXL_BUFFER_DEVICE} gds_l1=${LMCACHE_L1_SIZE_GB}GB local_disk=${AIC_LOCAL_DISK_SIZE_GB}GB(odirect=${AIC_L2_ODIRECT})"
+# In MP mode the DRAM L1 is --l1-size-gb (nvme arm: max_local_cpu_size when
+# local_cpu=true, else the default) and the slab is --l1-size-gb (gds arm).
+log "tiers       : l2_backend=${AIC_L2_BACKEND} local_cpu=${AIC_LOCAL_CPU} dram_l1(nvme)=${LMCACHE_MAX_LOCAL_CPU_SIZE}GB nvme_pool=${LMCACHE_NVME_POOL} slots (~$(( LMCACHE_NVME_POOL * 45 / 10 / 1024 )) GiB) gds_slab=${AIC_GDS_SLAB_GB}GB local_disk=${AIC_LOCAL_DISK_SIZE_GB}GB(odirect=${AIC_L2_ODIRECT})"
 
 if _arm_on vram; then run_arm_vram && STATUS[vram_only]=ok || STATUS[vram_only]=FAIL; else STATUS[vram_only]=skip; fi
 if _arm_on nvme; then run_arm_kvd nvme "${KVD_NVME_CSV}" && STATUS[kvd_nvme]=ok || STATUS[kvd_nvme]=FAIL; else STATUS[kvd_nvme]=skip; fi

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -22,11 +22,15 @@ HTTPS
 HuggingFace
 Huggingface
 InfiniBand
+JSON
 KV
 LLM
 LMCache
 LMCache's
+LMCacheMPConnector
+LocalDiskBackend
 MERCHANTABILITY
+MiB
 Mountpoint
 NFS
 NIXL
@@ -55,7 +59,9 @@ aic
 ais
 amd
 ansible
+arg
 args
+backend
 benchmarking
 config
 cpp
@@ -67,6 +73,7 @@ disaggregated
 diskstats
 dispatch
 env
+fp
 ftrace
 gds
 gfx

--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,25 @@ export VLM_GPU_MEMORY_UTILIZATION VLM_MAX_MODEL_LEN VLM_MAX_NUM_BATCHED_TOKENS
 export NIXL_GIT_URL NIXL_SHA
 
 comma := ,
-_COMPOSE_BIN := $(shell docker compose version >/dev/null 2>&1 && echo "docker compose" || echo "docker-compose")
+# The whole stack is `docker compose` (v2) only -- the docker-compose v1 standalone
+# and the old docker-run sidecar fallbacks are gone.  `make ensure-compose` installs
+# the v2 plugin into ~/.docker/cli-plugins (shared $HOME) on nodes that lack it.
+_COMPOSE_BIN := docker compose
 COMPOSE      := DOCKER_BUILDKIT=1 $(_COMPOSE_BIN) -f "$(CURDIR)/docker/docker-compose.yml"
+# The lmcache service lives behind the `cache` profile; the interactive stack and
+# the cliff kvd arms enable it, the plain vram baseline does not.
+COMPOSE_CACHE := $(COMPOSE) --profile cache
+
+# docker compose v2 plugin (installed by `ensure-compose` when missing).  Override
+# the version to bump.  Downloaded from the docker/compose GitHub releases.
+COMPOSE_PLUGIN_VERSION ?= v2.40.0
+
+# vLLM --kv-transfer-config for the MP connector (interactive `make up`).  The JSON
+# is wrapped in single quotes so compose's shlex splitting preserves the inner
+# double quotes; leave KV_TRANSFER_ARG empty for a plain (baseline) vLLM.
+_MP_CONNECTOR_JSON := {"kv_connector":"LMCacheMPConnector","kv_role":"kv_both","kv_connector_extra_config":{"lmcache.mp.host":"tcp://lmcache","lmcache.mp.port":$(LMCACHE_PORT)}}
+KV_TRANSFER_ARG    ?= --kv-transfer-config '$(_MP_CONNECTOR_JSON)'
+export KV_TRANSFER_ARG
 
 # ---- Metrics capture (Prometheus sidecar) ----------------------------------
 # AIC_METRICS_DIR: Prometheus TSDB dir (bind-mount an NFS path here to explore
@@ -97,6 +114,15 @@ PYTHON := $(if $(wildcard $(REPO_ROOT)/.venv/bin/python3),$(REPO_ROOT)/.venv/bin
 # /scratch so a failed build resumes from the last good layer on any node
 # (set AIC_CACHE_DIR= to disable); AIC_BUILD_EXPORTERS=0 skips the fabric images.
 DIST := $(CURDIR)/.slurm/run-build-distribute.sh
+
+# ---- Self-hosted CI runner scripts -----------------------------------------
+# The hardware-CI workflows call helper scripts from AIC_CI_LIB_DIR on the
+# self-hosted runner (spur-dist-build.sh / spur-smoke-test.sh / spur-tiny-test.sh
+# / spur-cliff.sh).  `make install-ci-scripts` deploys the source copies from
+# .github/scripts there.  Writing under /usr/local usually needs root, so the
+# target uses sudo when the destination is not writable by the current user.
+AIC_CI_LIB_DIR    ?= /usr/local/lib/aic-ci
+AIC_CI_SCRIPT_DIR := $(CURDIR)/.github/scripts
 
 # ---- SPUR cluster overrides ------------------------------------------------
 # When AIC_SPUR_CLUSTER=1, default storage paths to AIC_SHARED_NFS (the NFS
@@ -152,10 +178,10 @@ _GIT_DIRTY     := $(if $(shell git -C "$(CURDIR)" status --porcelain -- . 2>/dev
 _GEN_DATE      := $(shell date +%Y%m%d)
 EXPORT_TARBALL ?= $(CURDIR)/$(EXPORT_PREFIX)-$(_GEN_DATE)-$(_GIT_SHORT_REV)$(_GIT_DIRTY).tar.gz
 
-.PHONY: help build up up-batch up-gds-l1 up-gds-l1-batch down logs logs-lmcache logs-vllm \
+.PHONY: help ensure-compose build up up-batch up-gds-l1 up-gds-l1-batch down logs logs-lmcache logs-vllm \
         ps shell-lmcache shell-vllm restart-vllm restart-lmcache cliff plot venv \
         monitoring-up monitoring-down monitoring-logs monitoring-build-exporters \
-        dist-build dist-build-exporters dist-push smoke-test cliff-submit cliff-short \
+        dist-build dist-build-exporters dist-push smoke-test tiny-test install-ci-scripts cliff-submit cliff-short \
         cliff-long-64k cliff-long-128k \
         export _check_hf_token _prep_dirs _check_gds_slab
 
@@ -165,6 +191,7 @@ help:
 	@echo "rocm-aic aic-release — AMD Infinity Context inference stack + benchmarks"
 	@echo ""
 	@echo "Stack targets:"
+	@echo "  make ensure-compose    Install the docker compose v2 plugin if missing (user-local)"
 	@echo "  make build             Build the shared image ($(IMAGE_NAME))"
 	@echo "  make up                Start lmcache + vllm (foreground, DRAM L1 + AIS_MT/NFS L2)"
 	@echo "  make up-batch          Start lmcache + vllm (background)"
@@ -193,6 +220,8 @@ help:
 	@echo "  make smoke-test        Load + smoke-test the image on a GPU+NVMe node"
 	@echo "                         (also sanity-checks exporters + writes a Prometheus TSDB"
 	@echo "                          to logs/<job-id>/prometheus; AIC_SMOKE_EXPORTERS=0 skips)"
+	@echo "  make tiny-test         End-to-end serve check (MP stack + tiny model, one completion)"
+	@echo "  make install-ci-scripts  Deploy .github/scripts/spur-*.sh to $(AIC_CI_LIB_DIR) (sudo if needed)"
 	@echo "  make cliff-submit      sbatch the full 3-arm cliff sweep -> logs/<job-id>/"
 	@echo "  make cliff-short       sbatch a 1-point cliff (concur=1, 1 iter) to smoke-test the flow"
 	@echo "  make cliff-long-64k    sbatch a 64k-ISL YaRN(x2) 3-arm sweep (pools sized for the working set)"
@@ -262,40 +291,59 @@ _prep_dirs:
 		"$(HF_HOME)/vllm_config" "$(HF_HOME)/torch" "$(HF_HOME)/torch_inductor" \
 		"$(BENCH_LOGDIR)/results" "$(BENCH_LOGDIR)/plots"
 
-build:
+# Ensure the `docker compose` (v2) plugin is available.  Docker checks
+# $HOME/.docker/cli-plugins before the system dir, and $HOME is shared across the
+# Slurm/SPUR nodes, so a user-local install fixes every node without root.  No-op
+# when compose is already present; idempotent.
+ensure-compose:
+	@if docker compose version >/dev/null 2>&1; then \
+		echo "docker compose present: $$(docker compose version --short 2>/dev/null)"; \
+	else \
+		echo "docker compose plugin missing; installing $(COMPOSE_PLUGIN_VERSION) -> ~/.docker/cli-plugins"; \
+		mkdir -p "$$HOME/.docker/cli-plugins" && \
+		arch="$$(uname -m)" && \
+		curl -fsSL "https://github.com/docker/compose/releases/download/$(COMPOSE_PLUGIN_VERSION)/docker-compose-linux-$$arch" \
+			-o "$$HOME/.docker/cli-plugins/docker-compose" && \
+		chmod +x "$$HOME/.docker/cli-plugins/docker-compose" && \
+		docker compose version >/dev/null 2>&1 || { \
+			echo "ERROR: docker compose still unavailable after install" >&2; exit 1; }; \
+		echo "installed: $$(docker compose version --short 2>/dev/null)"; \
+	fi
+
+build: ensure-compose
 	@test -n "$(ROCM_ARCH)" || { \
 		echo "ERROR: ROCM_ARCH empty (install ROCm or set ROCM_ARCH=gfxNNNN)" >&2; exit 1; }
-	cd "$(REPO_ROOT)" && $(COMPOSE) build \
+	cd "$(REPO_ROOT)" && $(COMPOSE_CACHE) build \
 		$(if $(TLS_CERT),--secret id=tls_cert$(comma)src=$(TLS_CERT),)
 
-up: _check_hf_token _prep_dirs
-	$(COMPOSE) up
+up: ensure-compose _check_hf_token _prep_dirs
+	$(COMPOSE_CACHE) up
 
-up-batch: _check_hf_token _prep_dirs
-	$(COMPOSE) up -d
+up-batch: ensure-compose _check_hf_token _prep_dirs
+	$(COMPOSE_CACHE) up -d
 	@echo "Started. Use 'make logs' to follow or 'make down' to stop."
 
-up-gds-l1: _check_hf_token _check_gds_slab _prep_dirs
-	GDS_MODE=1 $(COMPOSE) up
+up-gds-l1: ensure-compose _check_hf_token _check_gds_slab _prep_dirs
+	GDS_MODE=1 $(COMPOSE_CACHE) up
 
-up-gds-l1-batch: _check_hf_token _check_gds_slab _prep_dirs
-	GDS_MODE=1 $(COMPOSE) up -d
+up-gds-l1-batch: ensure-compose _check_hf_token _check_gds_slab _prep_dirs
+	GDS_MODE=1 $(COMPOSE_CACHE) up -d
 	@echo "Started (GDS L1 mode). Use 'make logs' to follow or 'make down' to stop."
 
 down:
-	$(COMPOSE) down
+	$(COMPOSE_CACHE) down
 
 logs:
-	$(COMPOSE) logs -f
+	$(COMPOSE_CACHE) logs -f
 
 logs-lmcache:
-	$(COMPOSE) logs -f lmcache
+	$(COMPOSE_CACHE) logs -f lmcache
 
 logs-vllm:
-	$(COMPOSE) logs -f vllm
+	$(COMPOSE_CACHE) logs -f vllm
 
 ps:
-	$(COMPOSE) ps
+	$(COMPOSE_CACHE) ps
 
 shell-lmcache:
 	docker exec -it aic-lmcache bash -l
@@ -304,10 +352,10 @@ shell-vllm:
 	docker exec -it aic-vllm-gpu$(GPU) bash -l
 
 restart-vllm:
-	$(COMPOSE) restart vllm
+	$(COMPOSE_CACHE) restart vllm
 
 restart-lmcache:
-	$(COMPOSE) restart lmcache
+	$(COMPOSE_CACHE) restart lmcache
 
 venv:
 	@if [ ! -d "$(REPO_ROOT)/.venv" ]; then \
@@ -339,7 +387,7 @@ plot: _prep_dirs
 		--output-dir "$(BENCH_LOGDIR)/plots/"
 	@echo "Charts written to $(BENCH_LOGDIR)/plots/"
 
-monitoring-up:
+monitoring-up: ensure-compose
 	@mkdir -p "$(AIC_METRICS_DIR)"
 	PROM_UID="$$(id -u)" PROM_GID="$$(id -g)" \
 		$(MON_COMPOSE) $(_MON_PROFILE) up -d
@@ -391,6 +439,25 @@ dist-push:                     # Tag + push the built image to a registry (needs
 
 smoke-test:                    # Load + smoke-test the image on a GPU+NVMe node
 	"$(DIST)" test
+
+tiny-test:                     # End-to-end serve check: MP stack + a tiny model, one real completion
+	@# Stages Qwen/Qwen2.5-0.5B-Instruct, brings up the compose MP stack (nvme arm),
+	@# waits for the endpoint, and asserts one non-empty chat completion.  Fast
+	@# functional gate that exercises the connector path a smoke-test cannot.
+	"$(DIST)" tiny-test
+
+install-ci-scripts:            # Deploy .github/scripts/spur-*.sh to the runner's AIC_CI_LIB_DIR
+	@set -e; \
+	src="$(AIC_CI_SCRIPT_DIR)"; dst="$(AIC_CI_LIB_DIR)"; \
+	ls "$$src"/spur-*.sh >/dev/null 2>&1 || { echo "ERROR: no spur-*.sh under $$src" >&2; exit 1; }; \
+	if [ -w "$$(dirname "$$dst")" ] || [ -w "$$dst" ]; then SUDO=; else SUDO="sudo"; \
+		echo "$$dst not writable; using sudo"; fi; \
+	$$SUDO install -d -m 0755 "$$dst"; \
+	for f in "$$src"/spur-*.sh; do \
+		$$SUDO install -m 0755 "$$f" "$$dst/$$(basename "$$f")"; \
+		echo "installed $$(basename "$$f") -> $$dst/"; \
+	done; \
+	echo "CI runner scripts deployed to $$dst"
 
 # Submit the full 3-arm cliff sweep (vram_only + kvd_v2 nvme + kvd_v2 gds).  Pin
 # a node with AIC_CLIFF_NODE, narrow arms with AIC_CLIFF_ARMS=nvme (etc), and

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![Export Tarball](https://github.com/ROCm/rocm-aic/actions/workflows/aic-export.yml/badge.svg)](https://github.com/ROCm/rocm-aic/actions/workflows/aic-export.yml)
 [![Nightly Dist Build](https://github.com/ROCm/rocm-aic/actions/workflows/aic-amd-nightly-dist-build.yml/badge.svg)](https://github.com/ROCm/rocm-aic/actions/workflows/aic-amd-nightly-dist-build.yml)
 [![Nightly Smoke Test](https://github.com/ROCm/rocm-aic/actions/workflows/aic-amd-nightly-smoke-test.yml/badge.svg)](https://github.com/ROCm/rocm-aic/actions/workflows/aic-amd-nightly-smoke-test.yml)
+[![Nightly Tiny Test](https://github.com/ROCm/rocm-aic/actions/workflows/aic-amd-nightly-tiny-test.yml/badge.svg)](https://github.com/ROCm/rocm-aic/actions/workflows/aic-amd-nightly-tiny-test.yml)
 [![Nightly Cliff](https://github.com/ROCm/rocm-aic/actions/workflows/aic-amd-nightly-cliff.yml/badge.svg)](https://github.com/ROCm/rocm-aic/actions/workflows/aic-amd-nightly-cliff.yml)
 [![Nightly Wheels](https://github.com/ROCm/rocm-aic/actions/workflows/aic-nightly-wheels.yml/badge.svg)](https://github.com/ROCm/rocm-aic/actions/workflows/aic-nightly-wheels.yml)
 [![Nightly Patch Validation](https://github.com/ROCm/rocm-aic/actions/workflows/aic-patches.yml/badge.svg)](https://github.com/ROCm/rocm-aic/actions/workflows/aic-patches.yml)
@@ -69,7 +70,11 @@ compatibility notes. Wheels are rebuilt nightly from `main` and published to the
   multi-arch — it bakes in every gfx the vLLM wheel supports (`gfx90a`, `gfx942`,
   `gfx950`, and the RDNA `gfx11xx`/`gfx12xx` line), so one image runs on any of
   them. Narrow with `ROCM_ARCH=gfx942` for a faster single-arch build.
-- Docker with BuildKit and the `docker compose` plugin (Docker 23+)
+- Docker with BuildKit and the `docker compose` (v2) plugin (Docker 23+). On a
+  node that lacks it, `make ensure-compose` installs the plugin user-locally
+  (`~/.docker/cli-plugins`); the Slurm cliff / smoke / tiny-test jobs self-install
+  it automatically. The whole stack is `docker compose` only — there is no
+  `docker-compose` v1 or docker-run fallback.
 - Host mounts: local NVMe (`NVME_DATA`) and NFS-over-RDMA (`NFS_DATA`) pre-mounted
 - HuggingFace token with access to the target model
 - Python 3.10+ for host-side benchmarks

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,9 +11,23 @@
 #                 L2b: nixl_store POSIX  → NFS-over-RDMA (host pre-mounted)
 #               GDS L1 mode (GDS_MODE=1):
 #                 L1:  NVMe slab at GDS_SLAB_DATA (hipFile on ROCm, cuFile on NVIDIA — auto-detected)
+#               local_disk L2 (AIC_L2_BACKEND=local_disk):
+#                 L1:  DRAM (--l1-size-gb) + native LocalDiskBackend L2 via LMCACHE_CONFIG_FILE
 #
-#   vllm    — vllm serve with LMCacheMPConnector
-#               Connects to lmcache:${LMCACHE_PORT:-6555} over ZMQ
+#   vllm    — vllm serve, optionally with LMCacheMPConnector
+#               KV_TRANSFER_ARG selects the connector.  Set it to the
+#               LMCacheMPConnector JSON (default via `make up`) to connect to the
+#               lmcache service over ZMQ, or leave it EMPTY for a plain
+#               VRAM-prefix-cache-only vLLM (the cliff `vram` baseline arm).
+#
+# This one compose file is the single source of truth for every launch path:
+#   make up / up-gds-l1                — interactive MP stack
+#   .slurm/run-cliff.sbatch            — all cliff arms (vram baseline + nvme + gds)
+#   .slurm/run-build-distribute.sh     — tiny-test end-to-end serve
+#
+# The lmcache service sits behind the `cache` compose profile, so the plain
+# `vram` baseline can start `vllm` alone (`docker compose up vllm`) without
+# pulling in lmcache — vllm's depends_on uses `required: false` for that.
 #
 # Required env:
 #   ROCM_ARCH      — e.g. gfx942
@@ -25,6 +39,9 @@
 #   GPU                    — ROCR_VISIBLE_DEVICES for vllm and lmcache (default: 0)
 #   GDS_MODE               — set to 1 to enable hipFile NVMe slab as L1 (requires GDS_SLAB_DATA)
 #   GDS_SLAB_DATA          — host path for the hipFile slab file (required when GDS_MODE=1)
+#   AIC_L2_BACKEND         — nixl (default AIS_MT + POSIX L2) or local_disk (native LocalDiskBackend)
+#   LMCACHE_CONFIG_FILE_HOST — host path to an LMCache YAML config to mount (advanced; local_disk)
+#   KV_TRANSFER_ARG        — vLLM --kv-transfer-config arg (empty = plain vLLM baseline)
 #   HF_HOME                — host HF cache dir (default: ~/.cache/huggingface)
 #   LOG                    — host log dir (default: ../logs, i.e. /logs)
 #   IMAGE_NAME             — Docker image tag (default: rocm-aic)
@@ -34,19 +51,26 @@
 #   LMCACHE_NVME_POOL      — nixl pool slots for NVMe adapter (default: 4096)
 #   LMCACHE_NVME_SLOT_SIZE — nixl file size per slot in bytes (default: 256 MiB)
 #   LMCACHE_NFS_POOL       — nixl pool slots for NFS adapter (default: 1024)
+#   AIC_NIXL_USE_DIRECT_IO — O_DIRECT for the AIS_MT NVMe L2 (default: true)
 #   VLM_GPU_MEMORY_UTILIZATION — vllm --gpu-memory-utilization (default: 0.90)
 #   VLM_MAX_MODEL_LEN          — vllm --max-model-len (default: 32768)
 #   VLM_MAX_NUM_BATCHED_TOKENS — vllm --max-num-batched-tokens (default: 4096)
+#   VLM_ATTENTION_BACKEND      — vllm --attention-backend (default: TRITON_ATTN)
+#   VLM_KV_CACHE_DTYPE         — vllm --kv-cache-dtype (default: fp8)
+#   VLLM_EXTRA_ARGS            — extra vllm args appended verbatim (e.g. --hf-overrides ...)
 #   TENSOR_PARALLEL_SIZE       — vllm --tensor-parallel-size (default: 1)
 
 services:
 
   # ---------------------------------------------------------------------------
   # lmcache: standalone LMCache server in MP mode
-  # Selects between DRAM L1 + AIS_MT/NFS L2 (default) and GDS NVMe slab L1
-  # via the GDS_MODE environment variable.
+  # Selects between DRAM L1 + AIS_MT/NFS L2 (default), GDS NVMe slab L1
+  # (GDS_MODE=1), and native LocalDiskBackend L2 (AIC_L2_BACKEND=local_disk).
+  # Behind the `cache` profile so the plain vram baseline can skip it.
   # ---------------------------------------------------------------------------
   lmcache:
+    profiles:
+      - cache
     build:
       # Compose lives in docker/; the build context is the  tree
       # root (one level up) so the Dockerfile's COPY scripts/ patches/ benchmarks/
@@ -74,6 +98,10 @@ services:
       nofile:
         soft: 1048576
         hard: 1048576
+      # hipFileBufRegister pins the registered staging buffer; needs unlimited memlock.
+      memlock:
+        soft: -1
+        hard: -1
     devices:
       - /dev/kfd
       - /dev/dri
@@ -84,6 +112,9 @@ services:
       - ${NFS_DATA:-/mnt/lmcache-nfs}:/data/nfs
       # GDS L1 slab (GDS_MODE=1 only; mount is harmless when GDS_MODE is unset)
       - ${GDS_SLAB_DATA:-/tmp/gds-slab-unused}:/data/slab
+      # Optional LMCache YAML config (local_disk / advanced tuning).  Defaults to a
+      # harmless mount; only read when LMCACHE_CONFIG_FILE is set in the environment.
+      - ${LMCACHE_CONFIG_FILE_HOST:-/dev/null}:/config/lmcache.yml:ro
       # Kernel interfaces for hipFile KFD GPUDirect fastpath (GDS L1 mode)
       - /lib/modules:/lib/modules:ro
       - /usr/src:/usr/src:ro
@@ -96,6 +127,13 @@ services:
       - LMCACHE_L1_SIZE_GB=${LMCACHE_L1_SIZE_GB:-20}
       - GDS_MODE=${GDS_MODE:-}
       - GDS_SLAB_DATA=${GDS_SLAB_DATA:-}
+      - AIC_L2_BACKEND=${AIC_L2_BACKEND:-nixl}
+      - LMCACHE_NVME_POOL=${LMCACHE_NVME_POOL:-4096}
+      - LMCACHE_NVME_SLOT_SIZE=${LMCACHE_NVME_SLOT_SIZE:-268435456}
+      - LMCACHE_NFS_POOL=${LMCACHE_NFS_POOL:-1024}
+      - AIC_NIXL_USE_DIRECT_IO=${AIC_NIXL_USE_DIRECT_IO:-true}
+      # Only set when a real config file is mounted (local_disk / advanced tuning).
+      - LMCACHE_CONFIG_FILE=${LMCACHE_CONFIG_FILE:-}
       - HIPFILE_ALLOW_COMPAT_MODE=false
       - HIPFILE_UNSUPPORTED_FILE_SYSTEMS=true
       # NIXL native Prometheus telemetry exporter (serves /metrics on :19090).
@@ -107,7 +145,8 @@ services:
       - ROCR_VISIBLE_DEVICES=${GPU:-0}
       - PYTHONHASHSEED=0
       - TZ=${TZ:-America/Edmonton}
-    # The entrypoint script selects standard vs GDS L1 mode based on GDS_MODE.
+    # The entrypoint script selects the L1/L2 topology from GDS_MODE +
+    # AIC_L2_BACKEND.  local_disk relies on LMCACHE_CONFIG_FILE (mounted above).
     entrypoint: ["/bin/bash", "-o", "pipefail", "-c"]
     command:
       - |
@@ -118,14 +157,22 @@ services:
             --l1-size-gb "$$LMCACHE_L1_SIZE_GB" \
             --eviction-policy LRU \
             --gds-l1-path /data/slab
+        elif [ "$$AIC_L2_BACKEND" = "local_disk" ]; then
+          # Native LocalDiskBackend L2: DRAM L1 (--l1-size-gb) in front of a
+          # .pt-per-chunk disk tier configured via the mounted LMCACHE_CONFIG_FILE.
+          exec lmcache server \
+            --host 0.0.0.0 \
+            --port "$$LMCACHE_PORT" \
+            --l1-size-gb "$$LMCACHE_L1_SIZE_GB" \
+            --eviction-policy LRU
         else
           exec lmcache server \
             --host 0.0.0.0 \
             --port "$$LMCACHE_PORT" \
             --l1-size-gb "$$LMCACHE_L1_SIZE_GB" \
             --eviction-policy LRU \
-            --l2-adapter "{\"type\":\"nixl_store\",\"backend\":\"AIS_MT\",\"backend_params\":{\"file_path\":\"/data/nvme/lmcache\",\"use_direct_io\":\"true\",\"file_size\":${LMCACHE_NVME_SLOT_SIZE:-268435456}},\"pool_size\":${LMCACHE_NVME_POOL:-4096}}" \
-            --l2-adapter "{\"type\":\"nixl_store\",\"backend\":\"POSIX\",\"backend_params\":{\"file_path\":\"/data/nfs/lmcache\"},\"pool_size\":${LMCACHE_NFS_POOL:-1024}}"
+            --l2-adapter "{\"type\":\"nixl_store\",\"backend\":\"AIS_MT\",\"backend_params\":{\"file_path\":\"/data/nvme/lmcache\",\"use_direct_io\":\"$$AIC_NIXL_USE_DIRECT_IO\",\"file_size\":$$LMCACHE_NVME_SLOT_SIZE},\"pool_size\":$$LMCACHE_NVME_POOL}" \
+            --l2-adapter "{\"type\":\"nixl_store\",\"backend\":\"POSIX\",\"backend_params\":{\"file_path\":\"/data/nfs/lmcache\"},\"pool_size\":$$LMCACHE_NFS_POOL}"
         fi
     healthcheck:
       test:
@@ -139,7 +186,7 @@ services:
       start_period: 30s
 
   # ---------------------------------------------------------------------------
-  # vllm: vLLM serve with LMCacheMPConnector
+  # vllm: vLLM serve, optionally with LMCacheMPConnector (via KV_TRANSFER_ARG)
   # ---------------------------------------------------------------------------
   vllm:
     image: ${IMAGE_NAME:-rocm-aic}
@@ -161,10 +208,12 @@ services:
       - ${HF_HOME:-~/.cache/huggingface}:/hf
       - ${LOG:-../logs}/vllm:/var/log/aic-vllm
     environment:
-      - HF_TOKEN=${HF_TOKEN}
+      - HF_TOKEN=${HF_TOKEN:-}
       - HF_HOME=/hf
       - HF_HUB_CACHE=/hf/hub
       - HF_DATASETS_CACHE=/hf/datasets
+      - HF_HUB_OFFLINE=${HF_HUB_OFFLINE:-0}
+      - TRANSFORMERS_OFFLINE=${TRANSFORMERS_OFFLINE:-0}
       - VLLM_CACHE_ROOT=/hf/vllm
       - VLLM_CONFIG_ROOT=/hf/vllm_config
       - TORCH_HOME=/hf/torch
@@ -173,6 +222,9 @@ services:
       - AMDGCN_USE_BUFFER_OPS=0
       - MIOPEN_FIND_MODE=FAST
       - MIOPEN_USER_DB_PATH=/app/miopen
+      # AITER unified attention: required so a KV connector (LMCache) can unify a
+      # hybrid model's KV-cache specs.  Harmless for the plain baseline.
+      - VLLM_ROCM_USE_AITER=${AIC_ROCM_USE_AITER:-1}
       - PYTORCH_ALLOC_CONF=${PYTORCH_ALLOC_CONF:-expandable_segments:False}
       - PYTHONHASHSEED=0
       - TZ=${TZ:-America/Edmonton}
@@ -186,15 +238,20 @@ services:
         --max-num-batched-tokens ${VLM_MAX_NUM_BATCHED_TOKENS:-4096}
         --block-size 64
         --enable-prefix-caching
-        --kv-cache-dtype fp8
+        --kv-cache-dtype ${VLM_KV_CACHE_DTYPE:-fp8}
+        --attention-backend ${VLM_ATTENTION_BACKEND:-TRITON_ATTN}
         --stream-interval 20
         --async-scheduling
         --disable-access-log-for-endpoints "/health,/metrics,/v1/models"
         --enable-mfu-metrics
-        --kv-transfer-config '{"kv_connector":"LMCacheMPConnector","kv_role":"kv_both","kv_connector_extra_config":{"lmcache.mp.host":"tcp://lmcache","lmcache.mp.port":${LMCACHE_PORT:-6555}}}'
+        ${KV_TRANSFER_ARG:-}
+        ${VLLM_EXTRA_ARGS:-}
     depends_on:
       lmcache:
         condition: service_healthy
+        # required:false lets the plain baseline run `vllm` alone (lmcache not in
+        # the active profile) without a dependency error (needs Compose v2.20+).
+        required: false
 
 networks:
   aic-net:

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -9,9 +9,18 @@
 | `NFS_DATA` | `/mnt/lmcache-nfs` | Host path for NFS-over-RDMA L2b pool |
 | `GDS_SLAB_DATA` | — | Host path for GDS NVMe slab (GDS L1 mode only) |
 | `GDS_MODE` | — | Set to `1` to enable GDS L1 mode |
-| `LMCACHE_L1_SIZE_GB` | `20` | L1 memory cap in GiB |
+| `AIC_L2_BACKEND` | `nixl` | LMCache L2 backend: `nixl` (AIS_MT NVMe + POSIX NFS) or `local_disk` (native LocalDiskBackend via a mounted config) |
+| `KV_TRANSFER_ARG` | LMCacheMPConnector JSON | vLLM `--kv-transfer-config` arg; empty = plain vLLM (the cliff `vram` baseline). Wrap the JSON in single quotes |
+| `LMCACHE_L1_SIZE_GB` | `20` | MP server L1 cap in GiB (DRAM L1 in nvme mode, hipFile slab size in GDS mode) |
 | `LMCACHE_NVME_POOL` | `4096` | NIXL pool slots for NVMe adapter |
+| `LMCACHE_NVME_SLOT_SIZE` | `268435456` | NIXL file size per NVMe pool slot, bytes (256 MiB) |
 | `LMCACHE_NFS_POOL` | `1024` | NIXL pool slots for NFS adapter |
+| `VLM_ATTENTION_BACKEND` | `TRITON_ATTN` | vLLM `--attention-backend` (TRITON_ATTN supports KV connectors) |
+| `VLM_KV_CACHE_DTYPE` | `fp8` | vLLM `--kv-cache-dtype` (`auto` for non-fp8 arches) |
+| `VLLM_EXTRA_ARGS` | — | Extra vLLM args appended verbatim (e.g. `--hf-overrides '{...}'`; single-quote embedded JSON) |
+| `COMPOSE_PLUGIN_VERSION` | `v2.40.0` | docker compose v2 plugin version installed by `make ensure-compose` / `ensure_compose` when missing |
+| `AIC_TINY_MODEL` | `Qwen/Qwen2.5-0.5B-Instruct` | Model served by `make tiny-test` (end-to-end serve check) |
+| `AIC_TINY_HF_HOME` | `<image-dir>/tiny-hf` | Persistent HF cache the tiny model is downloaded into for `tiny-test` |
 | `TENSOR_PARALLEL_SIZE` | `1` | vLLM tensor parallel degree |
 | `GPU` | `0` | ROCR_VISIBLE_DEVICES for the vllm container |
 | `AIC_NVME_AUTO` | `1` (cliff) | Auto-detect a dedicated local NVMe for the LMCache tiers: reuse a mounted `aic-lmcache` volume, else format+mount a raw non-root spare, else use a non-root mounted NVMe, else node-local `/tmp`. `0` forces `/tmp`; needs passwordless `sudo` to format/mount |

--- a/docs/METRICS_TELEMETRY.md
+++ b/docs/METRICS_TELEMETRY.md
@@ -59,21 +59,24 @@ same upstream release binaries so the `nvme_*` / `rdma_port_*` series match:
 > / node-exporter's nvme+infiniband collectors.
 
 ```bash
-# build both fabric-exporter images (works without the compose plugin)
+# build both fabric-exporter images (plain docker build)
 make monitoring-build-exporters
 
-# run them alongside the sidecar via the exporters-fabric compose profile
+# run them via the exporters-fabric compose profile
 AIC_METRICS_DIR=/mnt/lmcache-nfs/metrics \
   docker compose -f monitoring/docker-compose.monitoring.yml \
     --profile exporters --profile exporters-fabric up -d
 ```
 
-For the cliff sbatch docker-run path (nodes without the compose plugin), set
-`AIC_NVME_EXPORTER_IMAGE=aic-nvme-exporter:local` /
-`AIC_RDMA_EXPORTER_IMAGE=aic-rdma-exporter:local` after building. Each
-container is skipped automatically if a host service already serves its port.
-On a node lacking both, NVMe I/O still comes from node-exporter's
-`diskstats`/`nvme` collectors and RDMA from its `infiniband` collector.
+The whole metrics path is `docker compose` (v2) only. The cliff sbatch and the
+smoke-test run `ensure_compose` first, which installs the plugin user-locally
+(`~/.docker/cli-plugins`, shared `$HOME`) on any node that lacks it — so there is
+no longer a `docker run` sidecar fallback. When the fabric-exporter images are
+present on the node, set `AIC_NVME_EXPORTER_IMAGE=aic-nvme-exporter:latest` /
+`AIC_RDMA_EXPORTER_IMAGE=aic-rdma-exporter:latest` and the cliff enables the
+`exporters-fabric` compose profile automatically. On a node without them, NVMe
+I/O still comes from node-exporter's `diskstats`/`nvme` collectors and RDMA from
+its `infiniband` collector.
 
 **hsa-snoop (`:9488`).**
 [sbates130272/hsa-snoop](https://github.com/sbates130272/hsa-snoop)

--- a/monitoring/monitoring-lib.sh
+++ b/monitoring/monitoring-lib.sh
@@ -5,15 +5,19 @@
 #
 # SPDX-License-Identifier: MIT
 #
-# Shared metrics-capture helpers: bring up the Prometheus sidecar + the exporter
-# fleet via `docker run` (the Markham GPU nodes have docker but not the compose
-# plugin), health-check each exporter, summarize what landed in the TSDB, and
-# tear the stack down.  SOURCED (not executed) by:
+# Shared metrics-capture helpers: bring up the Prometheus capture stack + the
+# exporter fleet via `docker compose`, health-check each exporter, summarize what
+# landed in the TSDB, and tear the stack down.  SOURCED (not executed) by:
 #
 #   .slurm/run-cliff.sbatch          -- capture metrics across the cliff sweep
 #   .slurm/run-build-distribute.sh   -- the `smoke-test` exporter sanity check
 #
 # so both drive metrics identically and there is one place to fix.
+#
+# The whole stack is `docker compose` (v2) only.  The old docker-run fallback for
+# nodes without the compose plugin is gone; ensure_compose() below installs the
+# plugin user-locally ($HOME/.docker/cli-plugins, shared across the Slurm nodes)
+# when it is missing, so `docker compose` always resolves.
 #
 # Caller contract (set before calling the functions; the defaults below keep a
 # bare source harmless and the linter quiet):
@@ -41,209 +45,58 @@ declare -F log >/dev/null 2>&1 || log() { printf '[monitoring] %s\n' "$*" >&2; }
 
 have_compose() { docker compose version >/dev/null 2>&1; }
 
-mon_profile() {  # echo the compose --profile args for the exporters profile
-    [[ "${AIC_EXPORTERS}" == "1" ]] && printf -- '--profile\nexporters\n'
-}
-
-# Compose service container_names -- reused by the docker-run fallback so both
-# paths produce identically-named containers and share one teardown.
-MON_CONTAINERS=(aic-prometheus aic-node-exporter aic-amdgpu-exporter
-                aic-nvme-exporter aic-rdma-exporter aic-hsa-snoop)
-
-# True (0) if something is already listening on the given local TCP port -- used
-# to skip launching a containerized exporter when a host exporter serves it
-# already (Prometheus scrapes the host one on the same port either way).
-_port_in_use() { timeout 1 bash -c "exec 3<>/dev/tcp/127.0.0.1/$1" 2>/dev/null; }
-
-# True (0) if the /metrics endpoint on the given local port actually serves AMD
-# GPU device-metrics series (gpu_* or amd_gpu_*).  Distinguishes a real GPU
-# exporter from a stray/empty listener occupying the port (see amdgpu launch).
-_endpoint_serves_gpu() {
-    curl -fsS --max-time 2 "http://127.0.0.1:$1/metrics" 2>/dev/null | grep -qE '^(amd_)?gpu_'
-}
-
-# Like _endpoint_serves_gpu but polls a few times before giving up.  A real GPU
-# exporter (host service, or one launched by a prior run under --restart) can
-# still be warming up when we probe; without the retry it gets misclassified as a
-# phantom, spawning a redundant :5050 exporter and double-scraping GPU series.
-# $1=port  $2=tries (default 5, ~1s apart).
-_endpoint_serves_gpu_retry() {
-    local port="$1" tries="${2:-5}" i
-    for (( i = 0; i < tries; i++ )); do
-        _endpoint_serves_gpu "${port}" && return 0
-        sleep 1
-    done
+# Ensure the `docker compose` (v2) plugin is available.  Docker checks
+# $HOME/.docker/cli-plugins before the system dir, and $HOME is shared across the
+# Slurm/SPUR nodes, so a user-local install fixes every node without root.  No-op
+# when compose is already present.  Returns non-zero if it still cannot be made
+# available (callers treat that as "skip metrics", never fatal).
+: "${COMPOSE_PLUGIN_VERSION:=v2.40.0}"
+ensure_compose() {
+    have_compose && return 0
+    log "docker compose plugin missing; installing ${COMPOSE_PLUGIN_VERSION} -> ~/.docker/cli-plugins"
+    local arch; arch="$(uname -m)"
+    mkdir -p "${HOME}/.docker/cli-plugins" 2>/dev/null || return 1
+    if curl -fsSL "https://github.com/docker/compose/releases/download/${COMPOSE_PLUGIN_VERSION}/docker-compose-linux-${arch}" \
+            -o "${HOME}/.docker/cli-plugins/docker-compose" 2>/dev/null \
+       && chmod +x "${HOME}/.docker/cli-plugins/docker-compose" 2>/dev/null \
+       && have_compose; then
+        log "docker compose installed: $(docker compose version --short 2>/dev/null)"
+        return 0
+    fi
+    log "WARN: could not install docker compose (no egress?); metrics capture unavailable"
     return 1
 }
 
-# Best-effort quiet pull so a subsequent `docker run` doesn't flood the log with
-# layer-by-layer pull progress.  No-op when the image is already present (the
-# local AIC image + tarball-loaded exporters); on a bare node it pulls
-# quietly, and a pull failure is left for `docker run` to surface.
-_pull_quiet() {
-    local img="$1"
-    docker image inspect "${img}" >/dev/null 2>&1 && return 0
-    log "  pulling ${img} ..."
-    docker pull -q "${img}" >/dev/null 2>&1 || log "  ${img}: pull failed (will retry at run)"
-}
-
-# Launch one exporter container unless its port is already served on the host.
-# $1=container name  $2=port  rest=docker run flags + image + command.
-_run_exporter() {
-    local name="$1" port="$2"; shift 2
-    if _port_in_use "${port}"; then
-        log "  ${name}: :${port} already served (host exporter?), skipping container"
-        return 0
-    fi
-    docker rm -f "${name}" >/dev/null 2>&1 || true
-    docker run -d --name "${name}" "$@" >/dev/null \
-        && log "  ${name} on :${port}" \
-        || log "  ${name}: docker run failed"
-}
-
-# docker run fallback for nodes without the compose plugin (the Markham GPU
-# nodes have docker but not `docker compose`).  Mirrors the services in
-# monitoring/docker-compose.monitoring.yml: same images, host networking, ports,
-# mounts, and container names.  Containerized exporters are skipped when a host
-# exporter already serves the port (see _run_exporter).  Idempotent (rm -f first).
-_monitoring_run_up() {
-    docker rm -f "${MON_CONTAINERS[@]}" >/dev/null 2>&1 || true
-
-    # Pre-pull the registry-hosted images quietly so the docker runs below don't
-    # flood the log with pull progress (hsa-snoop uses the local AIC image
-    # and nvme/rdma are tarball-loaded, so they never pull here).
-    _pull_quiet "${AIC_PROM_IMAGE:-prom/prometheus:v2.55.1}"
-
-    # prometheus (always, our capture process -- not port-skipped): scrape
-    # localhost targets, TSDB on AIC_METRICS_DIR.
-    docker run -d --name aic-prometheus --network host --restart unless-stopped \
-        --user "$(id -u):$(id -g)" \
-        -v "${MON_DIR}/prometheus/prometheus.yml":/etc/prometheus/prometheus.yml:ro \
-        -v "${MON_DIR}/prometheus/rules":/etc/prometheus/rules:ro \
-        -v "${AIC_METRICS_DIR}":/prometheus \
-        "${AIC_PROM_IMAGE:-prom/prometheus:v2.55.1}" \
-        --config.file=/etc/prometheus/prometheus.yml \
-        --storage.tsdb.path=/prometheus \
-        --storage.tsdb.retention.time="${AIC_PROM_RETENTION:-90d}" \
-        --web.enable-lifecycle \
-        --web.listen-address=":${AIC_PROM_PORT:-9090}" >/dev/null \
-        && log "  prometheus on :${AIC_PROM_PORT:-9090}" \
-        || log "  prometheus: docker run failed"
-
+mon_profile() {  # echo the compose --profile args for the exporter fleet
     [[ "${AIC_EXPORTERS}" == "1" ]] || return 0
-
-    # Pre-pull the other registry images quietly (node-exporter only when :9100 is
-    # free, since a host node-exporter makes us skip it anyway).
-    _port_in_use 9100 || _pull_quiet "${AIC_NODE_EXPORTER_IMAGE:-quay.io/prometheus/node-exporter:v1.8.2}"
-    _pull_quiet "${AIC_AMDGPU_EXPORTER_IMAGE:-rocm/device-metrics-exporter:v1.4.2}"
-
-    # node-exporter: host CPU/mem/net + NVMe (diskstats/nvme) + RDMA (infiniband).
-    _run_exporter aic-node-exporter 9100 \
-        --network host --pid host --restart unless-stopped -v /:/host:ro,rslave \
-        "${AIC_NODE_EXPORTER_IMAGE:-quay.io/prometheus/node-exporter:v1.8.2}" \
-        --path.rootfs=/host --collector.diskstats --collector.nvme \
-        --collector.infiniband --web.listen-address=":9100"
-
-    # amdgpu-exporter: AMD device-metrics-exporter (gpu_* metrics) on :5000.
-    # A bare TCP check (_port_in_use) is NOT enough here: some nodes have an
-    # unrelated/empty listener on :5000 (e.g. a stray promhttp handler) that
-    # serves no gpu_* series, and skipping our container in favour of it leaves
-    # the GPU panels blank.  So: reuse :5000 only if it actually serves gpu_*
-    # metrics; if :5000 is busy but is a phantom, launch ours on :5050 instead
-    # (prometheus.yml scrapes both); if :5000 is free, use it.  The gpu-serve
-    # probe is retried (a real exporter on :5000 may still be warming up) so we
-    # don't spawn a redundant :5050 and double-scrape GPU series.
-    if _port_in_use 5000 && _endpoint_serves_gpu_retry 5000; then
-        log "  aic-amdgpu-exporter: real GPU exporter already on :5000, reusing"
-    else
-        local amdgpu_port=5000 amdgpu_cfg="${MON_DIR}/amdgpu-exporter/config.json"
-        if _port_in_use 5000; then
-            amdgpu_port=5050
-            amdgpu_cfg="/tmp/aic-amdgpu-config.${SLURM_JOB_ID:-$$}.json"
-            sed 's/"ServerPort":[[:space:]]*5000/"ServerPort": 5050/' \
-                "${MON_DIR}/amdgpu-exporter/config.json" > "${amdgpu_cfg}"
-            log "  aic-amdgpu-exporter: :5000 busy but not a GPU exporter (phantom); using :5050"
-        fi
-        docker rm -f aic-amdgpu-exporter >/dev/null 2>&1 || true
-        docker run -d --name aic-amdgpu-exporter \
-            --network host --restart unless-stopped --device /dev/kfd --device /dev/dri \
-            -v /sys:/sys:ro \
-            -v "${amdgpu_cfg}":/etc/metrics/config.json:ro \
-            "${AIC_AMDGPU_EXPORTER_IMAGE:-rocm/device-metrics-exporter:v1.4.2}" >/dev/null \
-            && log "  aic-amdgpu-exporter on :${amdgpu_port}" \
-            || log "  aic-amdgpu-exporter: docker run failed"
-    fi
-
-    # nvme-exporter (:9998, dedicated NVMe metrics).  No standard published image
-    # (batesste host service); set AIC_NVME_EXPORTER_IMAGE to containerize it,
-    # else rely on the host service or node-exporter's nvme/diskstats collectors.
-    if [[ -n "${AIC_NVME_EXPORTER_IMAGE:-}" ]]; then
-        # shellcheck disable=SC2086  # AIC_NVME_EXPORTER_ARGS is an intentional arg list
-        _run_exporter aic-nvme-exporter "${NVME_EXPORTER_PORT:-9998}" \
-            --network host --pid host --privileged --restart unless-stopped \
-            -v /dev:/dev -v /sys:/sys:ro \
-            "${AIC_NVME_EXPORTER_IMAGE}" ${AIC_NVME_EXPORTER_ARGS:-}
-    else
-        log "  nvme-exporter: set AIC_NVME_EXPORTER_IMAGE to containerize (else host service / node-exporter nvme collector)"
-    fi
-
-    # rdma-exporter (:9879, yuuki-style, sysfs).  Build-your-own image (no
-    # published one -- github.com/yuuki/rdma_exporter ships a Dockerfile); set
-    # AIC_RDMA_EXPORTER_IMAGE to containerize, else rely on the host service or
-    # node-exporter's infiniband collector.
-    if [[ -n "${AIC_RDMA_EXPORTER_IMAGE:-}" ]]; then
-        # shellcheck disable=SC2086  # AIC_RDMA_EXPORTER_ARGS is an intentional arg list
-        _run_exporter aic-rdma-exporter "${RDMA_EXPORTER_PORT:-9879}" \
-            --network host --restart unless-stopped -v /sys:/sys:ro \
-            "${AIC_RDMA_EXPORTER_IMAGE}" ${AIC_RDMA_EXPORTER_ARGS:-}
-    else
-        log "  rdma-exporter: set AIC_RDMA_EXPORTER_IMAGE to containerize (else host service / node-exporter infiniband collector)"
-    fi
-
-    # hsa-snoop (:9488): HSA AQL queue snooper from the AIC image (v1.0.0+).
-    # Exports both HSA dispatch metrics (hsa_*) and AIS (AMD Infinity Storage)
-    # P2P storage metrics (ais_rx_ops_total, ais_tx_bytes_total, etc.) on the
-    # same endpoint.  Installs its kprobe via tracefs at /sys/kernel/tracing --
-    # so BOTH debugfs and tracefs must be mounted; with only /sys/kernel/debug it
-    # fails with ENOENT ("failed to install kprobe").  Needs root + privileged +
-    # host PID ns to see the vLLM/LMCache GPU processes.
-    if _port_in_use "${HSA_SNOOP_PORT:-9488}"; then
-        log "  hsa-snoop: :${HSA_SNOOP_PORT:-9488} already served, skipping container"
-    else
-        docker rm -f aic-hsa-snoop >/dev/null 2>&1 || true
-        local -a _tracefs=()
-        [[ -d /sys/kernel/tracing ]] && _tracefs=(-v /sys/kernel/tracing:/sys/kernel/tracing)
-        docker run -d --name aic-hsa-snoop --network host --pid host --privileged \
-            --restart unless-stopped --device /dev/kfd --device /dev/dri \
-            -v /sys/kernel/debug:/sys/kernel/debug "${_tracefs[@]}" \
-            --entrypoint /usr/local/bin/hsa-snoop "${AIC_IMAGE}" \
-            --all --prometheus --prometheus-port "${HSA_SNOOP_PORT:-9488}" >/dev/null \
-            && log "  hsa-snoop on :${HSA_SNOOP_PORT:-9488} (HSA + AIS metrics)" \
-            || log "  hsa-snoop: docker run failed"
-    fi
+    printf -- '--profile\nexporters\n'
+    # Also enable the fabric exporters (nvme/rdma) when their images are provided
+    # (built by run-build-distribute.sh build-exporters, loaded on the node).
+    [[ -n "${AIC_NVME_EXPORTER_IMAGE:-}${AIC_RDMA_EXPORTER_IMAGE:-}" ]] \
+        && printf -- '--profile\nexporters-fabric\n'
 }
+
+# Compose service container_names -- used to sweep up any leftovers from a
+# crashed run before/after a compose up/down (compose down handles the rest).
+MON_CONTAINERS=(aic-prometheus aic-node-exporter aic-amdgpu-exporter
+                aic-nvme-exporter aic-rdma-exporter aic-hsa-snoop)
 
 start_monitoring() {
     [[ "${AIC_MONITORING}" == "1" ]] || { log "monitoring disabled (AIC_MONITORING=0)"; return 0; }
     mkdir -p "${AIC_METRICS_DIR}" 2>/dev/null || { log "monitoring: cannot create ${AIC_METRICS_DIR}, skipping"; AIC_MONITORING=0; return 0; }
+    ensure_compose || { log "monitoring: docker compose unavailable, skipping"; AIC_MONITORING=0; return 0; }
+    [[ -f "${MON_COMPOSE}" ]] || { log "monitoring: ${MON_COMPOSE} not found, skipping"; AIC_MONITORING=0; return 0; }
     log "starting metrics capture -> ${AIC_METRICS_DIR} (exporters=${AIC_EXPORTERS})"
-    if have_compose && [[ -f "${MON_COMPOSE}" ]]; then
-        local -a profile; mapfile -t profile < <(mon_profile)
-        AIC_METRICS_DIR="${AIC_METRICS_DIR}" PROM_UID="$(id -u)" PROM_GID="$(id -g)" \
-            IMAGE_NAME="${AIC_IMAGE}" \
-            docker compose -f "${MON_COMPOSE}" "${profile[@]}" up -d \
-            || log "monitoring: compose up failed (continuing without metrics)"
-    else
-        # No compose plugin on this node -> equivalent docker-run sidecar.
-        log "monitoring: 'docker compose' unavailable; using docker run sidecar"
-        _monitoring_run_up
-    fi
+    local -a profile; mapfile -t profile < <(mon_profile)
+    AIC_METRICS_DIR="${AIC_METRICS_DIR}" PROM_UID="$(id -u)" PROM_GID="$(id -g)" \
+        IMAGE_NAME="${AIC_IMAGE}" \
+        docker compose -f "${MON_COMPOSE}" "${profile[@]}" up -d \
+        || log "monitoring: compose up failed (continuing without metrics)"
 }
 
 stop_monitoring() {
     [[ "${AIC_MONITORING}" == "1" ]] || return 0
     log "stopping metrics capture (TSDB retained at ${AIC_METRICS_DIR})"
-    # Compose down when available; then rm any docker-run containers (same names).
     if have_compose && [[ -f "${MON_COMPOSE}" ]]; then
         local -a profile; mapfile -t profile < <(mon_profile)
         AIC_METRICS_DIR="${AIC_METRICS_DIR}" IMAGE_NAME="${AIC_IMAGE}" \
@@ -268,14 +121,11 @@ _check_endpoint() {
 }
 
 # Probe every exporter's /metrics endpoint.  Informational only (the caller
-# decides whether to act on the result); the amdgpu exporter is retried on :5050
-# to match _monitoring_run_up's phantom-:5000 fallback.
+# decides whether to act on the result).
 monitoring_healthcheck() {
     log "exporter health check (/metrics):"
     _check_endpoint node-exporter   9100                           '^node_'       || true
-    if ! _check_endpoint amdgpu-exporter 5000 '^(amd_)?gpu_'; then
-        _check_endpoint amdgpu-exporter 5050 '^(amd_)?gpu_' || true
-    fi
+    _check_endpoint amdgpu-exporter 5000                           '^(amd_)?gpu_' || true
     _check_endpoint nvme-exporter   "${NVME_EXPORTER_PORT:-9998}"  '^nvme_'       || true
     _check_endpoint rdma-exporter   "${RDMA_EXPORTER_PORT:-9879}"  '^rdma_'       || true
     _check_endpoint hsa-snoop       "${HSA_SNOOP_PORT:-9488}"      '^hsa_\|^ais_' || true

--- a/monitoring/prometheus/rules/aic.yml
+++ b/monitoring/prometheus/rules/aic.yml
@@ -7,6 +7,49 @@
 # from different exporters can be correlated when exploring the captured TSDB.
 
 groups:
+  - name: aic_lmcache_mp
+    interval: 15s
+    rules:
+      # LMCache MP-mode L1/L2 hit rates (chunk-based).
+      # Counters are emitted by the server's OTel event-bus subscribers
+      # (L1MetricsSubscriber, L2MetricsSubscriber, LookupMetricsSubscriber)
+      # and scraped from localhost:8080/metrics (job: lmcache).
+
+      # L1 hit rate: fraction of looked-up chunks served from L1 DRAM.
+      # Denominator is l2_prefetch_lookup_objects (chunks that missed L1 and
+      # went to L2) + l1_read (chunks served directly from L1).
+      # Actual metric names (verified from live scrape):
+      #   lmcache_mp_l1_read_chunks_total
+      #   lmcache_mp_l2_prefetch_hit_chunks_total
+      #   lmcache_mp_l2_prefetch_lookup_objects_chunks_total
+      #   lmcache_mp_lookup_hit_tokens_total    {model_name, cache_salt}
+      #   lmcache_mp_lookup_requested_tokens_total {model_name, cache_salt}
+
+      - record: aic:lmcache_mp:l1_hit_rate
+        expr: |
+          rate(lmcache_mp_l1_read_chunks_total[1m])
+          /
+          clamp_min(
+            rate(lmcache_mp_l1_read_chunks_total[1m])
+            + rate(lmcache_mp_l2_prefetch_lookup_objects_chunks_total[1m]),
+            1e-9
+          )
+
+      # L2 hit rate: fraction of L2-prefetch lookups that found a result.
+      - record: aic:lmcache_mp:l2_hit_rate
+        expr: |
+          rate(lmcache_mp_l2_prefetch_hit_chunks_total[1m])
+          /
+          clamp_min(rate(lmcache_mp_l2_prefetch_lookup_objects_chunks_total[1m]), 1e-9)
+
+      # Combined L1+L2 token hit rate (labeled by model_name, cache_salt).
+      # Uses the token-granularity counters from LookupMetricsSubscriber.
+      - record: aic:lmcache_mp:combined_hit_rate
+        expr: |
+          rate(lmcache_mp_lookup_hit_tokens_total[1m])
+          /
+          clamp_min(rate(lmcache_mp_lookup_requested_tokens_total[1m]), 1e-9)
+
   - name: aic_join
     interval: 30s
     rules:

--- a/patches/lmcache/07-lmcache-nixl-ais-mt-l2-adapter.patch
+++ b/patches/lmcache/07-lmcache-nixl-ais-mt-l2-adapter.patch
@@ -1,8 +1,8 @@
 diff --git a/lmcache/v1/distributed/l2_adapters/nixl_store_l2_adapter.py b/lmcache/v1/distributed/l2_adapters/nixl_store_l2_adapter.py
-index 41a54be3..6bcde845 100644
+index 41a54be..aa336df 100644
 --- a/lmcache/v1/distributed/l2_adapters/nixl_store_l2_adapter.py
 +++ b/lmcache/v1/distributed/l2_adapters/nixl_store_l2_adapter.py
-@@ -170,30 +170,37 @@ class NixlStorageAgent:
+@@ -170,30 +170,58 @@ class NixlStorageAgent:
          self.device = device
          self.backend_params = backend_params
  
@@ -14,6 +14,27 @@ index 41a54be3..6bcde845 100644
 +            self.l1_align_bytes = l1_memory_desc.align_bytes
 +        else:
 +            self.l1_align_bytes = int(backend_params["file_size"])
++
++        # Guard: file_size must cover at least one L1 chunk page (l1_align_bytes).
++        # A smaller slot silently truncates stored KV chunks -- the NIXL transfer
++        # API succeeds but only writes file_size bytes of an l1_align_bytes-sized
++        # chunk. Subsequent lookups return miss (or load corrupt data), causing
++        # l2_prefetch_hit_chunks_total to stay at 0 with no error logged.
++        if self.backend in _FILE_BACKENDS:
++            _file_size = int(
++                self.backend_params.get("file_size", self.l1_align_bytes)
++            )
++            if _file_size < self.l1_align_bytes:
++                raise ValueError(
++                    f"nixl_store backend {self.backend!r}: file_size "
++                    f"({_file_size:,} bytes) is smaller than the L1 chunk "
++                    f"page size ({self.l1_align_bytes:,} bytes). Each pool "
++                    f"slot must hold at least one full chunk page. Set "
++                    f"file_size >= {self.l1_align_bytes} in backend_params. "
++                    f"For a typical MP-mode deployment, file_size should "
++                    f"equal the full KV chunk size in bytes (e.g. 8388608 "
++                    f"for a 7B fp8 model with chunk_size=256)."
++                )
  
          self.agent_name = "NixlAgent_" + str(uuid.uuid4())
          nixl_conf = NixlAgentConfig(backends=[])
@@ -52,7 +73,7 @@ index 41a54be3..6bcde845 100644
                  file_size=file_size,
                  file_path=self.backend_params["file_path"],
                  # TODO(Jiayi): Need to make argument parsing more elegant
-@@ -203,7 +210,7 @@ class NixlStorageAgent:
+@@ -203,7 +231,7 @@ class NixlStorageAgent:
          elif self.backend in ["OBJ", "AZURE_BLOB"]:
              self.pool = NixlObjPool(num_total_objs=self.pool_size)
              self.init_storage_handlers_object(
@@ -61,7 +82,7 @@ index 41a54be3..6bcde845 100644
                  num_pages=self.pool_size,
              )
          else:
-@@ -443,8 +450,13 @@ class NixlStoreL2Adapter(L2AdapterInterface):
+@@ -443,8 +471,13 @@ class NixlStoreL2Adapter(L2AdapterInterface):
              pool_size=config.pool_size,
              l1_memory_desc=l1_memory_desc,
          )
@@ -76,7 +97,7 @@ index 41a54be3..6bcde845 100644
          )
          super().__init__(max_capacity_bytes=max_capacity_bytes)
          self._config = config
-@@ -905,11 +917,12 @@ _VALID_NIXL_BACKENDS = (
+@@ -905,11 +938,12 @@ _VALID_NIXL_BACKENDS = (
      "GDS",
      "GDS_MT",
      "POSIX",
@@ -90,7 +111,26 @@ index 41a54be3..6bcde845 100644
  
  
  class NixlStoreL2AdapterConfig(L2AdapterConfigBase):
-@@ -1004,7 +1017,12 @@ def _create_nixl_store_adapter(
+@@ -948,6 +982,18 @@ class NixlStoreL2AdapterConfig(L2AdapterConfigBase):
+                     "'use_direct_io' for file-based "
+                     "backend %r" % backend
+                 )
++            if "file_size" not in backend_params:
++                logger.warning(
++                    "nixl_store backend %r: 'file_size' not set in "
++                    "backend_params. The slot size will default to "
++                    "l1_align_bytes (typically 4096 bytes). This is almost "
++                    "certainly wrong for MP-mode deployments where a single "
++                    "KV chunk can be several MiB -- stores will silently "
++                    "truncate and lookups will return miss. Set file_size to "
++                    "at least the KV chunk size in bytes. Example: 8388608 "
++                    "(8 MiB) for a 7B fp8 model with chunk_size=256.",
++                    backend,
++                )
+         self.backend = backend
+         self.backend_params = backend_params
+         self.pool_size = pool_size
+@@ -1004,7 +1050,12 @@ def _create_nixl_store_adapter(
  ) -> L2AdapterInterface:
      """Create a NixlStoreL2Adapter from config."""
      if l1_memory_desc is None:


### PR DESCRIPTION
patches/lmcache: add patch 08 — nixl_store file_size validation

NixlStoreL2AdapterConfig silently accepted a missing file_size in backend_params and fell back to l1_align_bytes (default 4 KiB). For large models (e.g. 7B fp8, ~7 MiB/chunk) this caused every NIXL store to truncate KV chunks to 4 KiB — the NIXL transfer API returned success because it transferred exactly what it was given. Subsequent L2 lookups returned miss, keeping lmcache_mp_l2_prefetch_hit_chunks_total at 0 across an entire benchmark run with no warning or error emitted.

Discovered during gfx1201 lmcache_driven testing with Qwen2.5-7B-Instruct: 18 k+ chunks stored, 19 k+ L2 lookups fired, 0 L2 hits — until LMCACHE_NVME_SLOT_SIZE=8388608 was set and the pool wiped and recreated.

The patch adds two guards in nixl_store_l2_adapter.py:

1. NixlStoreL2AdapterConfig.__init__(): WARNING at server startup when file_size is absent for a file-based backend (POSIX, GDS, AIS_MT, etc.), before any I/O. Operator sees the message and can correct the config without running a full benchmark.

2. NixlStorageAgent.__init__(): ValueError at adapter construction once l1_align_bytes is resolved from the L1 memory descriptor. Raises if effective file_size < l1_align_bytes — a slot smaller than one chunk page can never store a complete chunk, so a hard startup failure is better than silent L2 corruption.

Candidate for upstream submission to LMCache/LMCache.



gfx1201: lmcache_driven stack + L1/L2 Prometheus recording rules

Adds support for running the lmcache MP stack on consumer RDNA4 GPUs (gfx1201 / RX 9070 XT) where ROCm inter-process GPU IPC is unavailable.

 ## docker/docker-compose.gfx1201.yml (new)

Standalone compose file for gfx1201. Key differences from the MI300X docker-compose.yml:

- Host networking: both services bind to the host network stack; no container DNS or bridge network required.
- lmcache_driven transfer mode: passes --supported-transfer-mode lmcache_driven to the server and lmcache.mp.mp_transfer_mode= lmcache_driven in the connector extra config. Bypasses CUDA IPC handle sharing (unavailable on consumer RDNA4) in favour of CPU DRAM staging via ZMQ.
- POSIX NVMe L2 with configurable slot size: file_size is now passed explicitly via LMCACHE_NVME_SLOT_SIZE (default 256 MiB from Makefile). This avoids silent L2 truncation when the NIXL slot is smaller than a KV chunk — the root cause of zero L2 hits observed during 7B testing (patch 08 in patches/lmcache/ adds the lmcache-side validation).
- VLLM_QUANTIZATION optional env var: adds ${VLLM_QUANTIZATION:+...} expansion so --quantization fp8 can be passed for 7B models that would otherwise not fit in 16 GiB VRAM.
- Removed: IPC_LOCK cap, hipFile kernel volume mounts (/lib/modules, /usr/src, debugfs), aic-net bridge, GDS/AIS_MT L2 adapters.
- Added: /dev/shm bind-mount for ZMQ shared-memory transport.

 ## Makefile

- COMPOSE_GFX1201 variable pointing at docker-compose.gfx1201.yml
- make up-gfx1201 / up-gfx1201-batch / down-gfx1201 targets
- Help text entries for the three new targets

 ## monitoring/prometheus/rules/aic.yml

New aic_lmcache_mp rule group (15s interval) with three recording rules derived from counter names verified against a live lmcache v0.5.1 scrape:

- aic:lmcache_mp:l1_hit_rate   — chunk-level L1 DRAM hit rate
- aic:lmcache_mp:l2_hit_rate   — L2 prefetch hit rate (NVMe/NFS)
- aic:lmcache_mp:combined_hit_rate — L1+L2 token-level hit rate
  (labeled by model_name and cache_salt)

 ## New top-level files (untracked, not staged)

- prometheus-metrics.md: complete reference for all vLLM (:8000) and lmcache MP (:8080) Prometheus metrics with types, labels, descriptions, and key PromQL recipes.
- lmcache-mp-metrics.md: lmcache-specific metric catalogue (subset).
- patches/lmcache/08-lmcache-nixl-file-size-validation.patch: upstream candidate adding a startup WARNING and hard ValueError when file_size is absent or smaller than l1_align_bytes for file-based NIXL backends.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
