### PR TITLE
fix(docker): add flag to limit number of concurrent compile processes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,10 +57,7 @@ _ROCM_ARCH_DETECTED := $(shell rocm_agent_enumerator 2>/dev/null | grep -E '^gfx
 ROCM_ARCH := $(if $(strip $(ROCM_ARCH)),$(strip $(ROCM_ARCH)),$(_ROCM_ARCH_DETECTED))
 
 # ---- Build parallelism -----------------------------------------------------
-# Caps parallel compile jobs in the image build (passed through to the
-# Dockerfile BUILD_JOBS arg).  Empty = use all cores ($(nproc) inside the
-# build).  Lower it on high-core / low-RAM hosts where nproc-wide cc1plus
-# fan-out OOMs (issue #89), e.g. `make build BUILD_JOBS=3`.
+# Caps parallel compile jobs in the image build, Empty = use all cores ($(nproc)).
 BUILD_JOBS ?=
 
 export ROCM_ARCH GPU GDS_SLAB_DATA LOG HF_HOME IMAGE_NAME BUILD_JOBS
@@ -233,6 +230,7 @@ help:
 	@echo "  TLS_CERT       Path to corporate CA cert (e.g. Zscaler); passed as a"
 	@echo "                 BuildKit secret — never baked into the image."
 	@echo "                 Example: make build TLS_CERT=/etc/ssl/certs/zscaler-ca.crt"
+	@echo "  BUILD_JOBS     Cap parallel compile jobs (default: all cores)."
 	@echo ""
 	@echo "Key storage vars (current):"
 	@echo "  NVME_DATA=$(NVME_DATA)  NFS_DATA=$(NFS_DATA)  GDS_SLAB_DATA=$(GDS_SLAB_DATA)"
@@ -243,6 +241,7 @@ help:
 	@echo ""
 	@echo "Examples:"
 	@echo "  make build"
+	@echo "  make build BUILD_JOBS=3          # cap parallelism on low-RAM hosts"
 	@echo "  make up HF_TOKEN=hf_... NVME_DATA=/mnt/nvme NFS_DATA=/mnt/nfs"
 	@echo "  make up-gds-l1 GDS_SLAB_DATA=/mnt/nvme HF_TOKEN=hf_..."
 	@echo "  make cliff BENCH_ARM=vram_only BENCH_ENDPOINT=http://localhost:8000"

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,14 @@ BENCH_OUT         := $(BENCH_LOGDIR)/results/cliff-$(BENCH_ARM)-$(shell date +%Y
 _ROCM_ARCH_DETECTED := $(shell rocm_agent_enumerator 2>/dev/null | grep -E '^gfx' | head -1)
 ROCM_ARCH := $(if $(strip $(ROCM_ARCH)),$(strip $(ROCM_ARCH)),$(_ROCM_ARCH_DETECTED))
 
-export ROCM_ARCH GPU GDS_SLAB_DATA LOG HF_HOME IMAGE_NAME
+# ---- Build parallelism -----------------------------------------------------
+# Caps parallel compile jobs in the image build (passed through to the
+# Dockerfile BUILD_JOBS arg).  Empty = use all cores ($(nproc) inside the
+# build).  Lower it on high-core / low-RAM hosts where nproc-wide cc1plus
+# fan-out OOMs (issue #89), e.g. `make build BUILD_JOBS=3`.
+BUILD_JOBS ?=
+
+export ROCM_ARCH GPU GDS_SLAB_DATA LOG HF_HOME IMAGE_NAME BUILD_JOBS
 export LMCACHE_PORT LMCACHE_L1_SIZE_GB LMCACHE_NVME_POOL LMCACHE_NVME_SLOT_SIZE LMCACHE_NFS_POOL
 export NVME_DATA NFS_DATA
 export VLLM_MODEL TENSOR_PARALLEL_SIZE

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -55,6 +55,10 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROCM_ARCH
 RUN test -n "$ROCM_ARCH" || (echo "ERROR: ROCM_ARCH is not set" && exit 1)
 
+# Parallel compile jobs for the C++/HIP source builds below (LMCache, hipFile,
+# hsa-snoop). Defaults to $(nproc).
+ARG BUILD_JOBS=
+
 # vLLM wheel version on wheels.vllm.ai.  rocm723 = ROCm 7.2.3, Python 3.12 --
 # the only ROCm variant published for 0.25.0 (ABI-compatible with the 7.2.4 base).
 # Check https://wheels.vllm.ai/rocm/<version>/ for the variant tag on version bumps.
@@ -215,8 +219,8 @@ RUN --mount=type=cache,target=/root/.cache/pip \
         CXX=hipcc \
         BUILD_WITH_HIP=1 \
         ROCM_TARGET_LST=/etc/rocm_target.lst \
-        MAX_JOBS="$(nproc)" \
-        CMAKE_BUILD_PARALLEL_LEVEL="$(nproc)" \
+        MAX_JOBS="${BUILD_JOBS:-$(nproc)}" \
+        CMAKE_BUILD_PARALLEL_LEVEL="${BUILD_JOBS:-$(nproc)}" \
         python3 -m pip wheel --no-build-isolation --no-deps -w /wheels . && \
     uv pip install --system --no-cache /wheels/lmcache-*.whl
 
@@ -243,7 +247,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
           -DBUILD_TESTING=OFF \
           -DGPU_TARGETS="${ROCM_ARCH}" \
           -DCMAKE_HIP_ARCHITECTURES="${ROCM_ARCH}" .. && \
-    cmake --build . -j"$(nproc)" && \
+    cmake --build . -j"${BUILD_JOBS:-$(nproc)}" && \
     cpack -G DEB && \
     dpkg -i hipfile*deb && \
     cd ../python && \
@@ -286,6 +290,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
         AIS_PATH=/opt/rocm ROCM_PATH=/opt/rocm \
         NIXL_INSTALL_PREFIX=/opt/nixl \
         NIXL_BUILD_WHEEL=1 NIXL_WHEEL_DIR=/wheels \
+        BUILD_JOBS="${BUILD_JOBS}" \
         UV_SYSTEM_CERTS=1 \
         /tmp/nixl-scripts/build-nixl.sh
 
@@ -308,7 +313,7 @@ RUN git clone --depth 1 --branch "${HSA_SNOOP_REF}" "${HSA_SNOOP_GIT_URL}" /app/
     cmake -S /app/hsa-snoop -B /app/hsa-snoop/build -G Ninja \
         -DCMAKE_BUILD_TYPE=Release -DHSA_SNOOP_PROMETHEUS=ON \
         -DCMAKE_DISABLE_FIND_PACKAGE_hip=ON && \
-    cmake --build /app/hsa-snoop/build --parallel "$(nproc)" && \
+    cmake --build /app/hsa-snoop/build --parallel "${BUILD_JOBS:-$(nproc)}" && \
     cmake --install /app/hsa-snoop/build --prefix /usr/local && \
     test -x /usr/local/bin/hsa-snoop && \
     { /usr/local/bin/hsa-snoop --help 2>&1 || true; } | grep -q -- '--prometheus' \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -240,6 +240,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     cd projects/hipfile && \
     mkdir -p build && cd build && \
     cmake -DCMAKE_HIP_PLATFORM=amd -DAIS_INSTALL_TOOLS=ON \
+          -DBUILD_TESTING=OFF \
           -DGPU_TARGETS="${ROCM_ARCH}" \
           -DCMAKE_HIP_ARCHITECTURES="${ROCM_ARCH}" .. && \
     cmake --build . -j"$(nproc)" && \

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -55,6 +55,7 @@ services:
       dockerfile: docker/Dockerfile
       args:
         ROCM_ARCH: ${ROCM_ARCH}
+        BUILD_JOBS: ${BUILD_JOBS:-}
     image: ${IMAGE_NAME:-rocm-aic}
     container_name: aic-lmcache
     ports:

--- a/docker/scripts/build-nixl.sh
+++ b/docker/scripts/build-nixl.sh
@@ -15,6 +15,8 @@ ROCM_PATH="${ROCM_PATH:-/opt/rocm}"
 AIS_PATH="${AIS_PATH:-${ROCM_PATH}}"
 NIXL_INSTALL_PREFIX="${NIXL_INSTALL_PREFIX:-/opt/nixl}"
 
+BUILD_JOBS="${BUILD_JOBS:-$(nproc)}"
+
 if [[ ! -f "${NIXL_SRC}/meson.build" ]]; then
 	echo "ERROR: ${NIXL_SRC}/meson.build not found" >&2
 	exit 1
@@ -72,7 +74,7 @@ cd build
 	--with-verbs \
 	--with-dm \
 	--enable-mt
-make -j"$(nproc)"
+make -j"${BUILD_JOBS}"
 make install
 ldconfig
 
@@ -91,7 +93,7 @@ MESON_EXTRA=(
 )
 
 meson setup build "${MESON_EXTRA[@]}"
-ninja -C build
+ninja -C build -j"${BUILD_JOBS}"
 ninja -C build install
 ldconfig
 
@@ -212,6 +214,7 @@ if [[ "${NIXL_BUILD_WHEEL:-0}" == "1" ]]; then
 		[[ "${_arg}" == --prefix=* ]] && continue
 		wheel_setup_args+=("-Csetup-args=${_arg}")
 	done
+	wheel_setup_args+=("-Ccompile-args=-j${BUILD_JOBS}")
 	env -u CXX ROCM_PATH="${ROCM_PATH}" \
 		uv build --wheel --no-build-isolation \
 			--out-dir "${NIXL_WHEEL_DIR}" "${wheel_setup_args[@]}"

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -8,6 +8,12 @@ All commands run from the repo root with `make <target>`.
 make build ROCM_ARCH=gfx942
 ```
 
+> **Low on RAM?**
+>
+> ```bash
+> make build ROCM_ARCH=gfx942 BUILD_JOBS=8
+> ```
+
 ## 2. Start the stack (standard mode: DRAM L1 + NVMe L2a + NFS L2b)
 
 ```bash


### PR DESCRIPTION
## Motivation

Prevent OOM build errors for RAM-constrained machines. Improve Docker build time.

Closes https://github.com/ROCm/rocm-aic/issues/89.

## Technical Details

We pass a parameter from the Makefile/Dockerfile to the compile commands to limit the number of processes used to build the different subprojects included in the AIC docker container. This defaults to `$(nproc)`

We don't build the hipFile tests, since they are discarded anyways.

## Test Plan

`make build ROCM_ARCH=gfx942 BUILD_JOBS=3`, ensure no OOM error.

## Test Result

Docker container builds without crashing, polling top/pgrep shows only three processes.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
