### PR TITLE
feat: enable cross-container HIP IPC for LMCache

### DIFF
--- a/.slurm/run-build-distribute.sh
+++ b/.slurm/run-build-distribute.sh
@@ -1028,7 +1028,7 @@ export VLM_MAX_NUM_BATCHED_TOKENS=4096
 export VLM_ATTENTION_BACKEND=TRITON_ATTN
 export VLM_KV_CACHE_DTYPE=auto
 export LMCACHE_L1_SIZE_GB=4
-export KV_TRANSFER_ARG="--kv-transfer-config '{\"kv_connector\":\"LMCacheMPConnector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"lmcache.mp.host\":\"tcp://lmcache\",\"lmcache.mp.port\":6555}}'"
+export KV_TRANSFER_ARG="--kv-transfer-config '{\"kv_connector\":\"LMCacheMPConnector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"lmcache.mp.host\":\"tcp://127.0.0.1\",\"lmcache.mp.port\":6555}}'"
 mkdir -p "\${HF_HOME}" /tmp/aic-tiny-nvme /tmp/aic-tiny-nfs
 
 compose() { docker compose -f '${AIC_DAY_DIR}/docker/docker-compose.yml' "\$@"; }

--- a/.slurm/run-cliff.sbatch
+++ b/.slurm/run-cliff.sbatch
@@ -647,7 +647,7 @@ run_arm_kvd() {  # $1=mode(nvme|gds) $2=out_csv
     # MP connector arg for vLLM (+ optional kv_load_failure_policy).  Single-quote
     # the JSON so compose's shlex splitting preserves the inner double quotes.
     local _fp=""; [[ -n "${AIC_KV_LOAD_FAILURE_POLICY}" ]] && _fp=",\"kv_load_failure_policy\":\"${AIC_KV_LOAD_FAILURE_POLICY}\""
-    export KV_TRANSFER_ARG="--kv-transfer-config '{\"kv_connector\":\"LMCacheMPConnector\",\"kv_role\":\"kv_both\"${_fp},\"kv_connector_extra_config\":{\"lmcache.mp.host\":\"tcp://lmcache\",\"lmcache.mp.port\":${LMCACHE_PORT}}}'"
+    export KV_TRANSFER_ARG="--kv-transfer-config '{\"kv_connector\":\"LMCacheMPConnector\",\"kv_role\":\"kv_both\"${_fp},\"kv_connector_extra_config\":{\"lmcache.mp.host\":\"tcp://127.0.0.1\",\"lmcache.mp.port\":${LMCACHE_PORT}}}'"
 
     local _l2desc
     if [[ "${mode}" == "gds" ]]; then

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ LMCACHE_L1_SIZE_GB     ?= 20
 LMCACHE_NVME_POOL      ?= 4096
 LMCACHE_NVME_SLOT_SIZE ?= 268435456
 LMCACHE_NFS_POOL       ?= 1024
+LMCACHE_NFS_SLOT_SIZE  ?= 268435456
 
 # ---- vLLM knobs ------------------------------------------------------------
 VLLM_MODEL                  ?=
@@ -57,7 +58,7 @@ _ROCM_ARCH_DETECTED := $(shell rocm_agent_enumerator 2>/dev/null | grep -E '^gfx
 ROCM_ARCH := $(if $(strip $(ROCM_ARCH)),$(strip $(ROCM_ARCH)),$(_ROCM_ARCH_DETECTED))
 
 export ROCM_ARCH GPU GDS_SLAB_DATA LOG HF_HOME IMAGE_NAME
-export LMCACHE_PORT LMCACHE_L1_SIZE_GB LMCACHE_NVME_POOL LMCACHE_NVME_SLOT_SIZE LMCACHE_NFS_POOL
+export LMCACHE_PORT LMCACHE_L1_SIZE_GB LMCACHE_NVME_POOL LMCACHE_NVME_SLOT_SIZE LMCACHE_NFS_POOL LMCACHE_NFS_SLOT_SIZE
 export NVME_DATA NFS_DATA
 export VLLM_MODEL TENSOR_PARALLEL_SIZE
 export VLM_GPU_MEMORY_UTILIZATION VLM_MAX_MODEL_LEN VLM_MAX_NUM_BATCHED_TOKENS
@@ -80,7 +81,7 @@ COMPOSE_PLUGIN_VERSION ?= v2.40.0
 # vLLM --kv-transfer-config for the MP connector (interactive `make up`).  The JSON
 # is wrapped in single quotes so compose's shlex splitting preserves the inner
 # double quotes; leave KV_TRANSFER_ARG empty for a plain (baseline) vLLM.
-_MP_CONNECTOR_JSON := {"kv_connector":"LMCacheMPConnector","kv_role":"kv_both","kv_connector_extra_config":{"lmcache.mp.host":"tcp://lmcache","lmcache.mp.port":$(LMCACHE_PORT)}}
+_MP_CONNECTOR_JSON := {"kv_connector":"LMCacheMPConnector","kv_role":"kv_both","kv_connector_extra_config":{"lmcache.mp.host":"tcp://127.0.0.1","lmcache.mp.port":$(LMCACHE_PORT)}}
 KV_TRANSFER_ARG    ?= --kv-transfer-config '$(_MP_CONNECTOR_JSON)'
 export KV_TRANSFER_ARG
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,8 +17,15 @@
 #   vllm    — vllm serve, optionally with LMCacheMPConnector
 #               KV_TRANSFER_ARG selects the connector.  Set it to the
 #               LMCacheMPConnector JSON (default via `make up`) to connect to the
-#               lmcache service over ZMQ, or leave it EMPTY for a plain
+#               same-host lmcache service over ZMQ, or leave it EMPTY for a plain
 #               VRAM-prefix-cache-only vLLM (the cliff `vram` baseline arm).
+#
+# HIP IPC between the vLLM and LMCache containers requires both services to use
+# the host network and host PID namespace in this cross-container topology.  With
+# host networking there is no Compose DNS name for lmcache and no port publishing:
+# vLLM connects to
+# tcp://127.0.0.1:${LMCACHE_PORT:-6555}, while the service ports bind directly on
+# the host (vLLM 8000, LMCache HTTP 8080, NIXL metrics 19090).
 #
 # This one compose file is the single source of truth for every launch path:
 #   make up / up-gds-l1                — interactive MP stack
@@ -51,7 +58,10 @@
 #   LMCACHE_NVME_POOL      — nixl pool slots for NVMe adapter (default: 4096)
 #   LMCACHE_NVME_SLOT_SIZE — nixl file size per slot in bytes (default: 256 MiB)
 #   LMCACHE_NFS_POOL       — nixl pool slots for NFS adapter (default: 1024)
+#   LMCACHE_NFS_SLOT_SIZE  — nixl file size per NFS slot in bytes (default: 256 MiB)
+#   AIC_NIXL_NVME_BACKEND  — NIXL backend for NVME_DATA: AIS_MT (default) or POSIX
 #   AIC_NIXL_USE_DIRECT_IO — O_DIRECT for the AIS_MT NVMe L2 (default: true)
+#   HIPFILE_ALLOW_COMPAT_MODE — allow hipFile fallback when P2PDMA registration fails (default: false)
 #   VLM_GPU_MEMORY_UTILIZATION — vllm --gpu-memory-utilization (default: 0.90)
 #   VLM_MAX_MODEL_LEN          — vllm --max-model-len (default: 32768)
 #   VLM_MAX_NUM_BATCHED_TOKENS — vllm --max-num-batched-tokens (default: 4096)
@@ -81,11 +91,11 @@ services:
         ROCM_ARCH: ${ROCM_ARCH}
     image: ${IMAGE_NAME:-rocm-aic}
     container_name: aic-lmcache
-    ports:
-      - "8080:8080"   # lmcache HTTP API + /metrics
-      - "${NIXL_METRICS_PORT:-19090}:${NIXL_METRICS_PORT:-19090}"   # NIXL telemetry /metrics
-    networks:
-      - aic-net
+    # LMCache imports vLLM's HIP IPC memory handles and exports synchronization
+    # event handles in the reverse direction.  Use the host namespaces on both
+    # services so either process can be the HIP IPC producer.
+    network_mode: host
+    pid: host
     ipc: host
     cap_add:
       - CAP_SYS_ADMIN
@@ -131,10 +141,12 @@ services:
       - LMCACHE_NVME_POOL=${LMCACHE_NVME_POOL:-4096}
       - LMCACHE_NVME_SLOT_SIZE=${LMCACHE_NVME_SLOT_SIZE:-268435456}
       - LMCACHE_NFS_POOL=${LMCACHE_NFS_POOL:-1024}
+      - LMCACHE_NFS_SLOT_SIZE=${LMCACHE_NFS_SLOT_SIZE:-268435456}
+      - AIC_NIXL_NVME_BACKEND=${AIC_NIXL_NVME_BACKEND:-AIS_MT}
       - AIC_NIXL_USE_DIRECT_IO=${AIC_NIXL_USE_DIRECT_IO:-true}
       # Only set when a real config file is mounted (local_disk / advanced tuning).
       - LMCACHE_CONFIG_FILE=${LMCACHE_CONFIG_FILE:-}
-      - HIPFILE_ALLOW_COMPAT_MODE=false
+      - HIPFILE_ALLOW_COMPAT_MODE=${HIPFILE_ALLOW_COMPAT_MODE:-false}
       - HIPFILE_UNSUPPORTED_FILE_SYSTEMS=true
       # NIXL native Prometheus telemetry exporter (serves /metrics on :19090).
       # Requires the prometheus-cpp plugin compiled into the image (build-nixl.sh);
@@ -171,8 +183,8 @@ services:
             --port "$$LMCACHE_PORT" \
             --l1-size-gb "$$LMCACHE_L1_SIZE_GB" \
             --eviction-policy LRU \
-            --l2-adapter "{\"type\":\"nixl_store\",\"backend\":\"AIS_MT\",\"backend_params\":{\"file_path\":\"/data/nvme/lmcache\",\"use_direct_io\":\"$$AIC_NIXL_USE_DIRECT_IO\",\"file_size\":$$LMCACHE_NVME_SLOT_SIZE},\"pool_size\":$$LMCACHE_NVME_POOL}" \
-            --l2-adapter "{\"type\":\"nixl_store\",\"backend\":\"POSIX\",\"backend_params\":{\"file_path\":\"/data/nfs/lmcache\"},\"pool_size\":$$LMCACHE_NFS_POOL}"
+            --l2-adapter "{\"type\":\"nixl_store\",\"backend\":\"$$AIC_NIXL_NVME_BACKEND\",\"backend_params\":{\"file_path\":\"/data/nvme/lmcache\",\"use_direct_io\":\"$$AIC_NIXL_USE_DIRECT_IO\",\"file_size\":\"$$LMCACHE_NVME_SLOT_SIZE\"},\"pool_size\":$$LMCACHE_NVME_POOL}" \
+            --l2-adapter "{\"type\":\"nixl_store\",\"backend\":\"POSIX\",\"backend_params\":{\"file_path\":\"/data/nfs/lmcache\",\"use_direct_io\":\"false\",\"file_size\":\"$$LMCACHE_NFS_SLOT_SIZE\"},\"pool_size\":$$LMCACHE_NFS_POOL}"
         fi
     healthcheck:
       test:
@@ -191,10 +203,11 @@ services:
   vllm:
     image: ${IMAGE_NAME:-rocm-aic}
     container_name: aic-vllm-gpu${GPU:-0}
-    ports:
-      - "8000:8000"   # vLLM OpenAI API + /metrics
-    networks:
-      - aic-net
+    # vLLM owns and exports the KV-cache GPU allocations consumed by LMCache.
+    # Host networking + host PID visibility are required for cross-container
+    # HIP IPC; the API binds directly to host port 8000.
+    network_mode: host
+    pid: host
     ipc: host
     cap_add:
       - CAP_SYS_ADMIN
@@ -252,7 +265,3 @@ services:
         # required:false lets the plain baseline run `vllm` alone (lmcache not in
         # the active profile) without a dependency error (needs Compose v2.20+).
         required: false
-
-networks:
-  aic-net:
-    driver: bridge

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -15,6 +15,9 @@
 | `LMCACHE_NVME_POOL` | `4096` | NIXL pool slots for NVMe adapter |
 | `LMCACHE_NVME_SLOT_SIZE` | `268435456` | NIXL file size per NVMe pool slot, bytes (256 MiB) |
 | `LMCACHE_NFS_POOL` | `1024` | NIXL pool slots for NFS adapter |
+| `LMCACHE_NFS_SLOT_SIZE` | `268435456` | NIXL file size per POSIX/NFS pool slot, bytes (256 MiB); must cover the largest serialized KV chunk |
+| `AIC_NIXL_NVME_BACKEND` | `AIS_MT` | NIXL backend for `NVME_DATA`; use `POSIX` for ordinary filesystems such as `/tmp` that do not support hipFile P2PDMA |
+| `HIPFILE_ALLOW_COMPAT_MODE` | `false` | Allow hipFile fallback when P2PDMA buffer registration is unavailable; this may permit initialization but does not guarantee writes on unsupported filesystems |
 | `VLM_ATTENTION_BACKEND` | `TRITON_ATTN` | vLLM `--attention-backend` (TRITON_ATTN supports KV connectors) |
 | `VLM_KV_CACHE_DTYPE` | `fp8` | vLLM `--kv-cache-dtype` (`auto` for non-fp8 arches) |
 | `VLLM_EXTRA_ARGS` | — | Extra vLLM args appended verbatim (e.g. `--hf-overrides '{...}'`; single-quote embedded JSON) |


### PR DESCRIPTION
## Motivation

Place vLLM and LMCache in the host IPC, PID, and network namespaces so GPU memory and synchronization handles remain usable across container boundaries. Configure the namespaces symmetrically because either service can act as a HIP IPC producer.

## Technical Details

Why all three host namespaces are required
- vLLM exports KV-cache allocations for LMCache to import, while LMCache may export synchronization event handles in the reverse direction. The peers need a common view of the processes and IPC resources behind those handles.
- With only `ipc: host`, the standalone reproducer failed handle import with hipErrorInvalidContext (201).
- Adding `pid: host` while retaining the Compose bridge network progressed further. Handle import then failed with hipErrorInvalidDevicePointer (17).
- Sharing the host network in addition to PID and IPC namespaces allowed the HIP IPC producer-consumer round trip to complete.

Host-network consequences
- Remove Compose port publishing and the bridge network because the services now bind their vLLM, LMCache HTTP, ZMQ, and NIXL ports directly on the host.
- Point LMCacheMPConnector at 127.0.0.1 because Compose DNS service names are not available in host network mode.

L2 backend compatibility
- Stringify NIXL backend parameters and explicitly configure direct I/O and NFS slot sizes as required by the current LMCache and NIXL bindings.
- Make the local NIXL backend and hipFile compatibility mode configurable. This permits a POSIX fallback for filesystems such as `/tmp` that do not support the P2PDMA path required by AIS_MT.

## Test Plan

Tested docker compose invocations to validate cross-container vllm/lmcache GPU memory registration and sharing.

## Test Result

Success.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
