### PR TITLE
fix(ci): Use shared paths for CI artifacts/caching

### DIFF
--- a/.github/scripts/spur-cliff.sh
+++ b/.github/scripts/spur-cliff.sh
@@ -38,8 +38,7 @@ set -euo pipefail
 
 SHORT="${SHA:0:7}"
 WORKDIR="$HOME/Projects/rocm-aic.${SHORT}"
-# $USER here is the head-node user — define paths here, not on the runner.
-TARBALL_DIR="${AIC_SHARED_NFS}/${USER}/images/aic-ci-${SHORT}"
+TARBALL_DIR="${AIC_SHARED_NFS}/rocm-aic/images/aic-ci-${SHORT}"
 
 cleanup() {
     echo "=== Cleaning up ==="

--- a/.github/scripts/spur-dist-build.sh
+++ b/.github/scripts/spur-dist-build.sh
@@ -29,8 +29,7 @@ set -euo pipefail
 
 SHORT="${SHA:0:7}"
 WORKDIR="$HOME/Projects/rocm-aic.${SHORT}"
-# $USER here is the head-node user, not the runner's local user.
-TARBALL_DIR="${AIC_SHARED_NFS}/${USER}/images/aic-ci-${SHORT}"
+TARBALL_DIR="${AIC_SHARED_NFS}/rocm-aic/images/aic-ci-${SHORT}"
 
 cleanup_on_fail() {
     echo "=== Build failed — cleaning up ==="

--- a/.github/scripts/spur-monitoring-cpu-smoke.sh
+++ b/.github/scripts/spur-monitoring-cpu-smoke.sh
@@ -41,6 +41,7 @@ WORKDIR="$HOME/Projects/rocm-aic.${SHORT}"
 # $USER here is the head-node user — define paths here, not on the runner.
 TARBALL_DIR="${AIC_SHARED_NFS}/${USER}/images/aic-ci-${SHORT}"
 METRICS_PAGE_DIR="${AIC_SHARED_NFS}/${USER}/metrics-page-${SHORT}"
+HF_HOME="${AIC_SHARED_NFS}/huggingface"
 
 cleanup() {
     echo "=== Cleaning up ==="
@@ -75,6 +76,7 @@ METRICS_PAGE_DIR="${3}"
 SHA="${4}"
 TARBALL_DIR="${5}"
 AIC_SMOKE_USE_REGISTRY="${6:-0}"
+HF_HOME="${7}"
 SHORT="${SHA:0:7}"
 
 MON_DIR="${WORKDIR}/monitoring"
@@ -102,6 +104,7 @@ fi
 # ---------------------------------------------------------------------------
 # Source shared monitoring helpers and configure for CPU-only smoke test
 # ---------------------------------------------------------------------------
+mkdir -p "${HF_HOME}"
 # shellcheck source=monitoring/monitoring-lib.sh
 source "${MON_DIR}/monitoring-lib.sh"
 
@@ -139,7 +142,8 @@ start_monitoring
 # 3. Start vLLM emulator via its compose file
 # ---------------------------------------------------------------------------
 echo "=== Starting vLLM emulator (8000) ==="
-IMAGE_NAME="${AIC_IMAGE}" VLLM_CPU_MODEL="${VLLM_CPU_MODEL:-facebook/opt-125m}" \
+HF_HOME="${HF_HOME}" IMAGE_NAME="${AIC_IMAGE}" \
+    VLLM_CPU_MODEL="${VLLM_CPU_MODEL:-facebook/opt-125m}" \
     docker compose -f "${EMULATOR_COMPOSE}" up -d
 
 # ---------------------------------------------------------------------------
@@ -240,7 +244,8 @@ srun \
         "${METRICS_PAGE_DIR}" \
         "${SHA}" \
         "${TARBALL_DIR}" \
-        "${AIC_SMOKE_USE_REGISTRY}"
+        "${AIC_SMOKE_USE_REGISTRY}" \
+        "${HF_HOME}"
 
 echo "=== srun job completed ==="
 REMOTE

--- a/.github/scripts/spur-smoke-test.sh
+++ b/.github/scripts/spur-smoke-test.sh
@@ -28,8 +28,7 @@ set -euo pipefail
 
 SHORT="${SHA:0:7}"
 WORKDIR="$HOME/Projects/rocm-aic.${SHORT}"
-# $USER here is the head-node user, not the runner's local user.
-TARBALL_DIR="${AIC_SHARED_NFS}/${USER}/images/aic-ci-${SHORT}"
+TARBALL_DIR="${AIC_SHARED_NFS}/rocm-aic/images/aic-ci-${SHORT}"
 
 cleanup_on_fail() {
     echo "=== Smoke test failed — cleaning up ==="

--- a/.github/scripts/spur-tiny-test.sh
+++ b/.github/scripts/spur-tiny-test.sh
@@ -13,8 +13,8 @@ set -euo pipefail
 #   * Nightly (dist-build -> smoke -> tiny -> cliff): cliff runs next and needs
 #     the artifacts, so the nightly tiny-test step sets KEEP_ARTIFACTS=1 and this
 #     script only cleans up on failure (spur-cliff.sh does the final cleanup).
-# The tiny model is cached in a persistent shared HF dir (outside the tarball
-# dir) so it is downloaded once and reused across runs.
+# The tiny model uses the cluster-wide HF cache so it is downloaded once and
+# reused across CI workflows and SPUR accounts.
 
 SHA="${1:?usage: $0 <full-sha>}"
 SHORT="${SHA:0:7}"
@@ -42,7 +42,7 @@ SHORT="${SHA:0:7}"
 WORKDIR="$HOME/Projects/rocm-aic.${SHORT}"
 # $USER here is the head-node user — define paths here, not on the runner.
 TARBALL_DIR="${AIC_SHARED_NFS}/${USER}/images/aic-ci-${SHORT}"
-TINY_HF_HOME="${AIC_SHARED_NFS}/${USER}/tiny-hf"
+TINY_HF_HOME="${AIC_SHARED_NFS}/huggingface"
 
 _cleanup() {
     echo "=== Cleaning up ==="

--- a/.github/scripts/spur-tiny-test.sh
+++ b/.github/scripts/spur-tiny-test.sh
@@ -40,8 +40,7 @@ set -euo pipefail
 
 SHORT="${SHA:0:7}"
 WORKDIR="$HOME/Projects/rocm-aic.${SHORT}"
-# $USER here is the head-node user — define paths here, not on the runner.
-TARBALL_DIR="${AIC_SHARED_NFS}/${USER}/images/aic-ci-${SHORT}"
+TARBALL_DIR="${AIC_SHARED_NFS}/rocm-aic/images/aic-ci-${SHORT}"
 
 _cleanup() {
     echo "=== Cleaning up ==="

--- a/.github/scripts/spur-tiny-test.sh
+++ b/.github/scripts/spur-tiny-test.sh
@@ -42,7 +42,6 @@ SHORT="${SHA:0:7}"
 WORKDIR="$HOME/Projects/rocm-aic.${SHORT}"
 # $USER here is the head-node user — define paths here, not on the runner.
 TARBALL_DIR="${AIC_SHARED_NFS}/${USER}/images/aic-ci-${SHORT}"
-TINY_HF_HOME="${AIC_SHARED_NFS}/huggingface"
 
 _cleanup() {
     echo "=== Cleaning up ==="
@@ -71,7 +70,6 @@ echo "=== Running tiny-test (AIC_IMAGE=${AIC_IMAGE}) ==="
 AIC_SPUR_CLUSTER=1 \
     AIC_IMAGE="${AIC_IMAGE}" \
     AIC_IMAGE_DIR="${TARBALL_DIR}" \
-    AIC_TINY_HF_HOME="${TINY_HF_HOME}" \
     HF_TOKEN="${HF_TOKEN:-}" \
     make -C "${WORKDIR}" tiny-test
 

--- a/.slurm/run-build-distribute.sh
+++ b/.slurm/run-build-distribute.sh
@@ -492,7 +492,7 @@ cmd_build() {
             local _cdir
             _cdir="${AIC_CACHE_DIR%/}/$(_arch_tag)"
             log "build cache: local dir ${_cdir} (mode ${AIC_CACHE_MODE}, builder ${AIC_BUILDX_BUILDER})"
-            _cache_args="--cache-from type=local,src=${_cdir} --cache-to type=local,dest=${_cdir},mode=${AIC_CACHE_MODE}"
+            _cache_args="--cache-from type=local,src=${_cdir} --cache-to type=local,dest=${_cdir},mode=${AIC_CACHE_MODE},ignore-error=true"
             _mkdir="mkdir -p '${_cdir}'; "
         fi
         # Create the docker-container builder once per node (idempotent), then
@@ -533,11 +533,6 @@ echo "[build] pruning BuildKit cache on \$(hostname) before build ..."
 docker buildx prune --builder ${AIC_BUILDX_BUILDER} --force 2>/dev/null || true
 echo "[build] disk after prune: \$(df -h / | awk 'NR==2{print \$3\" free / \"\$2\" total (\"\$5\" used)\"}')"
 tmp="${tarball}.partial.\$\$"
-# BuildKit exits non-zero on cache-write lock races even when the image was
-# exported successfully.  Run the pipeline without pipefail so we can inspect
-# each side independently: fail only when the compressor side failed (meaning
-# the tarball itself is corrupt/missing), treat buildx-only failures as warnings.
-set +o pipefail
 docker buildx build --builder ${AIC_BUILDX_BUILDER} --progress=plain --output type=docker,dest=- \
     --build-arg ROCM_ARCH="${AIC_ROCM_ARCH}" \
     ${_secret_arg} \
@@ -545,14 +540,6 @@ docker buildx build --builder ${AIC_BUILDX_BUILDER} --progress=plain --output ty
     -f "${AIC_DAY_DIR}/docker/Dockerfile" \
     -t "${AIC_IMAGE}" \
     "${AIC_DAY_DIR}" | ${COMPRESS_CMD} > "\${tmp}"
-_rc=("\${PIPESTATUS[@]}")
-set -o pipefail
-if [ "\${_rc[1]}" -ne 0 ]; then
-    echo "[build] ERROR: compressor exited \${_rc[1]}; tarball may be corrupt" >&2; exit 1
-fi
-if [ "\${_rc[0]}" -ne 0 ]; then
-    echo "[build] WARN: docker buildx exited \${_rc[0]} (cache lock race?); tarball written, continuing"
-fi
 mv -f "\${tmp}" "${tarball}"
 echo "[build] saved \$(du -h "${tarball}" | cut -f1) -> ${tarball}"
 exit 0

--- a/.slurm/run-build-distribute.sh
+++ b/.slurm/run-build-distribute.sh
@@ -73,6 +73,8 @@
 #   AIC_ROCM_ARCH        gfx arch(es) baked in; ';'-list   (default: all vLLM archs)
 #   AIC_IMAGE            image name:tag                    (default: rocm-aic:latest)
 #   AIC_IMAGE_DIR        shared dir for the tarball        (default: /scratch/$USER/images)
+#   HF_HOME              persistent Hugging Face cache used by tiny-test
+#                        (default: <AIC_IMAGE_DIR>/tiny-hf)
 #   AIC_FORCE_LOAD       test/push: force a reload from the tarball even when the
 #                        node's image is already current (default: 0).  By default
 #                        a node auto-reloads only when the /scratch tarball is
@@ -198,9 +200,9 @@ AIC_TEST_MEM="${AIC_TEST_MEM:-32G}"
 # Brings up the compose MP stack (standalone lmcache + vLLM LMCacheMPConnector)
 # with a small model and asserts one non-empty chat completion.  A fast functional
 # gate that exercises the connector path a smoke-test cannot.  The model is
-# downloaded once into AIC_TINY_HF_HOME (a persistent shared HF cache) and reused.
+# downloaded once into HF_HOME (a persistent shared HF cache) and reused.
 AIC_TINY_MODEL="${AIC_TINY_MODEL:-Qwen/Qwen2.5-0.5B-Instruct}"
-AIC_TINY_HF_HOME="${AIC_TINY_HF_HOME:-${AIC_IMAGE_DIR}/tiny-hf}"
+HF_HOME="${HF_HOME:-${AIC_IMAGE_DIR}/tiny-hf}"
 AIC_TINY_TIME="${AIC_TINY_TIME:-00:25:00}"
 AIC_TINY_CPUS="${AIC_TINY_CPUS:-8}"
 AIC_TINY_MEM="${AIC_TINY_MEM:-32G}"
@@ -1051,7 +1053,7 @@ cmd_tiny_test() {
         _sel=(--constraint="${AIC_TEST_CONSTRAINT}")
         log "tiny-test via sbatch (partition ${AIC_BUILD_PARTITION}, constraint ${AIC_TEST_CONSTRAINT})"
     fi
-    log "image: ${AIC_IMAGE}  model: ${AIC_TINY_MODEL}  hf: ${AIC_TINY_HF_HOME}"
+    log "image: ${AIC_IMAGE}  model: ${AIC_TINY_MODEL}  hf: ${HF_HOME}"
 
     local remote_script
     remote_script="$(cat <<REMOTE
@@ -1080,12 +1082,12 @@ source '${AIC_DAY_DIR}/monitoring/monitoring-lib.sh'
 ensure_compose || { echo "[tiny-test] docker compose unavailable and could not be installed" >&2; exit 1; }
 
 # Tiny-model MP stack env.  Small footprint; the tiny model is downloaded online
-# into the persistent AIC_TINY_HF_HOME.
+# into the persistent HF_HOME forwarded by the Makefile.
 export IMAGE_NAME='${AIC_IMAGE}'
 export ROCM_ARCH='${AIC_ROCM_ARCH}'
 export GPU=0
 export VLLM_MODEL='${AIC_TINY_MODEL}'
-export HF_HOME='${AIC_TINY_HF_HOME}'
+export HF_HOME='${HF_HOME}'
 export HF_TOKEN='${HF_TOKEN:-}'
 export HF_HUB_OFFLINE=0 TRANSFORMERS_OFFLINE=0
 export LOG="\${_logdir}"

--- a/Makefile
+++ b/Makefile
@@ -141,12 +141,15 @@ export AIC_SPUR_CONTROLLER  ?= $(SPUR_CONTROLLER_ADDR)
 export AIC_IMAGE_DIR        ?= $(AIC_SHARED_NFS)/rocm-aic/images
 # BuildKit mutates its cache in place, so don't share that between runners.
 export AIC_CACHE_DIR        ?= $(AIC_SHARED_NFS)/rocm-aic/images/buildcache/$(USER)
+# Use the same model cache for both normal and tiny-model CI paths.
+export AIC_TINY_HF_HOME     ?= $(AIC_SHARED_NFS)/huggingface
 # SPUR nodes have 8x NVMe drives combined into a single LVM at /mnt/m2m_nobackup.
 # Use override (not ?=) so these win over the top-level ?= defaults set earlier.
-# HF_HOME points to AIC_SHARED_NFS since /scratch does not exist on this cluster.
+# HF_HOME points to the cluster-wide model cache since /scratch does not exist
+# on this cluster.
 override export NVME_DATA     := /mnt/m2m_nobackup/aic-cliff/nvme
 override export GDS_SLAB_DATA := /mnt/m2m_nobackup/aic-cliff/slab
-override export HF_HOME       := $(AIC_SHARED_NFS)/rocm-aic/huggingface
+override export HF_HOME       := $(AIC_SHARED_NFS)/huggingface
 else
 export AIC_CACHE_DIR        ?= /scratch/$(USER)/images/buildcache
 endif

--- a/Makefile
+++ b/Makefile
@@ -141,8 +141,6 @@ export AIC_SPUR_CONTROLLER  ?= $(SPUR_CONTROLLER_ADDR)
 export AIC_IMAGE_DIR        ?= $(AIC_SHARED_NFS)/rocm-aic/images
 # BuildKit mutates its cache in place, so don't share that between runners.
 export AIC_CACHE_DIR        ?= $(AIC_SHARED_NFS)/rocm-aic/images/buildcache/$(USER)
-# Use the same model cache for both normal and tiny-model CI paths.
-export AIC_TINY_HF_HOME     ?= $(AIC_SHARED_NFS)/huggingface
 # SPUR nodes have 8x NVMe drives combined into a single LVM at /mnt/m2m_nobackup.
 # Use override (not ?=) so these win over the top-level ?= defaults set earlier.
 # HF_HOME points to the cluster-wide model cache since /scratch does not exist

--- a/Makefile
+++ b/Makefile
@@ -138,14 +138,15 @@ AIC_SHARED_NFS ?=
 ifeq ($(AIC_SPUR_CLUSTER),1)
 export AIC_SPUR_CLUSTER
 export AIC_SPUR_CONTROLLER  ?= $(SPUR_CONTROLLER_ADDR)
-export AIC_IMAGE_DIR        ?= $(AIC_SHARED_NFS)/$(USER)/images
-export AIC_CACHE_DIR        ?= $(AIC_SHARED_NFS)/$(USER)/images/buildcache
+export AIC_IMAGE_DIR        ?= $(AIC_SHARED_NFS)/rocm-aic/images
+# BuildKit mutates its cache in place, so don't share that between runners.
+export AIC_CACHE_DIR        ?= $(AIC_SHARED_NFS)/rocm-aic/images/buildcache/$(USER)
 # SPUR nodes have 8x NVMe drives combined into a single LVM at /mnt/m2m_nobackup.
 # Use override (not ?=) so these win over the top-level ?= defaults set earlier.
 # HF_HOME points to AIC_SHARED_NFS since /scratch does not exist on this cluster.
 override export NVME_DATA     := /mnt/m2m_nobackup/aic-cliff/nvme
 override export GDS_SLAB_DATA := /mnt/m2m_nobackup/aic-cliff/slab
-override export HF_HOME       := $(AIC_SHARED_NFS)/$(USER)/hf
+override export HF_HOME       := $(AIC_SHARED_NFS)/rocm-aic/huggingface
 else
 export AIC_CACHE_DIR        ?= /scratch/$(USER)/images/buildcache
 endif

--- a/Makefile
+++ b/Makefile
@@ -139,8 +139,8 @@ ifeq ($(AIC_SPUR_CLUSTER),1)
 export AIC_SPUR_CLUSTER
 export AIC_SPUR_CONTROLLER  ?= $(SPUR_CONTROLLER_ADDR)
 export AIC_IMAGE_DIR        ?= $(AIC_SHARED_NFS)/rocm-aic/images
-# BuildKit mutates its cache in place, so don't share that between runners.
-export AIC_CACHE_DIR        ?= $(AIC_SHARED_NFS)/rocm-aic/images/buildcache/$(USER)
+# Cache export is best-effort, so SPUR runners can share one BuildKit cache.
+export AIC_CACHE_DIR        ?= $(AIC_SHARED_NFS)/rocm-aic/images/buildcache
 # SPUR nodes have 8x NVMe drives combined into a single LVM at /mnt/m2m_nobackup.
 # Use override (not ?=) so these win over the top-level ?= defaults set earlier.
 # HF_HOME points to the cluster-wide model cache since /scratch does not exist

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -20,7 +20,7 @@
 | `VLLM_EXTRA_ARGS` | — | Extra vLLM args appended verbatim (e.g. `--hf-overrides '{...}'`; single-quote embedded JSON) |
 | `COMPOSE_PLUGIN_VERSION` | `v2.40.0` | docker compose v2 plugin version installed by `make ensure-compose` / `ensure_compose` when missing |
 | `AIC_TINY_MODEL` | `Qwen/Qwen2.5-0.5B-Instruct` | Model served by `make tiny-test` (end-to-end serve check) |
-| `AIC_TINY_HF_HOME` | `<image-dir>/tiny-hf` | Persistent HF cache the tiny model is downloaded into for `tiny-test` |
+| `HF_HOME` | `~/.cache/huggingface` (`/shared_nfs/huggingface` on SPUR) | Persistent Hugging Face cache used by normal, cliff, monitoring, and tiny-model paths |
 | `TENSOR_PARALLEL_SIZE` | `1` | vLLM tensor parallel degree |
 | `GPU` | `0` | ROCR_VISIBLE_DEVICES for the vllm container |
 | `AIC_NVME_AUTO` | `1` (cliff) | Auto-detect a dedicated local NVMe for the LMCache tiers: reuse a mounted `aic-lmcache` volume, else format+mount a raw non-root spare, else use a non-root mounted NVMe, else node-local `/tmp`. `0` forces `/tmp`; needs passwordless `sudo` to format/mount |


### PR DESCRIPTION
## Motivation

With multiple GitHub runners potentially using different users, we'd like CI artifacts and cached models to reside in a shared directory that other GitHub runners can reuse.

## Technical Details

N/A

## Test Plan

Run CI, wait for a run where `dist-build` is picked up by one runner, and `smoke-test` is picked up by another runner, ensure that the test continues as normal.

## Test Result

Not yet validated.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
