### PR TITLE
feat(vllm): enable fastsafetensors load format for faster model startup

### DIFF
--- a/.slurm/run-cliff.sbatch
+++ b/.slurm/run-cliff.sbatch
@@ -229,6 +229,11 @@ AIC_ROCM_USE_AITER="${AIC_ROCM_USE_AITER:-1}"
 # NFS HF cache, exceeding the 1200 s default -> spurious "never became ready".
 # Raise for big models / slow shared storage.
 AIC_VLLM_READY_TIMEOUT="${AIC_VLLM_READY_TIMEOUT:-1200}"
+# Model load format.  'fastsafetensors' (default) parallelises weight loading
+# across ranks for faster startup; falls back to 'safetensors' if the model
+# lacks safetensor shards.  Set AIC_LOAD_FORMAT=safetensors to use the serial
+# loader (e.g. when debugging load-order issues or on non-safetensor checkpoints).
+AIC_LOAD_FORMAT="${AIC_LOAD_FORMAT:-fastsafetensors}"
 
 # Every arm now serves vLLM on the compose-published :8000 (arms run sequentially,
 # each stack torn down before the next), so one endpoint port suffices.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -256,6 +256,7 @@ services:
         --gpu-memory-utilization ${VLM_GPU_MEMORY_UTILIZATION:-0.90}
         --max-model-len ${VLM_MAX_MODEL_LEN:-32768}
         --max-num-batched-tokens ${VLM_MAX_NUM_BATCHED_TOKENS:-4096}
+        --load-format ${VLM_LOAD_FORMAT:-fastsafetensors}
         --block-size 64
         --enable-prefix-caching
         --kv-cache-dtype ${VLM_KV_CACHE_DTYPE:-fp8}


### PR DESCRIPTION
Add --load-format fastsafetensors to all vLLM server invocations so that weight shards are loaded in parallel across tensor-parallel ranks rather than serially on rank 0 and broadcast.  For large models (70B+) on multi-GPU configs this materially reduces startup time by shifting the bottleneck away from CPU/NFS I/O.

Changes:
- docker/docker-compose.yml: add --load-format ${VLM_LOAD_FORMAT:-fastsafetensors}
- .slurm/run-cliff.sbatch: introduce AIC_LOAD_FORMAT variable (default fastsafetensors) and pass --load-format to all three benchmark arms (vram_only, kvd/nvme, kvd/gds)

Override to 'safetensors' or 'auto' via VLM_LOAD_FORMAT / AIC_LOAD_FORMAT for models that only ship pickle (.bin) shards or when debugging load order.
