### PR TITLE
monitoring: add LMCache MP coordinator with Prometheus exporter

### DIFF
--- a/.slurm/run-build-distribute.sh
+++ b/.slurm/run-build-distribute.sh
@@ -201,6 +201,8 @@ else
     AIC_BUILD_CONSTRAINT="${AIC_BUILD_CONSTRAINT:-CPUONLY}"
     AIC_TEST_CONSTRAINT="${AIC_TEST_CONSTRAINT:-GFX942&NVME}"
 fi
+AIC_SLURM_ACCOUNT="${AIC_SLURM_ACCOUNT:-}"
+AIC_PIP_WHEELS_DIR="${AIC_PIP_WHEELS_DIR:-}"
 AIC_BUILD_CPUS="${AIC_BUILD_CPUS:-32}"
 AIC_BUILD_TIME="${AIC_BUILD_TIME:-02:00:00}"
 AIC_LOAD_TIME="${AIC_LOAD_TIME:-00:30:00}"
@@ -339,6 +341,7 @@ PROLOGUE
             --controller="${AIC_SPUR_CONTROLLER}" \
             --job-name="${jobname}" \
             --partition="${AIC_BUILD_PARTITION}" \
+            ${AIC_SLURM_ACCOUNT:+--account="${AIC_SLURM_ACCOUNT}"} \
             --output=/dev/null \
             "$@" \
             "${tmpscript}" 2>&1)" || { rm -f "${tmpscript}"; die "sbatch submission failed: ${submit_out}"; }
@@ -431,6 +434,7 @@ PROLOGUE
         "${_stdbuf[@]}" sbatch --parsable --wait \
             --job-name="${jobname}" \
             --partition="${AIC_BUILD_PARTITION}" \
+            ${AIC_SLURM_ACCOUNT:+--account="${AIC_SLURM_ACCOUNT}"} \
             --output=/dev/null \
             "$@" \
             <<<"${script}" >"${idfile}" &
@@ -551,6 +555,18 @@ cmd_build() {
         _builder_setup="${_pre}${_mkdir}if ! docker buildx inspect ${AIC_BUILDX_BUILDER} >/dev/null 2>&1; then echo '[build] creating buildx builder ${AIC_BUILDX_BUILDER} (docker-container)'; docker buildx create --name ${AIC_BUILDX_BUILDER} --driver docker-container${_cfg_arg} >/dev/null; fi; docker buildx inspect --bootstrap ${AIC_BUILDX_BUILDER} >/dev/null"
     fi
 
+    # pip-wheels build context: supply a local wheel cache dir to skip the 6 GB
+    # torch download.  If AIC_PIP_WHEELS_DIR is unset, fall back to an empty
+    # sentinel dir on shared storage so BuildKit does not try to pull the
+    # non-existent docker.io/library/pip-wheels image.
+    local _pip_wheels_dir="${AIC_PIP_WHEELS_DIR}"
+    if [[ -z "${_pip_wheels_dir}" ]]; then
+        _pip_wheels_dir="${AIC_DAY_DIR}/.empty-pip-wheels"
+        mkdir -p "${_pip_wheels_dir}"
+    fi
+    local _pip_wheels_arg="--build-context pip-wheels=${_pip_wheels_dir}"
+    log "pip-wheels context: ${_pip_wheels_dir}"
+
     # The build + save block runs on ONE node so the saved tarball comes from the
     # image that was just built.  Values are baked in here (not passed via env)
     # to keep it robust regardless of sbatch environment propagation.
@@ -590,6 +606,7 @@ docker buildx build --builder ${AIC_BUILDX_BUILDER} --progress=plain --output ty
     ${_version_build_args} \
     ${_secret_arg} \
     ${_cache_args} \
+    ${_pip_wheels_arg} \
     -f "${AIC_DAY_DIR}/docker/Dockerfile" \
     -t "${AIC_IMAGE}" \
     -t "${latest_ref}" \

--- a/Makefile
+++ b/Makefile
@@ -470,13 +470,13 @@ venv:
 	@echo "Activate: source $(REPO_ROOT)/.venv/bin/activate"
 
 vllm-reset-test: _check_hf_token _prep_dirs
-	@echo "Starting LMCache L1+L2 retrieval test with small L1 (1 GiB) + NIXL POSIX L2..."
+	@echo "Starting LMCache L1+L2 retrieval test (L1=$(LMCACHE_L1_SIZE_GB)GiB) + NIXL POSIX L2..."
 	@mkdir -p "$(AIC_METRICS_DIR)"
 	PROM_UID="$$(id -u)" PROM_GID="$$(id -g)" \
-	    LMCACHE_L1_SIZE_GB=1 \
+	    LMCACHE_L1_SIZE_GB=$(LMCACHE_L1_SIZE_GB) \
 	    VLLM_EXTRA_ARGS="--enforce-eager $${VLLM_EXTRA_ARGS}" \
-	    AIC_L2_BACKEND=nixl_posix \
-	    $(COMPOSE_CACHE) --profile monitoring up -d --no-recreate
+	    AIC_L2_BACKEND=$(AIC_L2_BACKEND) \
+	    $(COMPOSE_CACHE) --profile monitoring up -d
 	@echo "Waiting for vLLM to be healthy..."
 	@for i in $$(seq 1 60); do \
 	    r=$$(docker exec aic-client curl -s -o /dev/null -w '%{http_code}' \

--- a/Makefile
+++ b/Makefile
@@ -476,7 +476,7 @@ vllm-reset-test: _check_hf_token _prep_dirs
 	    LMCACHE_L1_SIZE_GB=1 \
 	    VLLM_EXTRA_ARGS="--enforce-eager $${VLLM_EXTRA_ARGS}" \
 	    AIC_L2_BACKEND=nixl_posix \
-	    $(COMPOSE_CACHE) --profile monitoring up -d
+	    $(COMPOSE_CACHE) --profile monitoring up -d --no-recreate
 	@echo "Waiting for vLLM to be healthy..."
 	@for i in $$(seq 1 60); do \
 	    r=$$(docker exec aic-client curl -s -o /dev/null -w '%{http_code}' \

--- a/Makefile
+++ b/Makefile
@@ -579,6 +579,7 @@ monitoring-build-exporters:
 	@echo "Run them via:  AIC_EXPORTERS=1 with --profile exporters-fabric, or set"
 	@echo "AIC_NVME_EXPORTER_IMAGE / AIC_RDMA_EXPORTER_IMAGE for the .slurm docker-run path."
 
+
 # ---- Distribute / cliff (Slurm) --------------------------------------------
 # Thin wrappers over .slurm/run-build-distribute.sh (build/push/test on a Slurm
 # node) and `sbatch .slurm/run-cliff.sbatch` (the full cliff sweep).  These

--- a/benchmarks/vllm_reset_test.py
+++ b/benchmarks/vllm_reset_test.py
@@ -197,7 +197,7 @@ def main():
     dummy = post_json(f"{VLLM}/v1/chat/completions", {
         "model": MODEL, "messages": [{"role": "user", "content": "hi"}],
         "max_tokens": 5, "temperature": 0.0,
-    }, timeout=30)
+    }, timeout=TIMEOUT)
     if dummy is None or "choices" not in dummy:
         log("ERROR: vLLM not responding or model not loaded", prefix="✗ ")
         sys.exit(1)

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -69,6 +69,16 @@
 #                                  Should match actual KV chunk bytes; smaller than AIS_MT's 256 MiB.
 #   LMCACHE_NIXL_POSIX_POOL      — pool slot count for the POSIX backend (default: 32768).
 #   LMCACHE_MAX_GPU_WORKERS      — lmcache --max-gpu-workers for parallel STORE/RETRIEVE (default: 1).
+#   LMCACHE_COORDINATOR_URL      — base URL the MP server registers/heartbeats against
+#                                  (default: http://aic-lmcache-coordinator:9300).
+#                                  Unset to disable coordinator registration entirely.
+#   LMCACHE_COORDINATOR_PORT     — coordinator HTTP port (default: 9300); /metrics on COORDINATOR_METRICS_PORT (default: 9301).
+#   COORDINATOR_METRICS_PORT     — Prometheus /metrics port on the coordinator container (default: 9301).
+#   LMCACHE_COORDINATOR_INSTANCE_TIMEOUT — seconds without heartbeat before instance eviction (default: 120).
+#   LMCACHE_COORDINATOR_HEALTH_INTERVAL  — seconds between heartbeat-sweep runs (default: 10).
+#   LMCACHE_COORDINATOR_EVICTION_INTERVAL — seconds between L2 eviction-check runs (default: 5).
+#   LMCACHE_COORDINATOR_KEEPALIVE — uvicorn keep-alive timeout in seconds (default: 65).
+#   LMCACHE_CHUNK_SIZE           — tokens per KV chunk; must match MP server and coordinator (default: 256).
 #   VLM_GPU_MEMORY_UTILIZATION — vllm --gpu-memory-utilization (default: 0.90)
 #   VLM_MAX_MODEL_LEN          — vllm --max-model-len (default: 32768)
 #   VLM_MAX_NUM_BATCHED_TOKENS — vllm --max-num-batched-tokens (default: 4096)
@@ -176,6 +186,10 @@ services:
       - LMCACHE_NIXL_POSIX_POOL=${LMCACHE_NIXL_POSIX_POOL:-32768}
       - LMCACHE_MAX_GPU_WORKERS=${LMCACHE_MAX_GPU_WORKERS:-1}
       - LMCACHE_L2_PREFETCH_MAX_IN_FLIGHT=${LMCACHE_L2_PREFETCH_MAX_IN_FLIGHT:-4}
+      # Coordinator registration: the MP server registers, heartbeats, and
+      # deregisters against the coordinator so it can track which blocks are held.
+      # Unset LMCACHE_COORDINATOR_URL to run without coordinator (standalone mode).
+      - LMCACHE_COORDINATOR_URL=${LMCACHE_COORDINATOR_URL:-http://aic-lmcache-coordinator:9300}
       # Only set when a real config file is mounted (local_disk / advanced tuning).
       - LMCACHE_CONFIG_FILE=${LMCACHE_CONFIG_FILE:-}
       - HIPFILE_ALLOW_COMPAT_MODE=false
@@ -200,6 +214,11 @@ services:
     entrypoint: ["/bin/bash", "-o", "pipefail", "-c"]
     command:
       - |
+        # Build coordinator flags once; empty when LMCACHE_COORDINATOR_URL is unset.
+        _COORD_FLAGS=""
+        if [ -n "$${LMCACHE_COORDINATOR_URL:-}" ]; then
+          _COORD_FLAGS="--coordinator-url $$LMCACHE_COORDINATOR_URL --coordinator-event-reporting"
+        fi
         if [ "${GDS_MODE:-0}" = "1" ]; then
           exec lmcache server \
             --no-separate-object-groups \
@@ -210,7 +229,8 @@ services:
             --eviction-policy LRU \
             --max-gpu-workers "$${LMCACHE_MAX_GPU_WORKERS:-1}" \
             --worker-reap-timeout-seconds "$${LMCACHE_WORKER_REAP_TIMEOUT:-3600}" \
-            --gds-l1-path /data/slab
+            --gds-l1-path /data/slab \
+            $$_COORD_FLAGS
         elif [ "$$AIC_L2_BACKEND" = "local_disk" ] || [ "$$AIC_L2_BACKEND" = "none" ]; then
           # DRAM L1 only on the CLI.  local_disk adds a native LocalDiskBackend L2
           # via the mounted LMCACHE_CONFIG_FILE; none = pure DRAM (the minimal MP
@@ -223,7 +243,8 @@ services:
             --l1-size-gb "$$LMCACHE_L1_SIZE_GB" \
             --eviction-policy LRU \
             --max-gpu-workers "$${LMCACHE_MAX_GPU_WORKERS:-1}" \
-            --worker-reap-timeout-seconds "$${LMCACHE_WORKER_REAP_TIMEOUT:-3600}"
+            --worker-reap-timeout-seconds "$${LMCACHE_WORKER_REAP_TIMEOUT:-3600}" \
+            $$_COORD_FLAGS
         elif [ "$${AIC_NIXL_BACKEND:-AIS_MT}" = "POSIX" ] || [ "$$AIC_L2_BACKEND" = "nixl_posix" ]; then
           # NIXL first-class POSIX plugin (cpu staging buffer, no hipFileBufRegister).
           # Use for nodes where GPUDirect P2PDMA is unavailable (e.g. XFS LVM).
@@ -239,7 +260,8 @@ services:
             --max-gpu-workers "$${LMCACHE_MAX_GPU_WORKERS:-1}" \
             --l2-prefetch-max-in-flight "$${LMCACHE_L2_PREFETCH_MAX_IN_FLIGHT:-4}" \
             --worker-reap-timeout-seconds "$${LMCACHE_WORKER_REAP_TIMEOUT:-3600}" \
-            --l2-adapter "{\"type\":\"nixl_store\",\"backend\":\"POSIX\",\"backend_params\":{\"file_path\":\"/data/nvme/lmcache\",\"use_direct_io\":\"false\",\"file_size\":\"$$LMCACHE_NIXL_POSIX_SLOT_SIZE\"},\"pool_size\":$$LMCACHE_NIXL_POSIX_POOL}"
+            --l2-adapter "{\"type\":\"nixl_store\",\"backend\":\"POSIX\",\"backend_params\":{\"file_path\":\"/data/nvme/lmcache\",\"use_direct_io\":\"false\",\"file_size\":\"$$LMCACHE_NIXL_POSIX_SLOT_SIZE\"},\"pool_size\":$$LMCACHE_NIXL_POSIX_POOL}" \
+            $$_COORD_FLAGS
         else
           # nixl AIS_MT NVMe L2a + POSIX NFS L2b.  Both are file-based nixl_store
           # backends, so both backend_params MUST include use_direct_io (LMCache
@@ -254,8 +276,15 @@ services:
             --max-gpu-workers "$${LMCACHE_MAX_GPU_WORKERS:-1}" \
             --worker-reap-timeout-seconds "$${LMCACHE_WORKER_REAP_TIMEOUT:-3600}" \
             --l2-adapter "{\"type\":\"nixl_store\",\"backend\":\"AIS_MT\",\"backend_params\":{\"file_path\":\"/data/nvme/lmcache\",\"use_direct_io\":\"$$AIC_NIXL_USE_DIRECT_IO\",\"file_size\":\"$$LMCACHE_NVME_SLOT_SIZE\"},\"pool_size\":$$LMCACHE_NVME_POOL}" \
-            --l2-adapter "{\"type\":\"nixl_store\",\"backend\":\"POSIX\",\"backend_params\":{\"file_path\":\"/data/nfs/lmcache\",\"use_direct_io\":\"false\"},\"pool_size\":$$LMCACHE_NFS_POOL}"
+            --l2-adapter "{\"type\":\"nixl_store\",\"backend\":\"POSIX\",\"backend_params\":{\"file_path\":\"/data/nfs/lmcache\",\"use_direct_io\":\"false\"},\"pool_size\":$$LMCACHE_NFS_POOL}" \
+            $$_COORD_FLAGS
         fi
+    depends_on:
+      lmcache-coordinator:
+        condition: service_healthy
+        # required:false so standalone runs (LMCACHE_COORDINATOR_URL unset) don't
+        # block if the coordinator is somehow skipped from the active profile.
+        required: false
     healthcheck:
       test:
         - CMD
@@ -265,6 +294,43 @@ services:
       interval: 10s
       timeout: 5s
       retries: 18
+      start_period: 30s
+
+  # ---------------------------------------------------------------------------
+  # lmcache-coordinator: LMCache MP coordinator + Prometheus exporter in one
+  # container.  Uses the same rocm-aic image as lmcache (lmcache's dep tree
+  # cannot be split from the GPU wheels at import time) but runs no GPU
+  # workloads — no devices, no mounts, no IPC namespace needed.
+  # REST API on :9300; /metrics (Prometheus) on :9301.
+  # Behind the `cache` profile alongside lmcache.
+  # ---------------------------------------------------------------------------
+  lmcache-coordinator:
+    profiles:
+      - cache
+    image: ${IMAGE_REF:-${IMAGE_NAME:-rocm-aic}:latest}
+    container_name: aic-lmcache-coordinator
+    networks: [aic]
+    restart: unless-stopped
+    environment:
+      - LMCACHE_DISABLE_BANNER=1
+      - LMCACHE_COORDINATOR_PORT=${LMCACHE_COORDINATOR_PORT:-9300}
+      - COORDINATOR_METRICS_PORT=${COORDINATOR_METRICS_PORT:-9301}
+      - LMCACHE_COORDINATOR_INSTANCE_TIMEOUT=${LMCACHE_COORDINATOR_INSTANCE_TIMEOUT:-120}
+      - LMCACHE_COORDINATOR_HEALTH_INTERVAL=${LMCACHE_COORDINATOR_HEALTH_INTERVAL:-10}
+      - LMCACHE_COORDINATOR_EVICTION_INTERVAL=${LMCACHE_COORDINATOR_EVICTION_INTERVAL:-5}
+      - LMCACHE_COORDINATOR_KEEPALIVE=${LMCACHE_COORDINATOR_KEEPALIVE:-65}
+      - LMCACHE_CHUNK_SIZE=${LMCACHE_CHUNK_SIZE:-256}
+      - TZ=${TZ:-America/Edmonton}
+    volumes:
+      - ../monitoring/scripts/lmcache_coordinator_entrypoint.py:/app/entrypoint.py:ro
+    entrypoint: ["python3", "/app/entrypoint.py"]
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - "python3 -c \"import urllib.request; urllib.request.urlopen('http://127.0.0.1:${LMCACHE_COORDINATOR_PORT:-9300}/healthz', timeout=2)\""
+      interval: 10s
+      timeout: 5s
+      retries: 12
       start_period: 30s
 
   # ---------------------------------------------------------------------------

--- a/monitoring/grafana/dashboards/aic-overview.json
+++ b/monitoring/grafana/dashboards/aic-overview.json
@@ -2125,7 +2125,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(rdma_port_data_received_bytes_total[$__rate_interval])",
+          "expr": "rate(rdma_port_rcv_data_total[$__rate_interval])",
           "legendFormat": "RX {{device}} p{{port}}"
         },
         {
@@ -2133,7 +2133,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(rdma_port_data_transmitted_bytes_total[$__rate_interval])",
+          "expr": "rate(rdma_port_xmit_data_total[$__rate_interval])",
           "legendFormat": "TX {{device}} p{{port}}"
         }
       ],
@@ -3205,7 +3205,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Requests per second to the LMCache FastAPI HTTP server by handler and status. /v1/chat/completions is the main vLLM\u2192LMCache path; /health is the readiness probe. A drop in 2xx rates or appearance of 4xx/5xx indicates the LMCache server is unhealthy.",
+      "description": "Rates of LMCache internal operations. prefetch requests = cache lookup operations initiated by vLLM; L2 store submitted = KV chunks being written to NVMe; L2 load submitted = NVMe prefetch reads back to L1.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -3226,7 +3226,7 @@
         "y": 152
       },
       "id": 93,
-      "title": "LMCache HTTP API Request Rate",
+      "title": "LMCache Operation Rate",
       "options": {
         "tooltip": {
           "mode": "multi"
@@ -3238,8 +3238,27 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (handler, status) (rate(http_requests_total[$__rate_interval]))",
-          "legendFormat": "{{handler}} {{status}}"
+          "expr": "sum(rate(lmcache_mp_prefetch_requests_total{job=\"lmcache\"}[$__rate_interval]))",
+          "legendFormat": "prefetch lookups/s",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(lmcache_mp_l2_store_submitted_requests_total{job=\"lmcache\"}[$__rate_interval]))",
+          "legendFormat": "L2 store submitted/s",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(lmcache_mp_l2_prefetch_load_submitted_requests_total{job=\"lmcache\"}[$__rate_interval]))",
+          "legendFormat": "L2 load submitted/s",
+          "refId": "C"
         }
       ],
       "type": "timeseries"
@@ -3249,7 +3268,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "FastAPI request duration p50 and p95 per handler. High latency on /v1/chat/completions indicates LMCache is a bottleneck in the inference path \u2014 investigate L1 lookup time, L2 prefetch latency, or NIXL queue depth.",
+      "description": "Throughput of KV tensor transfers between GPU (L0) and DRAM (L1). Store: GPU\u2192DRAM (KV written to lmcache L1 after prefill). Load: DRAM\u2192GPU (KV retrieved from L1 for reuse). Source: lmcache_mp_l0_l1_store/load_throughput_GB_per_second histograms.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -3259,7 +3278,7 @@
             "lineWidth": 1,
             "fillOpacity": 10
           },
-          "unit": "s"
+          "unit": "Bps"
         },
         "overrides": []
       },
@@ -3270,7 +3289,7 @@
         "y": 152
       },
       "id": 94,
-      "title": "LMCache HTTP API Latency p50 / p95 (s)",
+      "title": "LMCache L0\u2192L1 Throughput (GB/s)",
       "options": {
         "tooltip": {
           "mode": "multi"
@@ -3282,16 +3301,18 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.5, sum by (handler, le) (rate(http_request_duration_seconds_bucket[$__rate_interval])))",
-          "legendFormat": "p50 {{handler}}"
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(lmcache_mp_l0_l1_store_throughput_GB_per_second_bucket{job=\"lmcache\"}[$__rate_interval])))",
+          "legendFormat": "store p50 (GB/s)",
+          "refId": "A"
         },
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum by (handler, le) (rate(http_request_duration_seconds_bucket[$__rate_interval])))",
-          "legendFormat": "p95 {{handler}}"
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(lmcache_mp_l0_l1_load_throughput_GB_per_second_bucket{job=\"lmcache\"}[$__rate_interval])))",
+          "legendFormat": "load p50 (GB/s)",
+          "refId": "B"
         }
       ],
       "type": "timeseries"
@@ -4488,7 +4509,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "L2 byte usage tracked by the coordinator per cache_salt. The coordinator tracks this from event-stream STORE/DELETE events; limits are set via PUT /quota/{cache_salt}.",
+      "description": "KV chunk keys tracked in the coordinator key directory. Keys (any placement): unique chunks with at least one placement. Placements total: sum across all instances and backends \u2014 a key held by two servers counts twice. L1 keys: L1-only subset per instance, for comparison against total directory coverage.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -4498,7 +4519,7 @@
             "lineWidth": 2,
             "fillOpacity": 10
           },
-          "unit": "bytes"
+          "unit": "short"
         },
         "overrides": []
       },
@@ -4525,8 +4546,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "lmcache_coordinator_quota_usage_bytes_total{job=\"lmcache_coordinator\"}",
-          "legendFormat": "total L2 usage",
+          "expr": "lmcache_coordinator_directory_keys_total{job=\"lmcache_coordinator\"}",
+          "legendFormat": "keys (any placement)",
           "refId": "A"
         },
         {
@@ -4534,8 +4555,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "lmcache_coordinator_quota_usage_bytes{job=\"lmcache_coordinator\"}",
-          "legendFormat": "{{cache_salt}}",
+          "expr": "lmcache_coordinator_directory_placements_total{job=\"lmcache_coordinator\"}",
+          "legendFormat": "placements total",
           "refId": "B"
         },
         {
@@ -4543,12 +4564,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "lmcache_coordinator_quota_limit_bytes{job=\"lmcache_coordinator\"} > 0",
-          "legendFormat": "limit {{cache_salt}}",
+          "expr": "lmcache_coordinator_instance_l1_keys{job=\"lmcache_coordinator\"}",
+          "legendFormat": "L1 keys {{instance_id}}",
           "refId": "C"
         }
       ],
-      "title": "L2 Usage per Cache Salt (bytes)",
+      "title": "Coordinator Key Directory",
       "type": "timeseries"
     },
     {
@@ -4598,6 +4619,288 @@
         }
       ],
       "title": "Coordinator Exporter Scrape Latency (s)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 191
+      },
+      "id": 408,
+      "title": "LMCache \u2014 Adapter & Transport Health",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Active vs draining L2 store/prefetch adapters. An adapter enters 'draining' when lmcache shuts down or a NIXL init error forces the adapter offline. Sustained draining=1 with active=0 indicates a nixl_posix pool init failure (e.g. stale pool files from a previous run).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 15
+          },
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "store active"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "store draining"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "prefetch active"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "prefetch draining"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 192
+      },
+      "id": 409,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "lmcache_mp_l2_store_adapters{job=\"lmcache\",state=\"active\"}",
+          "legendFormat": "store active",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "lmcache_mp_l2_store_adapters{job=\"lmcache\",state=\"draining\"}",
+          "legendFormat": "store draining",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "lmcache_mp_l2_prefetch_adapters{job=\"lmcache\",state=\"active\"}",
+          "legendFormat": "prefetch active",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "lmcache_mp_l2_prefetch_adapters{job=\"lmcache\",state=\"draining\"}",
+          "legendFormat": "prefetch draining",
+          "refId": "D"
+        }
+      ],
+      "title": "L2 Adapter State (active vs draining)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Average NIXL transfer latency per request = agent_xfer_time_total / agent_tx_requests_num_total. agent_xfer_time_total is in microseconds (Start-to-Complete per request). High values indicate NVMe saturation or NIXL registration overhead.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          },
+          "unit": "\u00b5s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 192
+      },
+      "id": 410,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(agent_xfer_time_total{job=\"nixl\"}[$__rate_interval]) / rate(agent_tx_requests_num_total{job=\"nixl\"}[$__rate_interval])",
+          "legendFormat": "avg xfer latency (\u00b5s/req)",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(agent_xfer_post_time_total{job=\"nixl\"}[$__rate_interval]) / rate(agent_tx_requests_num_total{job=\"nixl\"}[$__rate_interval])",
+          "legendFormat": "avg post-to-backend latency (\u00b5s/req)",
+          "refId": "B"
+        }
+      ],
+      "title": "NIXL Average Transfer Latency (\u00b5s/req)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "L1 allocation failures (lmcache_mp_l1_allocation_failure_total) indicate L1 is full and chunks are being dropped rather than stored \u2014 increase L1 size. Eviction loop triggered (lmcache_mp_l1_eviction_loop_triggered_total) shows when LRU eviction fires above the watermark.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          },
+          "unit": "ops"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "L1 alloc failures/s"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 192
+      },
+      "id": 411,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(lmcache_mp_l1_allocation_failure_chunks_total{job=\"lmcache\"}[$__rate_interval]))",
+          "legendFormat": "L1 alloc failures/s",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(lmcache_mp_l1_eviction_loop_triggered_total{job=\"lmcache\"}[$__rate_interval]))",
+          "legendFormat": "eviction triggered/s",
+          "refId": "B"
+        }
+      ],
+      "title": "L1 Allocation Failures & Eviction Triggers (rate)",
       "type": "timeseries"
     }
   ],

--- a/monitoring/grafana/dashboards/aic-overview.json
+++ b/monitoring/grafana/dashboards/aic-overview.json
@@ -4156,6 +4156,449 @@
         }
       ],
       "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 178
+      },
+      "id": 400,
+      "title": "LMCache Coordinator",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "1 when the LMCache MP coordinator /healthz returns healthy; 0 when unreachable.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 0,
+                  "text": "DOWN"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 1,
+                  "text": "UP"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 179
+      },
+      "id": 401,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "lmcache_coordinator_up{job=\"lmcache_coordinator\"}",
+          "instant": true,
+          "legendFormat": ""
+        }
+      ],
+      "title": "Coordinator Up",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Number of LMCache MP server instances currently registered with the coordinator.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 179
+      },
+      "id": 402,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "lmcache_coordinator_instances_registered{job=\"lmcache_coordinator\"}",
+          "instant": true,
+          "legendFormat": ""
+        }
+      ],
+      "title": "Registered Instances",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Sum across all instances of lmcache_coordinator_instance_seq_gap. Non-zero means at least one MP server had an event-stream sequence gap \u2014 the key directory may have missed some placements.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "OK"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 179
+      },
+      "id": 403,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(lmcache_coordinator_instance_seq_gap{job=\"lmcache_coordinator\"}) or vector(0)",
+          "instant": true,
+          "legendFormat": ""
+        }
+      ],
+      "title": "Event Stream Gaps",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Keys with at least one placement tracked in the coordinator key directory. Growth indicates active KV block advertising from MP servers.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 183
+      },
+      "id": 404,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "lmcache_coordinator_directory_keys_total{job=\"lmcache_coordinator\"}",
+          "legendFormat": "keys",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "lmcache_coordinator_directory_placements_total{job=\"lmcache_coordinator\"}",
+          "legendFormat": "placements",
+          "refId": "B"
+        }
+      ],
+      "title": "Key Directory \u2014 Keys & Placements",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "L1 keys reported by each MP server's event stream to the coordinator key directory. Separate lines per instance_id.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 183
+      },
+      "id": 405,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "lmcache_coordinator_instance_l1_keys{job=\"lmcache_coordinator\"}",
+          "legendFormat": "{{instance_id}}",
+          "refId": "A"
+        }
+      ],
+      "title": "L1 Keys per Instance",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "L2 byte usage tracked by the coordinator per cache_salt. The coordinator tracks this from event-stream STORE/DELETE events; limits are set via PUT /quota/{cache_salt}.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 183
+      },
+      "id": 406,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "lmcache_coordinator_quota_usage_bytes_total{job=\"lmcache_coordinator\"}",
+          "legendFormat": "total L2 usage",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "lmcache_coordinator_quota_usage_bytes{job=\"lmcache_coordinator\"}",
+          "legendFormat": "{{cache_salt}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "lmcache_coordinator_quota_limit_bytes{job=\"lmcache_coordinator\"} > 0",
+          "legendFormat": "limit {{cache_salt}}",
+          "refId": "C"
+        }
+      ],
+      "title": "L2 Usage per Cache Salt (bytes)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Time the coordinator exporter takes to scrape all REST endpoints. Spikes indicate coordinator slowness or network latency.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 5
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 12,
+        "x": 12,
+        "y": 179
+      },
+      "id": 407,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "lmcache_coordinator_scrape_duration_seconds{job=\"lmcache_coordinator\"}",
+          "legendFormat": "scrape latency",
+          "refId": "A"
+        }
+      ],
+      "title": "Coordinator Exporter Scrape Latency (s)",
+      "type": "timeseries"
     }
   ],
   "refresh": "10s",

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -55,6 +55,16 @@ scrape_configs:
     static_configs:
       - targets: ["aic-lmcache:8080"]
 
+  # LMCache coordinator exporter — polls the coordinator REST API (/instances,
+  # /directory/stats, /quota) and emits Prometheus text format on :9301.
+  # Exposes: lmcache_coordinator_up, _instances_registered, _directory_keys_total,
+  # _directory_placements_total, _instance_l1_keys, _instance_seq_gap,
+  # _quota_usage_bytes, _quota_limit_bytes, _scrape_duration_seconds.
+  - job_name: lmcache_coordinator
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["aic-lmcache-coordinator:9301"]
+
   # NIXL native telemetry exporter (agent_tx_bytes_total, agent_errors_total,
   # ...). Present only when the prometheus-cpp plugin is built into the image and
   # NIXL_TELEMETRY_* is set on the LMCache process. Beta; metric names may change.

--- a/monitoring/scripts/lmcache_coordinator_entrypoint.py
+++ b/monitoring/scripts/lmcache_coordinator_entrypoint.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# Combined entrypoint for the LMCache MP coordinator + Prometheus exporter.
+#
+# Runs the coordinator (lmcache.v1.mp_coordinator) in a background thread via
+# uvicorn, and serves /metrics (Prometheus text format) on a second port in the
+# same process.  A single python:3.12-slim container replaces the two heavy
+# rocm-aic containers that were previously used.
+#
+# Env vars (all optional):
+#   LMCACHE_COORDINATOR_PORT        coordinator HTTP port (default: 9300)
+#   COORDINATOR_METRICS_PORT        /metrics port (default: 9301)
+#   LMCACHE_COORDINATOR_INSTANCE_TIMEOUT   seconds before stale instance eviction (default: 120)
+#   LMCACHE_COORDINATOR_HEALTH_INTERVAL    health-check sweep interval (default: 10)
+#   LMCACHE_COORDINATOR_EVICTION_INTERVAL  L2 eviction sweep interval (default: 5)
+#   LMCACHE_COORDINATOR_KEEPALIVE          uvicorn keep-alive timeout (default: 65)
+#   LMCACHE_CHUNK_SIZE                     tokens per KV chunk (default: 256)
+#   LMCACHE_DISABLE_BANNER                 set to 1 to suppress the lmcache banner
+
+import http.server
+import logging
+import os
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+)
+log = logging.getLogger("coordinator")
+
+COORD_PORT = int(os.environ.get("LMCACHE_COORDINATOR_PORT", "9300"))
+METRICS_PORT = int(os.environ.get("COORDINATOR_METRICS_PORT", "9301"))
+COORD_URL = f"http://127.0.0.1:{COORD_PORT}"
+
+
+# ---------------------------------------------------------------------------
+# Prometheus exporter — polls coordinator REST API, serves /metrics
+# ---------------------------------------------------------------------------
+
+def _fetch_json(path: str):
+    try:
+        with urllib.request.urlopen(COORD_URL + path, timeout=5) as r:
+            import json
+            return json.loads(r.read())
+    except Exception as exc:
+        log.debug("fetch %s failed: %s", path, exc)
+        return None
+
+
+def collect_metrics() -> str:
+    t0 = time.monotonic()
+    lines: list[str] = []
+
+    def gauge(name, value, labels=None, help_text=""):
+        lines.append(f"# HELP {name} {help_text}")
+        lines.append(f"# TYPE {name} gauge")
+        ls = ""
+        if labels:
+            ls = "{" + ",".join(f'{k}="{v}"' for k, v in labels.items()) + "}"
+        lines.append(f"{name}{ls} {value}")
+
+    healthz = _fetch_json("/healthz")
+    up = 1.0 if (healthz and healthz.get("status") == "healthy") else 0.0
+    gauge("lmcache_coordinator_up", up,
+          help_text="1 if the LMCache MP coordinator /healthz reports healthy")
+
+    if up < 1.0:
+        gauge("lmcache_coordinator_scrape_duration_seconds",
+              time.monotonic() - t0,
+              help_text="Time in seconds to scrape the LMCache coordinator")
+        return "\n".join(lines) + "\n"
+
+    instances_resp = _fetch_json("/instances")
+    instances = (instances_resp or {}).get("instances", [])
+    lines.append("# HELP lmcache_coordinator_instances_registered Number of MP servers currently registered with the coordinator")
+    lines.append("# TYPE lmcache_coordinator_instances_registered gauge")
+    lines.append(f"lmcache_coordinator_instances_registered {len(instances)}")
+
+    if instances:
+        lines.append("# HELP lmcache_coordinator_instance_info Non-zero for each registered instance; labels carry metadata")
+        lines.append("# TYPE lmcache_coordinator_instance_info gauge")
+        for inst in instances:
+            iid = inst.get("instance_id", "")
+            ip = inst.get("ip", "")
+            port = str(inst.get("http_port", ""))
+            lines.append(f'lmcache_coordinator_instance_info{{instance_id="{iid}",ip="{ip}",http_port="{port}"}} 1')
+
+    dir_stats = _fetch_json("/directory/stats")
+    if dir_stats is not None:
+        gauge("lmcache_coordinator_directory_keys_total",
+              dir_stats.get("num_keys", 0),
+              help_text="Keys with at least one placement in the key directory")
+        gauge("lmcache_coordinator_directory_placements_total",
+              dir_stats.get("num_placements", 0),
+              help_text="Total placements across all tracked keys")
+        inst_stats = dir_stats.get("instances", {})
+        if inst_stats:
+            lines.append("# HELP lmcache_coordinator_instance_l1_keys L1 keys reported per instance")
+            lines.append("# TYPE lmcache_coordinator_instance_l1_keys gauge")
+            lines.append("# HELP lmcache_coordinator_instance_seq_gap 1 if an event-stream gap was detected")
+            lines.append("# TYPE lmcache_coordinator_instance_seq_gap gauge")
+            for iid, s in inst_stats.items():
+                lines.append(f'lmcache_coordinator_instance_l1_keys{{instance_id="{iid}"}} {s.get("num_l1_keys", 0)}')
+                lines.append(f'lmcache_coordinator_instance_seq_gap{{instance_id="{iid}"}} {1 if s.get("gap_detected") else 0}')
+
+    quota_list = _fetch_json("/quota?tier=l2")
+    if quota_list is not None:
+        # API returns {total_gb, by_cache_salt: [{cache_salt, usage_gb, quota_limit_gb, quota_exists}]}
+        GB = 1024 ** 3
+        total_gb = quota_list.get("total_gb", 0)
+        lines.append("# HELP lmcache_coordinator_quota_usage_bytes_total Total L2 usage bytes tracked by coordinator")
+        lines.append("# TYPE lmcache_coordinator_quota_usage_bytes_total gauge")
+        lines.append(f"lmcache_coordinator_quota_usage_bytes_total {total_gb * GB:.0f}")
+        entries = quota_list.get("by_cache_salt", [])
+        if entries:
+            lines.append("# HELP lmcache_coordinator_quota_usage_bytes L2 byte usage per cache_salt")
+            lines.append("# TYPE lmcache_coordinator_quota_usage_bytes gauge")
+            lines.append("# HELP lmcache_coordinator_quota_limit_bytes L2 quota limit per cache_salt; -1 = unlimited")
+            lines.append("# TYPE lmcache_coordinator_quota_limit_bytes gauge")
+            for entry in entries:
+                salt = entry.get("cache_salt", "")
+                usage = entry.get("usage_gb", 0) * GB
+                limit = entry.get("quota_limit_gb", -1)
+                limit_bytes = limit * GB if (limit and limit > 0) else -1
+                lines.append(f'lmcache_coordinator_quota_usage_bytes{{cache_salt="{salt}"}} {usage:.0f}')
+                lines.append(f'lmcache_coordinator_quota_limit_bytes{{cache_salt="{salt}"}} {limit_bytes:.0f}')
+
+    gauge("lmcache_coordinator_scrape_duration_seconds",
+          time.monotonic() - t0,
+          help_text="Time in seconds to scrape the LMCache coordinator REST API")
+
+    return "\n".join(lines) + "\n"
+
+
+class MetricsHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):  # noqa: N802
+        if self.path in ("/metrics", "/metrics/"):
+            body = collect_metrics().encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        elif self.path in ("/healthz", "/health"):
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"ok")
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, fmt, *args):
+        pass
+
+
+def run_metrics_server():
+    server = http.server.HTTPServer(("0.0.0.0", METRICS_PORT), MetricsHandler)
+    log.info("Prometheus exporter listening on :%d/metrics", METRICS_PORT)
+    server.serve_forever()
+
+
+# ---------------------------------------------------------------------------
+# Coordinator — run via uvicorn in this process
+# ---------------------------------------------------------------------------
+
+def run_coordinator():
+    from lmcache.v1.mp_coordinator.app import create_app
+    from lmcache.v1.mp_coordinator.config import MPCoordinatorConfig
+    import uvicorn
+
+    cfg = MPCoordinatorConfig(
+        host="0.0.0.0",
+        port=COORD_PORT,
+        instance_timeout=float(os.environ.get("LMCACHE_COORDINATOR_INSTANCE_TIMEOUT", "120")),
+        health_check_interval=float(os.environ.get("LMCACHE_COORDINATOR_HEALTH_INTERVAL", "10")),
+        eviction_check_interval=float(os.environ.get("LMCACHE_COORDINATOR_EVICTION_INTERVAL", "5")),
+        chunk_size=int(os.environ.get("LMCACHE_CHUNK_SIZE", "256")),
+        timeout_keep_alive=int(os.environ.get("LMCACHE_COORDINATOR_KEEPALIVE", "65")),
+    )
+    app = create_app(cfg)
+    log.info("Starting LMCache coordinator on :%d", COORD_PORT)
+    uvicorn.run(
+        app,
+        host=cfg.host,
+        port=cfg.port,
+        timeout_keep_alive=cfg.timeout_keep_alive,
+        log_level="warning",
+    )
+
+
+if __name__ == "__main__":
+    if os.environ.get("LMCACHE_DISABLE_BANNER") != "1":
+        pass  # banner suppressed via env in compose
+
+    # Start the Prometheus exporter in a daemon thread
+    t = threading.Thread(target=run_metrics_server, daemon=True, name="metrics")
+    t.start()
+
+    # Run the coordinator in the main thread (blocks until shutdown)
+    try:
+        run_coordinator()
+    except KeyboardInterrupt:
+        log.info("Shutting down")
+        sys.exit(0)

--- a/monitoring/scripts/lmcache_coordinator_exporter.py
+++ b/monitoring/scripts/lmcache_coordinator_exporter.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# Prometheus exporter for the LMCache MP coordinator REST API.
+#
+# The coordinator has no native /metrics endpoint; this script polls its JSON
+# REST API (/healthz, /instances, /directory/stats, /quota) and emits
+# Prometheus text-format metrics on --listen-port (default 9301).
+#
+# Metrics exposed:
+#   lmcache_coordinator_up                       — 1 if coordinator is reachable
+#   lmcache_coordinator_instances_registered     — number of live MP instances
+#   lmcache_coordinator_instance_info            — metadata gauge per instance
+#   lmcache_coordinator_directory_keys_total     — keys tracked in key directory
+#   lmcache_coordinator_directory_placements_total — total placements across all keys
+#   lmcache_coordinator_instance_l1_keys         — L1 keys reported by each instance
+#   lmcache_coordinator_instance_seq_gap         — 1 if an event-stream gap was detected
+#   lmcache_coordinator_quota_usage_bytes        — L2 usage bytes per cache_salt
+#   lmcache_coordinator_quota_limit_bytes        — L2 quota limit per cache_salt (-1 = unlimited)
+#   lmcache_coordinator_scrape_duration_seconds  — time to collect all metrics
+
+import argparse
+import http.server
+import logging
+import os
+import time
+import urllib.error
+import urllib.request
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("coordinator-exporter")
+
+
+def _fetch_json(base_url: str, path: str) -> object | None:
+    url = base_url.rstrip("/") + path
+    try:
+        with urllib.request.urlopen(url, timeout=5) as r:
+            import json
+            return json.loads(r.read())
+    except Exception as exc:
+        log.debug("fetch %s failed: %s", url, exc)
+        return None
+
+
+def collect(coordinator_url: str) -> str:
+    t0 = time.monotonic()
+    lines: list[str] = []
+
+    def gauge(name: str, value: float, labels: dict[str, str] | None = None, help_text: str = "", typ: str = "gauge") -> None:
+        lines.append(f"# HELP {name} {help_text}")
+        lines.append(f"# TYPE {name} {typ}")
+        label_str = ""
+        if labels:
+            pairs = ",".join(f'{k}="{v}"' for k, v in labels.items())
+            label_str = "{" + pairs + "}"
+        lines.append(f"{name}{label_str} {value}")
+
+    # --- coordinator liveness ---
+    healthz = _fetch_json(coordinator_url, "/healthz")
+    up = 1.0 if (healthz and healthz.get("status") == "healthy") else 0.0
+    gauge("lmcache_coordinator_up", up,
+          help_text="1 if the LMCache MP coordinator /healthz reports healthy")
+
+    if up < 1.0:
+        # Emit scrape duration and bail — everything else would be stale noise.
+        gauge("lmcache_coordinator_scrape_duration_seconds",
+              time.monotonic() - t0,
+              help_text="Time in seconds to scrape the LMCache coordinator")
+        return "\n".join(lines) + "\n"
+
+    # --- registered instances ---
+    instances_resp = _fetch_json(coordinator_url, "/instances")
+    instances = (instances_resp or {}).get("instances", [])
+    lines.append("# HELP lmcache_coordinator_instances_registered Number of MP servers currently registered with the coordinator")
+    lines.append("# TYPE lmcache_coordinator_instances_registered gauge")
+    lines.append(f"lmcache_coordinator_instances_registered {len(instances)}")
+
+    if instances:
+        lines.append("# HELP lmcache_coordinator_instance_info Non-zero for each registered instance; labels carry metadata")
+        lines.append("# TYPE lmcache_coordinator_instance_info gauge")
+        for inst in instances:
+            iid = inst.get("instance_id", "")
+            ip = inst.get("ip", "")
+            http_port = str(inst.get("http_port", ""))
+            lines.append(
+                f'lmcache_coordinator_instance_info{{instance_id="{iid}",ip="{ip}",http_port="{http_port}"}} 1'
+            )
+
+    # --- key directory stats ---
+    dir_stats = _fetch_json(coordinator_url, "/directory/stats")
+    if dir_stats is not None:
+        gauge("lmcache_coordinator_directory_keys_total",
+              dir_stats.get("num_keys", 0),
+              help_text="Keys with at least one placement tracked in the key directory")
+        gauge("lmcache_coordinator_directory_placements_total",
+              dir_stats.get("num_placements", 0),
+              help_text="Total placements (instance×tier×backend entries) across all tracked keys")
+
+        inst_stats = dir_stats.get("instances", {})
+        if inst_stats:
+            lines.append("# HELP lmcache_coordinator_instance_l1_keys L1 keys reported by each instance's event stream")
+            lines.append("# TYPE lmcache_coordinator_instance_l1_keys gauge")
+            lines.append("# HELP lmcache_coordinator_instance_seq_gap 1 if a sequence gap was detected in this instance's event stream")
+            lines.append("# TYPE lmcache_coordinator_instance_seq_gap gauge")
+            for iid, s in inst_stats.items():
+                lines.append(
+                    f'lmcache_coordinator_instance_l1_keys{{instance_id="{iid}"}} {s.get("num_l1_keys", 0)}'
+                )
+                lines.append(
+                    f'lmcache_coordinator_instance_seq_gap{{instance_id="{iid}"}} {1 if s.get("gap_detected") else 0}'
+                )
+
+    # --- quota / L2 usage ---
+    # API: {total_gb, by_cache_salt: [{cache_salt, usage_gb, quota_limit_gb, quota_exists}]}
+    quota_list = _fetch_json(coordinator_url, "/quota?tier=l2")
+    if quota_list is not None:
+        GB = 1024 ** 3
+        total_gb = quota_list.get("total_gb", 0)
+        lines.append("# HELP lmcache_coordinator_quota_usage_bytes_total Total L2 usage bytes tracked by coordinator")
+        lines.append("# TYPE lmcache_coordinator_quota_usage_bytes_total gauge")
+        lines.append(f"lmcache_coordinator_quota_usage_bytes_total {total_gb * GB:.0f}")
+        entries = quota_list.get("by_cache_salt", [])
+        if entries:
+            lines.append("# HELP lmcache_coordinator_quota_usage_bytes L2 byte usage tracked by the coordinator per cache_salt")
+            lines.append("# TYPE lmcache_coordinator_quota_usage_bytes gauge")
+            lines.append("# HELP lmcache_coordinator_quota_limit_bytes L2 quota limit per cache_salt; -1 means no limit set")
+            lines.append("# TYPE lmcache_coordinator_quota_limit_bytes gauge")
+            for entry in entries:
+                salt = entry.get("cache_salt", "")
+                usage = entry.get("usage_gb", 0) * GB
+                limit = entry.get("quota_limit_gb", -1)
+                limit_bytes = limit * GB if (limit and limit > 0) else -1
+                lines.append(f'lmcache_coordinator_quota_usage_bytes{{cache_salt="{salt}"}} {usage:.0f}')
+                lines.append(f'lmcache_coordinator_quota_limit_bytes{{cache_salt="{salt}"}} {limit_bytes:.0f}')
+
+    gauge("lmcache_coordinator_scrape_duration_seconds",
+          time.monotonic() - t0,
+          help_text="Time in seconds to scrape the LMCache coordinator REST API")
+
+    return "\n".join(lines) + "\n"
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    coordinator_url: str = ""
+
+    def do_GET(self):  # noqa: N802
+        if self.path in ("/metrics", "/metrics/"):
+            body = collect(self.coordinator_url).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        elif self.path in ("/healthz", "/health"):
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"ok")
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, fmt, *args):
+        pass  # suppress access log noise
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Prometheus exporter for the LMCache MP coordinator REST API"
+    )
+    parser.add_argument(
+        "--coordinator-url",
+        default=os.environ.get("LMCACHE_COORDINATOR_URL", "http://aic-lmcache-coordinator:9300"),
+        help="Base URL of the LMCache coordinator (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--listen-port",
+        type=int,
+        default=int(os.environ.get("COORDINATOR_EXPORTER_PORT", "9301")),
+        help="Port to serve /metrics on (default: %(default)s)",
+    )
+    args = parser.parse_args()
+
+    Handler.coordinator_url = args.coordinator_url
+    log.info("Exporting coordinator metrics from %s on :%d/metrics", args.coordinator_url, args.listen_port)
+    server = http.server.HTTPServer(("0.0.0.0", args.listen_port), Handler)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Wire the lmcache MP server into coordinator mode so the coordinator tracks which KV blocks each server holds (key directory), manages L2 eviction quotas, and enables CacheBlend lookup across a fleet.

Changes:
- docker/docker-compose.yml: add `lmcache-coordinator` service (cache profile, rocm-aic image, no GPU devices) running coordinator REST API on :9300 and /metrics on :9301 via a bind-mounted entrypoint script. Add `--coordinator-url` and `--coordinator-event-reporting` to all four `lmcache server` invocation paths; `lmcache` depends_on the coordinator being healthy before starting. Remove the separate `lmcache-coordinator-exporter` service (merged into coordinator container). Bump `--instance-timeout` default to 120s and add `--timeout-keep-alive 65` to prevent uvicorn from closing idle heartbeat connections.
- monitoring/scripts/lmcache_coordinator_entrypoint.py: combined entrypoint that runs the coordinator via uvicorn in the main thread and serves Prometheus /metrics on a second port in a daemon thread. Polls /instances, /directory/stats, and /quota and emits lmcache_coordinator_{up,instances_registered,directory_keys_total, directory_placements_total,instance_l1_keys,instance_seq_gap, quota_usage_bytes_total,quota_usage_bytes,quota_limit_bytes}.
- monitoring/scripts/lmcache_coordinator_exporter.py: standalone exporter variant (retained for reference / host-network deployments).
- monitoring/prometheus/prometheus.yml: add `lmcache_coordinator` scrape job targeting aic-lmcache-coordinator:9301.
- monitoring/grafana/dashboards/aic-overview.json: add "LMCache Coordinator" row with 7 panels — coordinator up/down status, registered instance count, event stream gap alert, key directory keys and placements over time, L1 keys per instance, L2 usage per cache_salt, and exporter scrape latency.


## Submission Checklist

- [ X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
