### PR TITLE
fix(monitoring): align image pins and LMCache eviction metric

### DIFF
--- a/.slurm/run-build-distribute.sh
+++ b/.slurm/run-build-distribute.sh
@@ -123,6 +123,8 @@
 #                        (default: <site>&GFX942&NVME -- MI300X + local NVMe).
 #                        Used only when AIC_TEST_NODE is unset.
 #   AIC_TEST_NODE        pin an exact test node via --nodelist  (default: unset)
+#   AIC_TEST_GRES        Slurm GPU resource request for smoke/tiny tests
+#                        (default: gpu:1)
 #   AIC_TEST_TIME        test job time limit               (default: 00:20:00)
 #   AIC_TEST_CPUS        --cpus-per-task for the test job  (default: 8)
 #   AIC_TEST_MEM         --mem for the test job            (default: 32G)
@@ -216,6 +218,7 @@ AIC_CACHE_INSECURE="${AIC_CACHE_INSECURE:-}"
 AIC_TEST_TIME="${AIC_TEST_TIME:-00:45:00}"
 AIC_TEST_CPUS="${AIC_TEST_CPUS:-8}"
 AIC_TEST_MEM="${AIC_TEST_MEM:-32G}"
+AIC_TEST_GRES="${AIC_TEST_GRES:-gpu:1}"
 
 # --- tiny-test: end-to-end serve check with a tiny model ---------------------
 # Brings up the compose MP stack (standalone lmcache + vLLM LMCacheMPConnector)
@@ -1018,6 +1021,12 @@ SMOKE
 set -euo pipefail
 command -v docker >/dev/null 2>&1 || { echo "\$(hostname): docker not found" >&2; exit 1; }
 echo "[test] host=\$(hostname) docker=\$(docker --version)"
+# Preserve Slurm's single-GPU allocation inside Docker.  SPUR sets
+# ROCR_VISIBLE_DEVICES for --gres=gpu:1; CUDA_VISIBLE_DEVICES is the fallback
+# used by some standard Slurm installations.
+_gpu_visible="\${ROCR_VISIBLE_DEVICES:-\${CUDA_VISIBLE_DEVICES:-0}}"
+_gpu_visible="\${_gpu_visible%%,*}"
+echo "[test] allocated gpu=\${_gpu_visible}"
 # Load the image from the shared tarball only when needed.  A node-local marker
 # records the tarball mtime that was last loaded here; we reload when the tarball
 # is newer (a rebuild happened), when the image is absent, or when forced.  We
@@ -1049,6 +1058,7 @@ docker run --rm \
     --cap-add SYS_PTRACE --cap-add SYS_ADMIN \
     --security-opt seccomp=unconfined \
     \${kmounts} \
+    -e ROCR_VISIBLE_DEVICES="\${_gpu_visible}" \
     -e EXPECT_ARCH='${AIC_ROCM_ARCH}' \
     -v '${smoketest}':/tmp/aic-smoketest.sh:ro \
     --entrypoint /bin/bash \
@@ -1094,7 +1104,9 @@ exit \${img_rc}
 REMOTE
 )"
 
-    local -a _gres_arg=(); [[ "${AIC_SPUR_CLUSTER}" != "1" ]] && _gres_arg=(--gres=gpu:1)
+    # Always reserve a GPU.  Omitting GRES on SPUR lets Slurm co-locate this job
+    # with an existing GPU workload, even though the test launches ROCm code.
+    local -a _gres_arg=(--gres="${AIC_TEST_GRES}")
     _sbatch_run aic-test smoke-test "${remote_script}" \
         "${_sel[@]}" \
         "${_gres_arg[@]}" \
@@ -1131,6 +1143,14 @@ cmd_tiny_test() {
 set -uo pipefail
 command -v docker >/dev/null 2>&1 || { echo "\$(hostname): docker not found" >&2; exit 1; }
 echo "[tiny-test] host=\$(hostname) docker=\$(docker --version)"
+# Preserve the GPU selected by Slurm instead of unconditionally exposing host
+# GPU 0 to both vLLM and LMCache.  A single-GPU GRES normally maps this to 0,
+# while the fallback keeps non-Slurm/manual execution working.
+_gpu_visible="\${ROCR_VISIBLE_DEVICES:-\${CUDA_VISIBLE_DEVICES:-0}}"
+_gpu_visible="\${_gpu_visible%%,*}"
+export GPU="\${_gpu_visible}"
+VLLM_CONTAINER="aic-vllm-gpu\${GPU}"
+echo "[tiny-test] allocated gpu=\${GPU} container=\${VLLM_CONTAINER}"
 
 # Load the image from the shared tarball only when needed (same marker logic as
 # smoke-test): reload when forced, absent, or the tarball is newer.
@@ -1157,7 +1177,6 @@ ensure_compose || { echo "[tiny-test] docker compose unavailable and could not b
 export IMAGE_REF='${AIC_IMAGE}'
 export IMAGE_NAME='${AIC_IMAGE%:*}'
 export ROCM_ARCH='${AIC_ROCM_ARCH}'
-export GPU=0
 export VLLM_MODEL='${AIC_TINY_MODEL}'
 export HF_HOME='${HF_HOME}'
 export HF_TOKEN='${HF_TOKEN:-}'
@@ -1196,7 +1215,7 @@ cleanup() {
     pkill -9 -f 'lmcache server'          2>/dev/null || true
     sleep 2
     timeout 60 compose --profile cache down --remove-orphans --timeout 5 >/dev/null 2>&1 || true
-    for c in aic-vllm-gpu0 aic-lmcache; do timeout 30 docker rm -f "\$c" >/dev/null 2>&1 || true; done
+    for c in "\${VLLM_CONTAINER}" aic-lmcache; do timeout 30 docker rm -f "\$c" >/dev/null 2>&1 || true; done
     rm -rf /tmp/aic-tiny-nvme /tmp/aic-tiny-nfs 2>/dev/null || true
 }
 trap cleanup EXIT
@@ -1214,7 +1233,14 @@ fi
 # inside its container instead of the Slurm host's loopback interface.
 ready=0
 for _i in \$(seq 1 ${AIC_TINY_READY_TIMEOUT}); do
-    if docker exec aic-vllm-gpu0 curl -fsS http://127.0.0.1:8000/v1/models >/dev/null 2>&1; then ready=1; break; fi
+    if docker exec "\${VLLM_CONTAINER}" curl -fsS http://127.0.0.1:8000/v1/models >/dev/null 2>&1; then ready=1; break; fi
+    _vllm_state="\$(docker inspect --format '{{.State.Status}}' "\${VLLM_CONTAINER}" 2>/dev/null || true)"
+    if [ "\${_vllm_state}" != "running" ]; then
+        _vllm_exit="\$(docker inspect --format '{{.State.ExitCode}}' "\${VLLM_CONTAINER}" 2>/dev/null || echo unknown)"
+        echo "[tiny-test] FAIL: vLLM exited before readiness (state=\${_vllm_state:-missing}, exit=\${_vllm_exit})" >&2
+        compose logs --tail 80 --no-color vllm 2>&1 | sed 's/^/  [vllm] /'
+        exit 1
+    fi
     sleep 5
 done
 if [ "\${ready}" != "1" ]; then
@@ -1226,7 +1252,7 @@ echo "[tiny-test] endpoint ready; sending one chat completion ..."
 
 # One real completion; assert a NON-EMPTY assistant content came back through the
 # LMCacheMPConnector path.
-resp="\$(docker exec aic-vllm-gpu0 curl -fsS http://127.0.0.1:8000/v1/chat/completions \
+resp="\$(docker exec "\${VLLM_CONTAINER}" curl -fsS http://127.0.0.1:8000/v1/chat/completions \
     -H 'Content-Type: application/json' \
     -d '{"model":"${AIC_TINY_MODEL}","messages":[{"role":"user","content":"Reply with the single word: pong"}],"max_tokens":16,"temperature":0}' 2>&1)" || {
     echo "[tiny-test] FAIL: completion request failed: \${resp}" >&2; exit 1; }
@@ -1240,7 +1266,8 @@ exit 1
 REMOTE
 )"
 
-    local -a _gres_arg=(); [[ "${AIC_SPUR_CLUSTER}" != "1" ]] && _gres_arg=(--gres=gpu:1)
+    # Always reserve a GPU; see cmd_test for why SPUR must not omit GRES.
+    local -a _gres_arg=(--gres="${AIC_TEST_GRES}")
     _sbatch_run aic-tiny-test tiny-test "${remote_script}" \
         "${_sel[@]}" \
         "${_gres_arg[@]}" \

--- a/.slurm/run-cliff.sbatch
+++ b/.slurm/run-cliff.sbatch
@@ -569,10 +569,10 @@ if [[ "${AIC_EXPORTERS}" != "0" ]]; then
     _b="$(printf '%s' "${_t}" | tr '/:' '--')"
     load_image_if_needed "${_t}" "${AIC_IMAGE_DIR}/${_b}.tar.*" && export AIC_AMDGPU_EXPORTER_IMAGE="${_t}"
   fi
-  # Prometheus (prom/prometheus:v2.55.1).  Pre-pull avoids 10+ min Docker Hub
+  # Prometheus (prom/prometheus:v3.13.2).  Pre-pull avoids 10+ min Docker Hub
   # download on fresh nodes; load_image_if_needed is a no-op when already present.
   if [[ -z "${AIC_PROM_IMAGE:-}" ]]; then
-    _t="prom/prometheus:v2.55.1"
+    _t="prom/prometheus:v3.13.2"
     _b="$(printf '%s' "${_t}" | tr '/:' '--')"
     load_image_if_needed "${_t}" "${AIC_IMAGE_DIR}/${_b}.tar.*" || true
   fi
@@ -886,7 +886,7 @@ declare -A STATUS
 # Pre-pull the Prometheus image so start_monitoring doesn't block on a Docker Hub
 # download (prom/prometheus is ~75 MB; on a cold node this adds 10+ minutes before
 # the first arm starts).  docker pull is a no-op when the image is already present.
-_prom_img="${AIC_PROM_IMAGE:-prom/prometheus:v2.55.1}"
+_prom_img="${AIC_PROM_IMAGE:-prom/prometheus:v3.13.2}"
 log "pre-pulling ${_prom_img} (no-op if cached)..."
 docker pull "${_prom_img}" >/dev/null 2>&1 && log "  ${_prom_img}: ready" \
     || log "  WARN: pull failed for ${_prom_img} (will try again at compose up)"

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ export KV_TRANSFER_ARG
 AIC_METRICS_DIR  ?= $(CURDIR)/logs/prometheus
 AIC_EXPORTERS    ?= 0
 AIC_GRAFANA_PORT ?= 3000
-AIC_GRAFANA_IMAGE ?= grafana/grafana:11.5.2
+AIC_GRAFANA_IMAGE ?= grafana/grafana:13.1.3
 MON_COMPOSE     := $(_COMPOSE_BIN) -f "$(CURDIR)/monitoring/docker-compose.monitoring.yml"
 _MON_PROFILE    := $(if $(filter 1,$(AIC_EXPORTERS)),--profile exporters,)
 export AIC_METRICS_DIR AIC_GRAFANA_PORT AIC_GRAFANA_IMAGE
@@ -613,7 +613,7 @@ dist-build-monitoring:         # Pull + save monitoring sidecar images to AIC_IM
 	@# load_image_if_needed call in run-cliff.sbatch picks them up automatically.
 	@set -e; \
 	for img in \
-	    "prom/prometheus:v2.55.1" \
+	    "prom/prometheus:v3.13.2" \
 	    "rocm/device-metrics-exporter:v1.5.1" \
 	; do \
 	    tag="$$(printf '%s' "$$img" | tr '/:' '--').tar.zst"; \

--- a/docs/METRICS_TELEMETRY.md
+++ b/docs/METRICS_TELEMETRY.md
@@ -225,7 +225,7 @@ LMCache uses OpenTelemetry with a Prometheus fallback at `--http-port`
 | `lmcache_mp_l2_store_completed_requests_total` | counter | *lazy* L2 store requests completed; `l2_name` label |
 | `lmcache_mp_l2_store_completed_objects_chunks_total` | counter | *lazy* Chunks successfully stored to L2 |
 | `lmcache_mp_l2_store_throughput_GB_per_second` | histogram | *lazy* L2 store throughput (GB/s); `l2_name` label |
-| `lmcache_mp_l2_evicted_objects` | counter | *lazy* Objects evicted from L2 |
+| `lmcache_mp_l2_evicted_objects_chunks_total` | counter | *lazy* Chunks evicted from L2 |
 | `lmcache_mp_num_inflight_l2_stores` | gauge | In-flight L2 store operations; `adapter_index`+`l2_name` labels |
 | `lmcache_mp_num_inflight_l2_loads` | gauge | In-flight L2 load operations |
 

--- a/monitoring/docker-compose.monitoring.yml
+++ b/monitoring/docker-compose.monitoring.yml
@@ -32,7 +32,7 @@
 # Optional env:
 #   AIC_PROM_PORT        — Prometheus web/listen port (default: 9090)
 #   AIC_PROM_RETENTION   — TSDB retention (default: 90d)
-#   AIC_PROM_IMAGE       — Prometheus image (default: prom/prometheus:v2.55.1)
+#   AIC_PROM_IMAGE       — Prometheus image (default: prom/prometheus:v3.13.2)
 #   AIC_NODE_EXPORTER_IMAGE — node-exporter image (exporters profile)
 #   AIC_AMDGPU_EXPORTER_IMAGE — AMD device-metrics-exporter image (exporters profile)
 #   AIC_HSA_SNOOP_IMAGE / IMAGE_NAME — image carrying hsa-snoop (default: rocm-aic)
@@ -201,7 +201,7 @@ services:
   # file uses network_mode: host throughout.
   # ---------------------------------------------------------------------------
   grafana:
-    image: ${AIC_GRAFANA_IMAGE:-grafana/grafana:11.5.2}
+    image: ${AIC_GRAFANA_IMAGE:-grafana/grafana:13.1.3}
     container_name: aic-grafana
     network_mode: host
     restart: unless-stopped

--- a/monitoring/grafana/dashboards/aic-overview.json
+++ b/monitoring/grafana/dashboards/aic-overview.json
@@ -5140,7 +5140,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "clamp_min(sum(lmcache_mp_l2_store_completed_objects_chunks_total{job=\"lmcache\"}) - sum(lmcache_mp_l2_evicted_objects{job=\"lmcache\"} or vector(0)), 0)",
+          "expr": "clamp_min(sum(lmcache_mp_l2_store_completed_objects_chunks_total{job=\"lmcache\"}) - sum(lmcache_mp_l2_evicted_objects_chunks_total{job=\"lmcache\"} or vector(0)), 0)",
           "instant": true,
           "legendFormat": ""
         }


### PR DESCRIPTION
Follow-up to #134.

## Summary

- align the remaining Prometheus defaults, Slurm preload, and distribution artifact with v3.13.2
- align the standalone monitoring Grafana default with 13.1.3
- query and document the emitted LMCache L2 eviction metric, lmcache_mp_l2_evicted_objects_chunks_total

## Validation

- git diff --check
- bash syntax check for .slurm/run-cliff.sbatch
- Grafana dashboard JSON parse
- both monitoring Compose paths render Prometheus v3.13.2 and Grafana 13.1.3
- promtool validates the Prometheus configuration and all three rules
- exact PR tiny-test configuration passed manually on MI355X (ready in 75 seconds; returned PONG!)