### PR TITLE
fix(ci): chain monitoring smoke off nightly dist-build, not a schedule

### DIFF
--- a/.github/scripts/spur-cliff-harvest.sh
+++ b/.github/scripts/spur-cliff-harvest.sh
@@ -33,16 +33,13 @@ AIC_SPUR_HOST="${AIC_SPUR_HOST//[$'\t\r\n ']}"
 AIC_SHARED_NFS="${AIC_SHARED_NFS:?AIC_SHARED_NFS must be set (e.g. via GitHub repo variable)}"
 AIC_SPUR_CONTROLLER="${AIC_SPUR_CONTROLLER:?AIC_SPUR_CONTROLLER must be set (e.g. via GitHub repo variable)}"
 REPO="https://github.com/ROCm/rocm-aic.git"
-TARBALL_DIR="${AIC_SHARED_NFS}/\${USER}/images/aic-ci-${SHORT}"
-CLIFF_STAGING_DIR="${AIC_SHARED_NFS}/\${USER}/cliff-results-${SHORT}"
 
 ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=4 "${AIC_SPUR_HOST}" env \
     SHA="${SHA}" \
     REPO="${REPO}" \
     RUN_DATE="${RUN_DATE}" \
     AIC_IMAGE="${AIC_IMAGE}" \
-    TARBALL_DIR="${TARBALL_DIR}" \
-    CLIFF_STAGING_DIR="${CLIFF_STAGING_DIR}" \
+    AIC_SHARED_NFS="${AIC_SHARED_NFS}" \
     AIC_SPUR_CONTROLLER="${AIC_SPUR_CONTROLLER}" \
     SPUR_CONTROLLER_ADDR="${AIC_SPUR_CONTROLLER}" \
     bash << 'REMOTE'
@@ -50,6 +47,9 @@ set -euo pipefail
 
 SHORT="${SHA:0:7}"
 WORKDIR="$HOME/Projects/rocm-aic.${SHORT}"
+# $USER here is the head-node user — define paths here, not on the runner.
+TARBALL_DIR="${AIC_SHARED_NFS}/${USER}/images/aic-ci-${SHORT}"
+CLIFF_STAGING_DIR="${AIC_SHARED_NFS}/${USER}/cliff-results-${SHORT}"
 
 cleanup() {
     echo "=== Cleaning up WORKDIR and TARBALL_DIR ==="
@@ -154,15 +154,18 @@ REMOTE
 # ---------------------------------------------------------------------------
 # Copy the HTML page back to the runner working directory
 # ---------------------------------------------------------------------------
+SPUR_USER="$(ssh -o ServerAliveInterval=30 "${AIC_SPUR_HOST}" id -un)"
+REMOTE_CLIFF_STAGING_DIR="${AIC_SHARED_NFS}/${SPUR_USER}/cliff-results-${SHORT}"
+
 echo "=== Copying cliff page back to runner ==="
 rm -rf cliff-page
 mkdir -p cliff-page
 scp -r -o ServerAliveInterval=30 \
-    "${AIC_SPUR_HOST}:${CLIFF_STAGING_DIR}/cliff-page/." \
+    "${AIC_SPUR_HOST}:${REMOTE_CLIFF_STAGING_DIR}/cliff-page/." \
     cliff-page/
 
 # Clean up the NFS staging dir now that we have a local copy
 ssh -o ServerAliveInterval=30 "${AIC_SPUR_HOST}" \
-    "rm -rf '${CLIFF_STAGING_DIR}'" || true
+    "rm -rf '${REMOTE_CLIFF_STAGING_DIR}'" || true
 
 echo "=== Cliff harvest complete for ${SHORT} — page at cliff-page/index.html ==="

--- a/.github/scripts/spur-cliff.sh
+++ b/.github/scripts/spur-cliff.sh
@@ -18,7 +18,6 @@ AIC_SPUR_HOST="${AIC_SPUR_HOST:?AIC_SPUR_HOST must be set (e.g. via GitHub repo 
 AIC_SPUR_HOST="${AIC_SPUR_HOST//[$'\t\r\n ']}"
 AIC_SHARED_NFS="${AIC_SHARED_NFS:?AIC_SHARED_NFS must be set (e.g. via GitHub repo variable)}"
 AIC_SPUR_CONTROLLER="${AIC_SPUR_CONTROLLER:?AIC_SPUR_CONTROLLER must be set (e.g. via GitHub repo variable)}"
-TARBALL_DIR="${AIC_SHARED_NFS}/\${USER}/images/aic-ci-${SHORT}"
 REPO="https://github.com/ROCm/rocm-aic.git"
 
 case "${TARGET}" in
@@ -31,7 +30,6 @@ ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=4 "${AIC_SPUR_HOST}" env \
     REPO="${REPO}" \
     TARGET="${TARGET}" \
     AIC_IMAGE="${AIC_IMAGE}" \
-    TARBALL_DIR="${TARBALL_DIR}" \
     AIC_SHARED_NFS="${AIC_SHARED_NFS}" \
     AIC_SPUR_CONTROLLER="${AIC_SPUR_CONTROLLER}" \
     SPUR_CONTROLLER_ADDR="${AIC_SPUR_CONTROLLER}" \
@@ -40,6 +38,8 @@ set -euo pipefail
 
 SHORT="${SHA:0:7}"
 WORKDIR="$HOME/Projects/rocm-aic.${SHORT}"
+# $USER here is the head-node user — define paths here, not on the runner.
+TARBALL_DIR="${AIC_SHARED_NFS}/${USER}/images/aic-ci-${SHORT}"
 
 cleanup() {
     echo "=== Cleaning up ==="

--- a/.github/scripts/spur-monitoring-cpu-smoke.sh
+++ b/.github/scripts/spur-monitoring-cpu-smoke.sh
@@ -26,15 +26,12 @@ AIC_SMOKE_USE_REGISTRY="${AIC_SMOKE_USE_REGISTRY:-0}"
 NODE_EXPORTER_IMAGE="${NODE_EXPORTER_IMAGE:-quay.io/prometheus/node-exporter:v1.8.2}"
 PROMETHEUS_IMAGE="${PROMETHEUS_IMAGE:-prom/prometheus:v2.55.1}"
 REPO="https://github.com/ROCm/rocm-aic.git"
-TARBALL_DIR="${AIC_SHARED_NFS}/\${USER}/images/aic-ci-${SHORT}"
-METRICS_PAGE_DIR="${AIC_SHARED_NFS}/\${USER}/metrics-page-${SHORT}"
 
 ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=4 "${AIC_SPUR_HOST}" env \
     SHA="${SHA}" \
     REPO="${REPO}" \
     AIC_IMAGE="${AIC_IMAGE}" \
-    TARBALL_DIR="${TARBALL_DIR}" \
-    METRICS_PAGE_DIR="${METRICS_PAGE_DIR}" \
+    AIC_SHARED_NFS="${AIC_SHARED_NFS}" \
     AIC_SPUR_CONTROLLER="${AIC_SPUR_CONTROLLER}" \
     SPUR_CONTROLLER_ADDR="${AIC_SPUR_CONTROLLER}" \
     AIC_SMOKE_USE_REGISTRY="${AIC_SMOKE_USE_REGISTRY}" \
@@ -45,6 +42,9 @@ set -euo pipefail
 
 SHORT="${SHA:0:7}"
 WORKDIR="$HOME/Projects/rocm-aic.${SHORT}"
+# $USER here is the head-node user — define paths here, not on the runner.
+TARBALL_DIR="${AIC_SHARED_NFS}/${USER}/images/aic-ci-${SHORT}"
+METRICS_PAGE_DIR="${AIC_SHARED_NFS}/${USER}/metrics-page-${SHORT}"
 
 cleanup() {
     echo "=== Cleaning up ==="
@@ -304,10 +304,13 @@ REMOTE
 # ---------------------------------------------------------------------------
 # Copy metrics page artifact back to the runner working directory
 # ---------------------------------------------------------------------------
+SPUR_USER="$(ssh -o ServerAliveInterval=30 "${AIC_SPUR_HOST}" id -un)"
+REMOTE_METRICS_PAGE_DIR="${AIC_SHARED_NFS}/${SPUR_USER}/metrics-page-${SHORT}"
+
 echo "=== Copying metrics page to runner ==="
 mkdir -p metrics-page
 scp -o ServerAliveInterval=30 \
-    "${AIC_SPUR_HOST}:${METRICS_PAGE_DIR}/index.html" \
+    "${AIC_SPUR_HOST}:${REMOTE_METRICS_PAGE_DIR}/index.html" \
     metrics-page/index.html
 
 echo "CPU monitoring smoke test passed for ${SHORT}"

--- a/.github/scripts/spur-monitoring-cpu-smoke.sh
+++ b/.github/scripts/spur-monitoring-cpu-smoke.sh
@@ -13,7 +13,7 @@ set -euo pipefail
 #
 # Uses the rocm-aic image tarball left by spur-dist-build.sh for the same SHA
 # (same TARBALL_DIR convention).  Set AIC_SMOKE_USE_REGISTRY=1 to pull from
-# Docker Hub instead.
+# a registry instead.
 
 SHA="${1:?usage: $0 <full-sha>}"
 SHORT="${SHA:0:7}"

--- a/.github/scripts/spur-smoke-test.sh
+++ b/.github/scripts/spur-smoke-test.sh
@@ -31,13 +31,14 @@ WORKDIR="$HOME/Projects/rocm-aic.${SHORT}"
 # $USER here is the head-node user, not the runner's local user.
 TARBALL_DIR="${AIC_SHARED_NFS}/${USER}/images/aic-ci-${SHORT}"
 
-cleanup() {
-    echo "=== Cleaning up ==="
-    # Preserve logs/ so CI can retrieve them after the job completes.
+cleanup_on_fail() {
+    echo "=== Smoke test failed — cleaning up ==="
     rm -rf "${TARBALL_DIR}"
     find "${WORKDIR}" -mindepth 1 -maxdepth 1 -not -name logs -exec rm -rf {} +
 }
-trap cleanup EXIT
+# On success: preserve TARBALL_DIR so the following tiny-test stage can use it.
+# On failure: clean up immediately so no stale state is left behind.
+trap cleanup_on_fail ERR
 
 # Re-clone if WORKDIR is missing or checked out at the wrong SHA.
 ACTUAL_SHA="$(git -C "${WORKDIR}" rev-parse HEAD 2>/dev/null || true)"

--- a/.github/scripts/spur-tiny-test.sh
+++ b/.github/scripts/spur-tiny-test.sh
@@ -23,8 +23,6 @@ AIC_SPUR_HOST="${AIC_SPUR_HOST:?AIC_SPUR_HOST must be set (e.g. via GitHub repo 
 AIC_SPUR_HOST="${AIC_SPUR_HOST//[$'\t\r\n ']}"
 AIC_SHARED_NFS="${AIC_SHARED_NFS:?AIC_SHARED_NFS must be set (e.g. via GitHub repo variable)}"
 AIC_SPUR_CONTROLLER="${AIC_SPUR_CONTROLLER:?AIC_SPUR_CONTROLLER must be set (e.g. via GitHub repo variable)}"
-TARBALL_DIR="${AIC_SHARED_NFS}/\${USER}/images/aic-ci-${SHORT}"
-TINY_HF_HOME="${AIC_SHARED_NFS}/\${USER}/tiny-hf"
 KEEP_ARTIFACTS="${KEEP_ARTIFACTS:-0}"
 REPO="https://github.com/ROCm/rocm-aic.git"
 
@@ -32,8 +30,7 @@ ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=4 "${AIC_SPUR_HOST}" env \
     SHA="${SHA}" \
     REPO="${REPO}" \
     AIC_IMAGE="${AIC_IMAGE}" \
-    TARBALL_DIR="${TARBALL_DIR}" \
-    TINY_HF_HOME="${TINY_HF_HOME}" \
+    AIC_SHARED_NFS="${AIC_SHARED_NFS}" \
     KEEP_ARTIFACTS="${KEEP_ARTIFACTS}" \
     AIC_SPUR_CONTROLLER="${AIC_SPUR_CONTROLLER}" \
     SPUR_CONTROLLER_ADDR="${AIC_SPUR_CONTROLLER}" \
@@ -42,6 +39,9 @@ set -euo pipefail
 
 SHORT="${SHA:0:7}"
 WORKDIR="$HOME/Projects/rocm-aic.${SHORT}"
+# $USER here is the head-node user — define paths here, not on the runner.
+TARBALL_DIR="${AIC_SHARED_NFS}/${USER}/images/aic-ci-${SHORT}"
+TINY_HF_HOME="${AIC_SHARED_NFS}/${USER}/tiny-hf"
 
 _cleanup() {
     echo "=== Cleaning up ==="

--- a/.github/workflows/aic-monitoring-cpu-smoke.yml
+++ b/.github/workflows/aic-monitoring-cpu-smoke.yml
@@ -26,9 +26,9 @@ name: AIC Monitoring CPU Smoke Test
 
 on:
   workflow_dispatch:
-  schedule:
-    # 03:30 PST (11:30 UTC) daily — after the nightly smoke test completes
-    - cron: '30 11 * * *'
+  workflow_run:
+    workflows: ["AIC Nightly Dist Build"]
+    types: [completed]
 
 permissions:
   contents: write   # required to push the gh-pages branch
@@ -36,6 +36,9 @@ permissions:
 jobs:
   monitoring-cpu-smoke:
     name: CPU exporter smoke test + metrics page
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
     runs-on: [self-hosted, rocm-aic-cicd]
     timeout-minutes: 45
     env:
@@ -47,7 +50,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run CPU monitoring smoke test on SPUR
-        run: bash .github/scripts/spur-monitoring-cpu-smoke.sh "${{ github.sha }}"
+        run: |
+          SHA="${{ github.event.workflow_run.head_sha || github.sha }}"
+          bash .github/scripts/spur-monitoring-cpu-smoke.sh "${SHA}"
 
       - name: Upload metrics reference page artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
The monitoring CPU smoke test needs the rocm-aic image tarball built by spur-dist-build.sh (vllm_emulator_server.py imports vllm, which is only in that image — no public registry exists).  Running on a fixed cron schedule meant the tarball was never present for workflow_dispatch or manual runs not preceded by a dist-build.

Fix: switch the trigger from `schedule` to `workflow_run` off "AIC Nightly Dist Build", matching the pattern used by all other nightly test workflows. Keep `workflow_dispatch` for manual reruns (tarball must already exist for the same SHA).  Guard the job with the standard conclusion check and resolve the SHA from `workflow_run.head_sha` when triggered by dist-build, falling back to `github.sha` for workflow_dispatch.

Also revert the AIC_SMOKE_USE_REGISTRY=1 env var added in the previous commit — the registry does not exist.
