### PR TITLE
fix(compose): share private IPC between LMCache and vLLM

### DIFF
--- a/.slurm/run-build-distribute.sh
+++ b/.slurm/run-build-distribute.sh
@@ -1147,6 +1147,7 @@ export LMCACHE_L1_SIZE_GB=4
 # /tmp (AIS_MT/GDS and file-based L2 need a real NVMe/GDS volume). tiny-test only
 # needs to prove the LMCacheMPConnector round-trip + serve works end-to-end.
 export AIC_L2_BACKEND=none
+export VLLM_IPC_MODE=service:lmcache
 export VLLM_PID_MODE=service:lmcache
 export KV_TRANSFER_ARG="--kv-transfer-config '{\"kv_connector\":\"LMCacheMPConnector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"lmcache.mp.host\":\"tcp://localhost\",\"lmcache.mp.port\":6555}}'"
 mkdir -p "\${HF_HOME}" /tmp/aic-tiny-nvme /tmp/aic-tiny-nfs

--- a/.slurm/run-cliff.sbatch
+++ b/.slurm/run-cliff.sbatch
@@ -656,6 +656,7 @@ run_arm_vram() {
   log "=== Arm A (vram_only): plain vLLM (no LMCache) on :${VLLM_ENDPOINT_PORT} ==="
   export KV_TRANSFER_ARG="" # no connector -> plain VRAM-prefix-cache-only vLLM
   export GDS_MODE=""
+  export VLLM_IPC_MODE=shareable # private IPC ns; no lmcache IPC ns to join
   export VLLM_PID_MODE="" # vllm runs alone; no lmcache PID ns to join
   if ! compose up -d vllm; then
     log "Arm A: compose up vllm failed"
@@ -713,6 +714,7 @@ run_arm_kvd() { # $1=mode(nvme|gds) $2=out_csv
   local _fp=""
   [[ -n "${AIC_KV_LOAD_FAILURE_POLICY}" ]] && _fp=",\"kv_load_failure_policy\":\"${AIC_KV_LOAD_FAILURE_POLICY}\""
   export KV_TRANSFER_ARG="--kv-transfer-config '{\"kv_connector\":\"LMCacheMPConnector\",\"kv_role\":\"kv_both\"${_fp},\"kv_connector_extra_config\":{\"lmcache.mp.host\":\"tcp://localhost\",\"lmcache.mp.port\":${LMCACHE_PORT}}}'"
+  export VLLM_IPC_MODE=service:lmcache # join lmcache IPC ns for cross-container HIP IPC
   export VLLM_PID_MODE=service:lmcache # share lmcache PID ns for cross-container HIP IPC
 
   local _l2desc

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -22,6 +22,7 @@ HTTPS
 HuggingFace
 Huggingface
 InfiniBand
+IPC
 JSON
 KV
 LLM
@@ -99,6 +100,7 @@ manylinux
 md
 mem
 mnt
+namespace
 nfs
 nixl
 nvme

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -26,8 +26,9 @@
 #   .slurm/run-build-distribute.sh     — tiny-test end-to-end serve
 #
 # The lmcache service sits behind the `cache` compose profile, so the plain
-# `vram` baseline can start `vllm` alone (`docker compose up vllm`) without
-# pulling in lmcache — vllm's depends_on uses `required: false` for that.
+# `vram` baseline can start `vllm` alone
+# (`VLLM_IPC_MODE=shareable docker compose up vllm`) without pulling in lmcache
+# — vllm's depends_on uses `required: false` for that.
 #
 # Required env:
 #   ROCM_ARCH      — e.g. gfx942
@@ -43,6 +44,9 @@
 #                            LocalDiskBackend via LMCACHE_CONFIG_FILE), or none (DRAM-only L1)
 #   LMCACHE_CONFIG_FILE_HOST — host path to an LMCache YAML config to mount (advanced; local_disk)
 #   KV_TRANSFER_ARG        — vLLM --kv-transfer-config arg (empty = plain vLLM baseline)
+#   VLLM_IPC_MODE          — vLLM IPC mode (default: service:lmcache; use shareable
+#                            when starting vllm without the lmcache service)
+#   AIC_SHM_SIZE           — private /dev/shm capacity (default: 64gb)
 #   HF_HOME                — host HF cache dir (default: ~/.cache/huggingface)
 #   LOG                    — host log dir (default: ../logs, i.e. /logs)
 #   IMAGE_REF              — full image ref name:tag (default: rocm-aic:latest;
@@ -99,14 +103,16 @@ services:
     image: ${IMAGE_REF:-${IMAGE_NAME:-rocm-aic}:latest}
     container_name: aic-lmcache
     # Cross-container HIP IPC (LMCacheMPConnector registering vLLM's KV tensors) on
-    # ROCm requires the two containers to share host networking + host IPC + a PID
-    # namespace.  lmcache owns its (default) PID namespace here; the vllm service
-    # JOINS it via `pid: service:lmcache` (see below) rather than both using host
-    # PID -- host PID makes `docker rm` hang on teardown, container-shared does not.
+    # ROCm requires the two containers to share host networking + IPC + a PID
+    # namespace.  lmcache owns shareable IPC and its default PID namespace here;
+    # the vllm service JOINS both via `ipc: service:lmcache` and
+    # `pid: service:lmcache` (see below), rather than either using host IPC/PID.
+    # Host PID makes `docker rm` hang on teardown; container-shared does not.
     # A bridge network fails IPC (hipErrorInvalidContext); host net is required.
     # Ports exposed on the host: lmcache 8080, NIXL telemetry ${NIXL_METRICS_PORT:-19090}.
     network_mode: host
-    ipc: host
+    ipc: shareable
+    shm_size: "${AIC_SHM_SIZE:-64gb}"
     cap_add:
       - CAP_SYS_ADMIN
       - SYS_PTRACE
@@ -221,13 +227,16 @@ services:
   vllm:
     image: ${IMAGE_REF:-${IMAGE_NAME:-rocm-aic}:latest}
     container_name: aic-vllm-gpu${GPU:-0}
-    # host net + host IPC + shared PID ns with lmcache: required for cross-container
-    # HIP IPC KV registration (see the lmcache service).  kvd arms set
-    # VLLM_PID_MODE=service:lmcache so vllm joins lmcache's PID namespace; the plain
-    # vram baseline leaves it empty (vllm runs alone, no lmcache to join).
+    # host net + shared IPC/PID namespaces with lmcache: required for cross-container
+    # HIP IPC KV registration (see the lmcache service).  vllm joins lmcache's
+    # shareable IPC namespace by default; cache-backed launch paths also set
+    # VLLM_PID_MODE=service:lmcache so it joins lmcache's PID namespace.  Set
+    # VLLM_IPC_MODE=shareable when starting vllm alone for the plain baseline.
     # vLLM OpenAI API + /metrics on host :8000.
     network_mode: host
-    ipc: host
+    ipc: "${VLLM_IPC_MODE:-service:lmcache}"
+    # Applied when vllm owns its IPC namespace; ignored when it joins lmcache.
+    shm_size: "${AIC_SHM_SIZE:-64gb}"
     pid: "${VLLM_PID_MODE:-}"
     cap_add:
       - CAP_SYS_ADMIN

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -11,6 +11,8 @@
 | `GDS_MODE` | — | Set to `1` to enable GDS L1 mode |
 | `AIC_L2_BACKEND` | `nixl` | LMCache L2 backend: `nixl` (AIS_MT NVMe + POSIX NFS) or `local_disk` (native LocalDiskBackend via a mounted config) |
 | `KV_TRANSFER_ARG` | LMCacheMPConnector JSON | vLLM `--kv-transfer-config` arg; empty = plain vLLM (the cliff `vram` baseline). Wrap the JSON in single quotes |
+| `VLLM_IPC_MODE` | `service:lmcache` | vLLM IPC namespace mode. Cache-backed runs join LMCache's shareable namespace; use `shareable` when launching vLLM alone |
+| `AIC_SHM_SIZE` | `64gb` | Capacity of the private `/dev/shm` used by LMCache and vLLM; increase if LMCache's L1 request is larger |
 | `LMCACHE_L1_SIZE_GB` | `20` | MP server L1 cap in GiB (DRAM L1 in nvme mode, hipFile slab size in GDS mode) |
 | `LMCACHE_NVME_POOL` | `4096` | NIXL pool slots for NVMe adapter |
 | `LMCACHE_NVME_SLOT_SIZE` | `268435456` | NIXL file size per NVMe pool slot, bytes (256 MiB) |


### PR DESCRIPTION
## Motivation

Avoids sharing the host IPC namespace to satisfy common container security policy restrictions.

## Technical Details

Straightforward changes as per motivation.

## Test Plan

Manual docker compose test.

## Test Result

Successful launch and operation.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
