### PR TITLE
LMCache workaround for hybrid KV cache models.

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -160,6 +160,7 @@ services:
       - |
         if [ "${GDS_MODE:-0}" = "1" ]; then
           exec lmcache server \
+            --no-separate-object-groups \
             --host 0.0.0.0 \
             --port "$$LMCACHE_PORT" \
             --l1-size-gb "$$LMCACHE_L1_SIZE_GB" \
@@ -170,6 +171,7 @@ services:
           # via the mounted LMCACHE_CONFIG_FILE; none = pure DRAM (the minimal MP
           # config -- used by tiny-test and DRAM-only deployments).
           exec lmcache server \
+            --no-separate-object-groups \
             --host 0.0.0.0 \
             --port "$$LMCACHE_PORT" \
             --l1-size-gb "$$LMCACHE_L1_SIZE_GB" \
@@ -179,6 +181,7 @@ services:
           # backends, so both backend_params MUST include use_direct_io (LMCache
           # rejects the adapter otherwise); POSIX/NFS uses buffered I/O (false).
           exec lmcache server \
+            --no-separate-object-groups \
             --host 0.0.0.0 \
             --port "$$LMCACHE_PORT" \
             --l1-size-gb "$$LMCACHE_L1_SIZE_GB" \


### PR DESCRIPTION
## Motivation

This commit adds `--no-separate-object-groups` argument to `lmcache server` launch commands to work around issues with hybrid KV cache models.

Fixes #100.

## Technical Details

Hybrid KV cache models have layers with different attention schemes, e.g. gpt-oss-120b has 18 layers with full-attention and 18 layer with sliding window attention (alternating) and the KV tensors for them differ in size and shape.

Currently, LMCache only registers the size & shape of group 0 with NIXL and thereafter all transfers are assumed to be uniform. This leads to NIXL errors later which then cause vLLM to re-compute the tensors that could not be restored.

NOTE: This workaround resolves the proximate problem (NIXL errors) at the cost of inefficiency -- loading and storing larger (but uniform size & shape) objects. It is a stop-gap solution that should be tracked and undone when a better resolution is merged in upstream LMCache.

## Test Plan

Exercised AIC setup with oss-gpt-120b in a L1 + L2 setup with L2 handled through NIXL.

## Test Result

Observed successful L2 stores and loads without errors.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
