### PR TITLE
fix(ci): fix monitoring CPU smoke workflow and standardise CI storage…

### DIFF
--- a/.github/scripts/spur-monitoring-cpu-smoke.sh
+++ b/.github/scripts/spur-monitoring-cpu-smoke.sh
@@ -24,6 +24,7 @@ AIC_SHARED_NFS="${AIC_SHARED_NFS:?AIC_SHARED_NFS must be set (e.g. via GitHub re
 AIC_SPUR_CONTROLLER="${AIC_SPUR_CONTROLLER:?AIC_SPUR_CONTROLLER must be set (e.g. via GitHub repo variable)}"
 AIC_CI_STORAGE_ROOT="${AIC_CI_STORAGE_ROOT:-}"
 AIC_SMOKE_USE_REGISTRY="${AIC_SMOKE_USE_REGISTRY:-0}"
+AIC_SLURM_ACCOUNT="${AIC_SLURM_ACCOUNT:-}"
 REPO="https://github.com/ROCm/rocm-aic.git"
 
 ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=4 "${AIC_SPUR_HOST}" env \
@@ -34,6 +35,7 @@ ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=4 "${AIC_SPUR_HOST}" env \
     AIC_CI_STORAGE_ROOT="${AIC_CI_STORAGE_ROOT}" \
     AIC_SPUR_CONTROLLER="${AIC_SPUR_CONTROLLER}" \
     SPUR_CONTROLLER_ADDR="${AIC_SPUR_CONTROLLER}" \
+    AIC_SLURM_ACCOUNT="${AIC_SLURM_ACCOUNT}" \
     AIC_SMOKE_USE_REGISTRY="${AIC_SMOKE_USE_REGISTRY}" \
     bash << 'REMOTE'
 set -euo pipefail
@@ -42,7 +44,7 @@ SHORT="${SHA:0:7}"
 WORKDIR="$HOME/Projects/rocm-aic.${SHORT}"
 CI_STORAGE_ROOT="${AIC_CI_STORAGE_ROOT:-$HOME/Projects/rocm-aic-ci}"
 TARBALL_DIR="${CI_STORAGE_ROOT}/images/aic-ci-${SHORT}"
-METRICS_PAGE_DIR="${CI_STORAGE_ROOT}/metrics-page-${SHORT}"
+AIC_METRICS_PAGE_DIR="${AIC_SHARED_NFS}/rocm-aic/metrics-pages-${SHORT}"
 HF_HOME="${AIC_SHARED_NFS}/huggingface"
 
 cleanup() {
@@ -81,7 +83,7 @@ set -euo pipefail
 
 WORKDIR="${1}"
 AIC_IMAGE="${2}"
-METRICS_PAGE_DIR="${3}"
+AIC_METRICS_PAGE_DIR="${3}"
 SHA="${4}"
 TARBALL_DIR="${5}"
 AIC_SMOKE_USE_REGISTRY="${6:-0}"
@@ -90,8 +92,8 @@ SHORT="${SHA:0:7}"
 
 MON_DIR="${WORKDIR}/monitoring"
 EMULATOR_COMPOSE="${WORKDIR}/docker/docker-compose.emulator.yml"
-METRICS_DIR="${METRICS_PAGE_DIR}/prom-tsdb"
-mkdir -p "${METRICS_DIR}" "${METRICS_PAGE_DIR}"
+METRICS_DIR="${AIC_METRICS_PAGE_DIR}/prom-tsdb"
+mkdir -p "${METRICS_DIR}" "${AIC_METRICS_PAGE_DIR}"
 
 # ---------------------------------------------------------------------------
 # Load or pull the rocm-aic image (docker is on the compute node, not the head node)
@@ -230,10 +232,10 @@ python3 "${WORKDIR}/monitoring/scripts/metrics_to_html.py" \
     "${METRICS_ARGS[@]}" \
     --sha "${SHA}" \
     --title "AIC Prometheus Metrics Reference" \
-    > "${METRICS_PAGE_DIR}/index.html"
+    > "${AIC_METRICS_PAGE_DIR}/index.html"
 
-echo "=== Metrics page written to ${METRICS_PAGE_DIR}/index.html ==="
-wc -l "${METRICS_PAGE_DIR}/index.html"
+echo "=== Metrics page written to ${AIC_METRICS_PAGE_DIR}/index.html ==="
+wc -l "${AIC_METRICS_PAGE_DIR}/index.html"
 
 SRUN_BODY
 
@@ -241,16 +243,19 @@ chmod +x "${SRUN_SCRIPT}"
 
 echo "=== Submitting CPU-only srun job ==="
 srun \
+    --controller="${SPUR_CONTROLLER_ADDR}" \
+    ${AIC_SLURM_ACCOUNT:+--account="${AIC_SLURM_ACCOUNT}"} \
     --nodes=1 \
     --ntasks=1 \
     --cpus-per-task=8 \
     --mem=16G \
     --time=00:30:00 \
     --partition=amd-spur \
+    --gres= \
     bash "${SRUN_SCRIPT}" \
         "${WORKDIR}" \
         "${AIC_IMAGE}" \
-        "${METRICS_PAGE_DIR}" \
+        "${AIC_METRICS_PAGE_DIR}" \
         "${SHA}" \
         "${TARBALL_DIR}" \
         "${AIC_SMOKE_USE_REGISTRY}" \
@@ -262,14 +267,13 @@ REMOTE
 # ---------------------------------------------------------------------------
 # Copy metrics page artifact back to the runner working directory
 # ---------------------------------------------------------------------------
-SPUR_USER="$(ssh -o ServerAliveInterval=30 "${AIC_SPUR_HOST}" id -un)"
-REMOTE_METRICS_PAGE_DIR="${AIC_SHARED_NFS}/${SPUR_USER}/metrics-page-${SHORT}"
+AIC_REMOTE_METRICS_PAGE_DIR="${AIC_SHARED_NFS}/rocm-aic/metrics-pages-${SHORT}"
 
 echo "=== Copying metrics page to runner ==="
 mkdir -p metrics-page
 scp -o ServerAliveInterval=30 \
-    "${AIC_SPUR_HOST}:${REMOTE_METRICS_PAGE_DIR}/index.html" \
+    "${AIC_SPUR_HOST}:${AIC_REMOTE_METRICS_PAGE_DIR}/index.html" \
     metrics-page/index.html
-ssh -o ServerAliveInterval=30 "${AIC_SPUR_HOST}" rm -rf "${REMOTE_METRICS_PAGE_DIR}"
+ssh -o ServerAliveInterval=30 "${AIC_SPUR_HOST}" rm -rf "${AIC_REMOTE_METRICS_PAGE_DIR}"
 
 echo "CPU monitoring smoke test passed for ${SHORT}"

--- a/.github/workflows/aic-amd-cliff.yml
+++ b/.github/workflows/aic-amd-cliff.yml
@@ -84,6 +84,7 @@ jobs:
     env:
       AIC_SPUR_HOST: ${{ secrets.AIC_SPUR_HOST }}
       AIC_SHARED_NFS: ${{ secrets.AIC_SHARED_NFS }}
+      AIC_CI_STORAGE_ROOT: ${{ secrets.AIC_SHARED_NFS }}/rocm-aic
       AIC_SPUR_CONTROLLER: ${{ secrets.AIC_SPUR_CONTROLLER }}
 
     steps:

--- a/.github/workflows/aic-amd-dist-build-fast.yml
+++ b/.github/workflows/aic-amd-dist-build-fast.yml
@@ -84,6 +84,7 @@ jobs:
     env:
       AIC_SPUR_HOST: ${{ secrets.AIC_SPUR_HOST }}
       AIC_SHARED_NFS: ${{ secrets.AIC_SHARED_NFS }}
+      AIC_CI_STORAGE_ROOT: ${{ secrets.AIC_SHARED_NFS }}/rocm-aic
       AIC_SPUR_CONTROLLER: ${{ secrets.AIC_SPUR_CONTROLLER }}
 
     steps:
@@ -157,6 +158,7 @@ jobs:
     env:
       AIC_SPUR_HOST: ${{ secrets.AIC_SPUR_HOST }}
       AIC_SHARED_NFS: ${{ secrets.AIC_SHARED_NFS }}
+      AIC_CI_STORAGE_ROOT: ${{ secrets.AIC_SHARED_NFS }}/rocm-aic
       AIC_SPUR_CONTROLLER: ${{ secrets.AIC_SPUR_CONTROLLER }}
 
     steps:
@@ -230,6 +232,7 @@ jobs:
     env:
       AIC_SPUR_HOST:       ${{ secrets.AIC_SPUR_HOST }}
       AIC_SHARED_NFS:      ${{ secrets.AIC_SHARED_NFS }}
+      AIC_CI_STORAGE_ROOT: ${{ secrets.AIC_SHARED_NFS }}/rocm-aic
       AIC_SPUR_CONTROLLER: ${{ secrets.AIC_SPUR_CONTROLLER }}
 
     steps:

--- a/.github/workflows/aic-amd-dist-build.yml
+++ b/.github/workflows/aic-amd-dist-build.yml
@@ -85,6 +85,7 @@ jobs:
     env:
       AIC_SPUR_HOST: ${{ secrets.AIC_SPUR_HOST }}
       AIC_SHARED_NFS: ${{ secrets.AIC_SHARED_NFS }}
+      AIC_CI_STORAGE_ROOT: ${{ secrets.AIC_SHARED_NFS }}/rocm-aic
       AIC_SPUR_CONTROLLER: ${{ secrets.AIC_SPUR_CONTROLLER }}
 
     steps:
@@ -158,6 +159,7 @@ jobs:
     env:
       AIC_SPUR_HOST: ${{ secrets.AIC_SPUR_HOST }}
       AIC_SHARED_NFS: ${{ secrets.AIC_SHARED_NFS }}
+      AIC_CI_STORAGE_ROOT: ${{ secrets.AIC_SHARED_NFS }}/rocm-aic
       AIC_SPUR_CONTROLLER: ${{ secrets.AIC_SPUR_CONTROLLER }}
 
     steps:
@@ -231,6 +233,7 @@ jobs:
     env:
       AIC_SPUR_HOST:       ${{ secrets.AIC_SPUR_HOST }}
       AIC_SHARED_NFS:      ${{ secrets.AIC_SHARED_NFS }}
+      AIC_CI_STORAGE_ROOT: ${{ secrets.AIC_SHARED_NFS }}/rocm-aic
       AIC_SPUR_CONTROLLER: ${{ secrets.AIC_SPUR_CONTROLLER }}
 
     steps:

--- a/.github/workflows/aic-amd-nightly-cliff.yml
+++ b/.github/workflows/aic-amd-nightly-cliff.yml
@@ -32,6 +32,7 @@ jobs:
     env:
       AIC_SPUR_HOST:       ${{ secrets.AIC_SPUR_HOST }}
       AIC_SHARED_NFS:      ${{ secrets.AIC_SHARED_NFS }}
+      AIC_CI_STORAGE_ROOT: ${{ secrets.AIC_SHARED_NFS }}/rocm-aic
       AIC_SPUR_CONTROLLER: ${{ secrets.AIC_SPUR_CONTROLLER }}
 
     steps:

--- a/.github/workflows/aic-amd-nightly-dist-build.yml
+++ b/.github/workflows/aic-amd-nightly-dist-build.yml
@@ -15,6 +15,7 @@ jobs:
     env:
       AIC_SPUR_HOST: ${{ secrets.AIC_SPUR_HOST }}
       AIC_SHARED_NFS: ${{ secrets.AIC_SHARED_NFS }}
+      AIC_CI_STORAGE_ROOT: ${{ secrets.AIC_SHARED_NFS }}/rocm-aic
       AIC_SPUR_CONTROLLER: ${{ secrets.AIC_SPUR_CONTROLLER }}
 
     steps:

--- a/.github/workflows/aic-amd-nightly-smoke-test.yml
+++ b/.github/workflows/aic-amd-nightly-smoke-test.yml
@@ -13,6 +13,7 @@ jobs:
     env:
       AIC_SPUR_HOST: ${{ secrets.AIC_SPUR_HOST }}
       AIC_SHARED_NFS: ${{ secrets.AIC_SHARED_NFS }}
+      AIC_CI_STORAGE_ROOT: ${{ secrets.AIC_SHARED_NFS }}/rocm-aic
       AIC_SPUR_CONTROLLER: ${{ secrets.AIC_SPUR_CONTROLLER }}
 
     steps:

--- a/.github/workflows/aic-amd-nightly-tiny-test.yml
+++ b/.github/workflows/aic-amd-nightly-tiny-test.yml
@@ -13,6 +13,7 @@ jobs:
     env:
       AIC_SPUR_HOST:       ${{ secrets.AIC_SPUR_HOST }}
       AIC_SHARED_NFS:      ${{ secrets.AIC_SHARED_NFS }}
+      AIC_CI_STORAGE_ROOT: ${{ secrets.AIC_SHARED_NFS }}/rocm-aic
       AIC_SPUR_CONTROLLER: ${{ secrets.AIC_SPUR_CONTROLLER }}
       HF_TOKEN:            ${{ secrets.AIC_HF_TOKEN }}
 

--- a/.github/workflows/aic-monitoring-cpu-smoke.yml
+++ b/.github/workflows/aic-monitoring-cpu-smoke.yml
@@ -45,6 +45,7 @@ jobs:
     env:
       AIC_SPUR_HOST:       ${{ secrets.AIC_SPUR_HOST }}
       AIC_SHARED_NFS:      ${{ secrets.AIC_SHARED_NFS }}
+      AIC_CI_STORAGE_ROOT: ${{ secrets.AIC_SHARED_NFS }}/rocm-aic
       AIC_SPUR_CONTROLLER: ${{ secrets.AIC_SPUR_CONTROLLER }}
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ dictionary.dic
 
 # Local AMD cluster environment (see .env.amd.example if it exists)
 .env.amd
+
+# CI artifact staging dir (spur-monitoring-cpu-smoke.sh copies index.html here
+# for upload-artifact / gh-pages deploy; never committed)
+metrics-page/


### PR DESCRIPTION
… root

## spur-monitoring-cpu-smoke.sh

The workflow was silently failing because the srun call was missing three flags required on SPUR:

  - --controller: srun couldn't reach the SPUR controller
  - --account:    job fell back to the default QOS (amd-general), hitting
                  node limits immediately
  - --gres=:      overrides the embedded GPU resource request that causes
                  immediate job cancellation on SPUR's scheduler

Also fixes a METRICS_PAGE_DIR path mismatch: the srun job wrote the generated HTML to ${CI_STORAGE_ROOT}/metrics-page-${SHORT} but the outer script tried to scp from ${AIC_SHARED_NFS}/${SPUR_USER}/metrics-page-${SHORT}. Both now use ${AIC_SHARED_NFS}/rocm-aic/metrics-pages-${SHORT} — a shared, user-agnostic path consistent with the rest of the CI storage layout.

Rename METRICS_PAGE_DIR → AIC_METRICS_PAGE_DIR and REMOTE_AIC_METRICS_PAGE_DIR → AIC_REMOTE_METRICS_PAGE_DIR for naming consistency. Drop the SPUR_USER ssh call that was only needed to construct the old per-user path.

AIC_SLURM_ACCOUNT is optional (omitted when unset) via the ${VAR:+--flag} pattern, consistent with run-build-distribute.sh.

## All CI workflows

Add AIC_CI_STORAGE_ROOT: ${{ secrets.AIC_SHARED_NFS }}/rocm-aic to every job env block. Without this, each script falls back to $HOME/Projects/rocm-aic-ci on the head node, which works when dist-build and smoke-test run on the same runner but silently breaks cross-runner chains (tarball written by one runner not found by another). The shared NFS path is already used for images and buildcache; making it explicit ensures all jobs in a chain agree on where to read and write.

## .gitignore

Add metrics-page/ — the local staging directory created by spur-monitoring-cpu-smoke.sh for the upload-artifact and gh-pages deploy steps; never committed.