### PR TITLE
fix(ci): clone rocm-aic over HTTPS

### DIFF
--- a/.github/scripts/spur-dist-build.sh
+++ b/.github/scripts/spur-dist-build.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 
 SHA="${1:?usage: $0 <full-sha>}"
 SHORT="${SHA:0:7}"
-REPO="git@github.com:ROCm/rocm-aic.git"
+REPO="https://github.com/ROCm/rocm-aic.git"
 AIC_IMAGE="rocm-aic-ci-${SHORT}:latest"
 AIC_SPUR_HOST="${AIC_SPUR_HOST:?AIC_SPUR_HOST must be set (e.g. via GitHub repo variable)}"
 AIC_SPUR_HOST="${AIC_SPUR_HOST//[$'\t\r\n ']}"


### PR DESCRIPTION
## Motivation

We can clone using HTTPS now that AIC is public to avoid SSH key management in CI.

## Technical Details

N/A

## Test Plan

See if we can clone with HTTPS.

## Test Result

CI still works.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
