### PR TITLE
fix(ci): add tiny-test-fast variant that uses single arch image

### DIFF
--- a/.github/scripts/spur-tiny-test.sh
+++ b/.github/scripts/spur-tiny-test.sh
@@ -16,7 +16,15 @@ set -euo pipefail
 # The tiny model uses the cluster-wide HF cache so it is downloaded once and
 # reused across CI workflows and SPUR accounts.
 
-SHA="${1:?usage: $0 <full-sha>}"
+SHA="${1:?usage: $0 <full-sha> [tiny-test|tiny-test-fast]}"
+AIC_TINY_TEST_TARGET="${2:-tiny-test}"
+case "${AIC_TINY_TEST_TARGET}" in
+    tiny-test | tiny-test-fast) ;;
+    *)
+        echo "ERROR: unsupported tiny-test target: ${AIC_TINY_TEST_TARGET}" >&2
+        exit 2
+        ;;
+esac
 SHORT="${SHA:0:7}"
 AIC_IMAGE="rocm-aic-ci-${SHORT}:latest"
 AIC_SPUR_HOST="${AIC_SPUR_HOST:?AIC_SPUR_HOST must be set (e.g. via GitHub repo variable)}"
@@ -30,6 +38,7 @@ ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=4 "${AIC_SPUR_HOST}" env \
     SHA="${SHA}" \
     REPO="${REPO}" \
     AIC_IMAGE="${AIC_IMAGE}" \
+    AIC_TINY_TEST_TARGET="${AIC_TINY_TEST_TARGET}" \
     AIC_SHARED_NFS="${AIC_SHARED_NFS}" \
     KEEP_ARTIFACTS="${KEEP_ARTIFACTS}" \
     AIC_SPUR_CONTROLLER="${AIC_SPUR_CONTROLLER}" \
@@ -65,14 +74,14 @@ if [[ ! -d "${WORKDIR}" || "${ACTUAL_SHA}" != "${SHA}" ]]; then
     git -C "${WORKDIR}" checkout "${SHA}"
 fi
 
-echo "=== Running tiny-test (AIC_IMAGE=${AIC_IMAGE}) ==="
+echo "=== Running ${AIC_TINY_TEST_TARGET} (AIC_IMAGE=${AIC_IMAGE}) ==="
 AIC_SPUR_CLUSTER=1 \
     AIC_IMAGE="${AIC_IMAGE}" \
     AIC_IMAGE_DIR="${TARBALL_DIR}" \
     HF_TOKEN="${HF_TOKEN:-}" \
-    make -C "${WORKDIR}" tiny-test
+    make -C "${WORKDIR}" "${AIC_TINY_TEST_TARGET}"
 
-echo "=== tiny-test complete ==="
+echo "=== ${AIC_TINY_TEST_TARGET} complete ==="
 REMOTE
 
 echo "Tiny test passed for ${SHORT}"

--- a/.github/workflows/aic-amd-dist-build-fast.yml
+++ b/.github/workflows/aic-amd-dist-build-fast.yml
@@ -248,8 +248,8 @@ jobs:
               description: 'Running tiny-model end-to-end serve on SPUR head node...',
             });
 
-      - name: Run tiny-test on SPUR head node
-        run: bash /usr/local/lib/aic-ci/spur-tiny-test.sh "${{ needs.authorize.outputs.sha }}"
+      - name: Run fast tiny-test on SPUR head node
+        run: bash /usr/local/lib/aic-ci/spur-tiny-test.sh "${{ needs.authorize.outputs.sha }}" tiny-test-fast
 
       - name: Set commit status on success
         if: success() && needs.authorize.outputs.pr_number != ''

--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,7 @@ EXPORT_TARBALL ?= $(CURDIR)/$(EXPORT_PREFIX)-$(_GEN_DATE)-$(_GIT_SHORT_REV)$(_GI
         ps shell-lmcache shell-vllm restart-vllm restart-lmcache cliff plot venv \
         monitoring-up monitoring-down monitoring-logs monitoring-build-exporters \
         dist-build dist-build-fast dist-build-exporters dist-push smoke-test smoke-test-fast \
-        tiny-test install-ci-scripts cliff-submit cliff-short \
+        tiny-test tiny-test-fast install-ci-scripts cliff-submit cliff-short \
         cliff-long-64k cliff-long-128k \
         export _check_hf_token _prep_dirs _check_gds_slab
 
@@ -232,6 +232,7 @@ help:
 	@echo "                          to logs/<job-id>/prometheus; AIC_SMOKE_EXPORTERS=0 skips)"
 	@echo "  make smoke-test-fast   Smoke-test the single-arch dev image (AIC_FAST_ARCH=$(AIC_FAST_ARCH))"
 	@echo "  make tiny-test         End-to-end serve check (MP stack + tiny model, one completion)"
+	@echo "  make tiny-test-fast    Fast variant of tiny-test"
 	@echo "  make install-ci-scripts  Deploy .github/scripts/spur-*.sh to $(AIC_CI_LIB_DIR) (sudo if needed)"
 	@echo "  make cliff-submit      sbatch the full 3-arm cliff sweep -> logs/<job-id>/"
 	@echo "  make cliff-short       sbatch a 1-point cliff (concur=1, 1 iter) to smoke-test the flow"
@@ -469,6 +470,11 @@ tiny-test:                     # End-to-end serve check: MP stack + a tiny model
 	@# waits for the endpoint, and asserts one non-empty chat completion.  Fast
 	@# functional gate that exercises the connector path a smoke-test cannot.
 	"$(DIST)" tiny-test
+
+tiny-test-fast:
+	@# Must pin the SAME AIC_ROCM_ARCH as dist-build-fast and smoke-test-fast.
+	@$(MAKE) --no-print-directory tiny-test \
+	    AIC_ROCM_ARCH='$(AIC_FAST_ARCH)'
 
 install-ci-scripts:            # Deploy .github/scripts/spur-*.sh to the runner's AIC_CI_LIB_DIR
 	@set -e; \


### PR DESCRIPTION
## Motivation

The tiny-test CI check fails because it looks for a docker image that is named with multiple gfx architectures.

## Technical Details

N/A

## Test Plan

Update the scripts on the runners, run CI again using `/run-ci-fast`.

## Test Result

N/A, let's see how CI goes.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
