### PR TITLE
fix(ci): replace ls glob with find for tarball discovery in monitorin…

### DIFF
--- a/.github/scripts/spur-monitoring-cpu-smoke.sh
+++ b/.github/scripts/spur-monitoring-cpu-smoke.sh
@@ -90,8 +90,8 @@ if [[ "${AIC_SMOKE_USE_REGISTRY}" == "1" ]]; then
     docker pull "${AIC_IMAGE}"
 else
     echo "=== Loading image from ${TARBALL_DIR} ==="
-    tarball="$(ls "${TARBALL_DIR}"/*.tar.zst "${TARBALL_DIR}"/*.tar.gz "${TARBALL_DIR}"/*.tar 2>/dev/null | head -1)"
-    [[ -n "${tarball}" ]] || { echo "ERROR: no tarball in ${TARBALL_DIR}" >&2; ls "${TARBALL_DIR}" >&2; exit 1; }
+    tarball="$(find "${TARBALL_DIR}" -maxdepth 1 \( -name '*.tar.zst' -o -name '*.tar.gz' -o -name '*.tar' \) 2>/dev/null | head -1)"
+    [[ -n "${tarball}" ]] || { echo "ERROR: no tarball in ${TARBALL_DIR}" >&2; ls -la "${TARBALL_DIR}" >&2 || true; exit 1; }
     case "${tarball}" in
         *.tar.zst) zstd -dc "${tarball}" | docker load ;;
         *.tar.gz)  gzip -dc "${tarball}" | docker load ;;


### PR DESCRIPTION
…g smoke

`ls *.tar.zst *.tar.gz *.tar 2>/dev/null | head -1` under `set -eo pipefail` exits non-zero when some glob patterns have no matches (even if others do), causing the script to abort before the `[[ -n tarball ]]` guard is reached.  The dist-build produces a single `.tar.zst` so the `.tar.gz` and `.tar` globs always fail, giving exit code 2.

Replace with `find -maxdepth 1` which always exits 0 regardless of whether matching files exist.  Also add `|| true` to the diagnostic `ls -la` in the error path so it is safe under `set -e`.

