### PR TITLE
fix(ci): fix monitoring tarball load, cliff grep, and rm robustness

### DIFF
--- a/.github/scripts/spur-cliff-harvest.sh
+++ b/.github/scripts/spur-cliff-harvest.sh
@@ -53,7 +53,8 @@ CLIFF_STAGING_DIR="${AIC_SHARED_NFS}/${USER}/cliff-results-${SHORT}"
 
 cleanup() {
     echo "=== Cleaning up WORKDIR and TARBALL_DIR ==="
-    rm -rf "${WORKDIR}" "${TARBALL_DIR}"
+    rm -rf "${WORKDIR}" "${TARBALL_DIR}" 2>/dev/null || \
+        rm -rf "${WORKDIR}" "${TARBALL_DIR}" 2>/dev/null || true
     # CLIFF_STAGING_DIR is on NFS and intentionally NOT cleaned here;
     # it is removed by the runner after scp completes.
 }
@@ -85,8 +86,8 @@ JOB_ID=$(SPUR_CONTROLLER_ADDR="${AIC_SPUR_CONTROLLER}" \
     AIC_IMAGE="${AIC_IMAGE}" \
     AIC_IMAGE_DIR="${TARBALL_DIR}" \
     make cliff-submit 2>&1 \
-  | grep -oP '(?<=submitted (cliff-short|aic-cliff) job )\d+|(?<=Submitted batch job )\d+' \
-  | tail -1)
+  | grep -oE '(submitted (cliff-short|aic-cliff) job |Submitted batch job )[0-9]+' \
+  | grep -oE '[0-9]+$' | tail -1)
 
 if [[ -z "${JOB_ID}" ]]; then
     echo "ERROR: could not determine Slurm job ID from make cliff-submit output" >&2

--- a/.github/scripts/spur-cliff.sh
+++ b/.github/scripts/spur-cliff.sh
@@ -67,7 +67,9 @@ cd "${WORKDIR}"
 JOB_ID=$(AIC_SPUR_CLUSTER=1 \
     AIC_IMAGE="${AIC_IMAGE}" \
     AIC_IMAGE_DIR="${TARBALL_DIR}" \
-    make "${TARGET}" 2>&1 | grep -oP '(?<=submitted (cliff-short|aic-cliff) job )\d+|(?<=Submitted batch job )\d+' | tail -1)
+    make "${TARGET}" 2>&1 \
+    | grep -oE '(submitted (cliff-short|aic-cliff) job |Submitted batch job )[0-9]+' \
+    | grep -oE '[0-9]+$' | tail -1)
 
 if [[ -z "${JOB_ID}" ]]; then
     echo "ERROR: could not determine Slurm job ID from make ${TARGET} output" >&2

--- a/.github/scripts/spur-monitoring-cpu-smoke.sh
+++ b/.github/scripts/spur-monitoring-cpu-smoke.sh
@@ -90,8 +90,13 @@ if [[ "${AIC_SMOKE_USE_REGISTRY}" == "1" ]]; then
     docker pull "${AIC_IMAGE}"
 else
     echo "=== Loading image from ${TARBALL_DIR} ==="
-    docker load -i "${TARBALL_DIR}/rocm-aic.tar"
-    docker tag rocm-aic:latest "${AIC_IMAGE}"
+    tarball="$(ls "${TARBALL_DIR}"/*.tar.zst "${TARBALL_DIR}"/*.tar.gz "${TARBALL_DIR}"/*.tar 2>/dev/null | head -1)"
+    [[ -n "${tarball}" ]] || { echo "ERROR: no tarball in ${TARBALL_DIR}" >&2; ls "${TARBALL_DIR}" >&2; exit 1; }
+    case "${tarball}" in
+        *.tar.zst) zstd -dc "${tarball}" | docker load ;;
+        *.tar.gz)  gzip -dc "${tarball}" | docker load ;;
+        *.tar)     docker load -i "${tarball}" ;;
+    esac
 fi
 
 MON_DIR="${WORKDIR}/monitoring"


### PR DESCRIPTION
Three fixes across spur-monitoring-cpu-smoke.sh and spur-cliff{,-harvest}.sh:

1. Hardcoded tarball filename in monitoring smoke — `docker load -i rocm-aic.tar` assumed a plain uncompressed tarball with a fixed name. dist-build writes a zstd-compressed file named after the image and arch tags (e.g. rocm-aic-ci-8368406-latest-gfx90a-...-gfx1201.tar.zst). Fix: glob for any tarball in TARBALL_DIR and pipe through the correct decompressor (zstd / gzip / plain), matching run-build-distribute.sh.

2. Variable-length lookbehind in grep — the PCRE pattern `(?<=submitted (cliff-short|aic-cliff) job )` uses alternation in a lookbehind, which GNU grep supports but the SPUR head node's grep does not ("lookbehind assertion is not fixed length").  Replace with `grep -oE` to match the full phrase then a second `grep -oE '[0-9]+$'` to extract the job ID.  Applies to both spur-cliff.sh and spur-cliff-harvest.sh.

3. `rm -rf "${WORKDIR}"` failing in spur-cliff-harvest.sh — NFS can still be flushing files written by the sbatch job when the EXIT trap fires, causing "Directory not empty".  Retry once on failure and suppress any remaining error so the EXIT trap does not mask the real job result.

Scripts redeployed to /usr/local/lib/aic-ci/ via make install-ci-scripts.
