### PR TITLE
feat(slurm): resolve SPUR GPU visibility via env vars

### DIFF
--- a/.slurm/ext-hit-test.sbatch
+++ b/.slurm/ext-hit-test.sbatch
@@ -1,7 +1,7 @@
 #!/bin/bash
 #SBATCH --partition=amd-spur
 #SBATCH --constraint=
-#SBATCH --gres=
+#SBATCH --gpus=1
 #SBATCH --time=01:30:00
 #SBATCH --job-name=aic-ext-hit-test
 
@@ -29,6 +29,13 @@ VLLM_MODEL="${VLLM_MODEL:-Qwen/Qwen2.5-3B-Instruct}"
 LMCACHE_PORT="${LMCACHE_PORT:-6555}"
 VLLM_PORT="${VLLM_PORT:-8000}"
 
+# --- GPU visibility ---
+export AIC_SPUR_CLUSTER="${AIC_SPUR_CLUSTER:-1}"
+# shellcheck source=monitoring/monitoring-lib.sh
+source "${REPO}/monitoring/monitoring-lib.sh"
+aic_resolve_gpu_visibility \
+    || { echo "ERROR: could not resolve the GPU allocation (refusing to default to GPU 0)" >&2; exit 1; }
+
 # --- Load image ---
 echo "--- Loading image ---"
 if ! docker image inspect "${AIC_IMAGE}" >/dev/null 2>&1; then
@@ -54,7 +61,9 @@ docker run -d --name aic-lmcache \
     --device /dev/kfd --device /dev/dri \
     --ulimit nofile=1048576:1048576 \
     -v "${NVME_DATA}:/data/nvme" \
-    -e ROCR_VISIBLE_DEVICES=0 \
+    -e ROCR_VISIBLE_DEVICES="${AIC_ROCR_VISIBLE}" \
+    -e HIP_VISIBLE_DEVICES="${AIC_HIP_VISIBLE}" \
+    -e CUDA_VISIBLE_DEVICES="${AIC_HIP_VISIBLE}" \
     -e PYTHONUNBUFFERED=1 \
     --entrypoint /bin/bash \
     "${AIC_IMAGE}" \
@@ -95,7 +104,9 @@ docker run -d --name aic-vllm-gpu0 \
     --ipc "container:aic-lmcache" \
     --device /dev/kfd --device /dev/dri \
     -v "${HF_HOME}:/hf" \
-    -e ROCR_VISIBLE_DEVICES=0 \
+    -e ROCR_VISIBLE_DEVICES="${AIC_ROCR_VISIBLE}" \
+    -e HIP_VISIBLE_DEVICES="${AIC_HIP_VISIBLE}" \
+    -e CUDA_VISIBLE_DEVICES="${AIC_HIP_VISIBLE}" \
     -e HF_HOME=/hf \
     -e HF_HUB_CACHE=/hf/hub \
     -e HF_HUB_OFFLINE=1 \

--- a/.slurm/run-build-distribute.sh
+++ b/.slurm/run-build-distribute.sh
@@ -1037,12 +1037,13 @@ SMOKE
 set -euo pipefail
 command -v docker >/dev/null 2>&1 || { echo "\$(hostname): docker not found" >&2; exit 1; }
 echo "[test] host=\$(hostname) docker=\$(docker --version)"
-# Preserve Slurm's single-GPU allocation inside Docker.  SPUR sets
-# ROCR_VISIBLE_DEVICES for --gres=gpu:1; CUDA_VISIBLE_DEVICES is the fallback
-# used by some standard Slurm installations.
-_gpu_visible="\${ROCR_VISIBLE_DEVICES:-\${CUDA_VISIBLE_DEVICES:-0}}"
-_gpu_visible="\${_gpu_visible%%,*}"
-echo "[test] allocated gpu=\${_gpu_visible}"
+# Preserve Slurm's GPU allocation inside Docker.
+export AIC_SPUR_CLUSTER='${AIC_SPUR_CLUSTER}'
+# shellcheck source=/dev/null
+source '${AIC_DAY_DIR}/monitoring/monitoring-lib.sh'
+aic_resolve_gpu_visibility \
+    || { echo "[test] could not resolve the GPU allocation (refusing to default to GPU 0)" >&2; exit 1; }
+echo "[test] allocated gpu: ROCR=\${AIC_ROCR_VISIBLE} HIP=\${AIC_HIP_VISIBLE}"
 # Load the image from the shared tarball only when needed.  A node-local marker
 # records the tarball mtime that was last loaded here; we reload when the tarball
 # is newer (a rebuild happened), when the image is absent, or when forced.  We
@@ -1074,7 +1075,9 @@ docker run --rm \
     --cap-add SYS_PTRACE --cap-add SYS_ADMIN \
     --security-opt seccomp=unconfined \
     \${kmounts} \
-    -e ROCR_VISIBLE_DEVICES="\${_gpu_visible}" \
+    -e ROCR_VISIBLE_DEVICES="\${AIC_ROCR_VISIBLE}" \
+    -e HIP_VISIBLE_DEVICES="\${AIC_HIP_VISIBLE}" \
+    -e CUDA_VISIBLE_DEVICES="\${AIC_HIP_VISIBLE}" \
     -e EXPECT_ARCH='${AIC_ROCM_ARCH}' \
     -v '${smoketest}':/tmp/aic-smoketest.sh:ro \
     --entrypoint /bin/bash \
@@ -1160,13 +1163,15 @@ set -uo pipefail
 command -v docker >/dev/null 2>&1 || { echo "\$(hostname): docker not found" >&2; exit 1; }
 echo "[tiny-test] host=\$(hostname) docker=\$(docker --version)"
 # Preserve the GPU selected by Slurm instead of unconditionally exposing host
-# GPU 0 to both vLLM and LMCache.  A single-GPU GRES normally maps this to 0,
-# while the fallback keeps non-Slurm/manual execution working.
-_gpu_visible="\${ROCR_VISIBLE_DEVICES:-\${CUDA_VISIBLE_DEVICES:-0}}"
-_gpu_visible="\${_gpu_visible%%,*}"
-export GPU="\${_gpu_visible}"
+# GPU 0 to both vLLM and LMCache.
+export AIC_SPUR_CLUSTER='${AIC_SPUR_CLUSTER}'
+# shellcheck source=/dev/null
+source '${AIC_DAY_DIR}/monitoring/monitoring-lib.sh'
+aic_resolve_gpu_visibility \
+    || { echo "[tiny-test] could not resolve the GPU allocation (refusing to default to GPU 0)" >&2; exit 1; }
+export GPU="\${AIC_ROCR_VISIBLE%%,*}"
 VLLM_CONTAINER="aic-vllm-gpu\${GPU}"
-echo "[tiny-test] allocated gpu=\${GPU} container=\${VLLM_CONTAINER}"
+echo "[tiny-test] allocated gpu: ROCR=\${AIC_ROCR_VISIBLE} HIP=\${AIC_HIP_VISIBLE} container=\${VLLM_CONTAINER}"
 
 # Load the image from the shared tarball only when needed (same marker logic as
 # smoke-test): reload when forced, absent, or the tarball is newer.

--- a/.slurm/run-cliff.sbatch
+++ b/.slurm/run-cliff.sbatch
@@ -612,7 +612,11 @@ compose() { docker compose -f "${COMPOSE_FILE}" "$@"; }
 export IMAGE_REF="${AIC_IMAGE}"
 export IMAGE_NAME="${AIC_IMAGE%:*}"
 export ROCM_ARCH="${ROCM_ARCH:-$(detect_gpu_arch)}"
-export GPU=0
+# Resolve the GPU allocation instead of hardcoding host GPU 0.
+source "${REPO}/monitoring/monitoring-lib.sh"
+aic_resolve_gpu_visibility \
+  || die "could not resolve the SPUR GPU allocation (refusing to default to GPU 0)"
+export GPU="${AIC_ROCR_VISIBLE%%,*}"
 export HF_HOME NVME_DATA NFS_DATA GDS_SLAB_DATA
 export LOG="${LOGDIR}" # lmcache/vllm container logs land under the job dir
 export HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1

--- a/.slurm/spur-gpu-allocation
+++ b/.slurm/spur-gpu-allocation
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Print the comma-separated GPU device IDs allocated to a Spur job."""
+
+import os
+import subprocess
+import sys
+
+DEFAULT_CONTROLLER = "http://crs-m2m-cpu-spur-005.crusoe.amd.com:6817"
+
+
+def encode_varint(value: int) -> bytes:
+    output = bytearray()
+    while value > 0x7F:
+        output.append((value & 0x7F) | 0x80)
+        value >>= 7
+    output.append(value)
+    return bytes(output)
+
+
+def protobuf_fields(data: bytes):
+    index = 0
+    while index < len(data):
+        tag = shift = 0
+        while True:
+            byte = data[index]
+            index += 1
+            tag |= (byte & 0x7F) << shift
+            if not byte & 0x80:
+                break
+            shift += 7
+        field, wire_type = tag >> 3, tag & 7
+
+        if wire_type == 0:
+            value = shift = 0
+            while True:
+                byte = data[index]
+                index += 1
+                value |= (byte & 0x7F) << shift
+                if not byte & 0x80:
+                    break
+                shift += 7
+        elif wire_type == 2:
+            size = shift = 0
+            while True:
+                byte = data[index]
+                index += 1
+                size |= (byte & 0x7F) << shift
+                if not byte & 0x80:
+                    break
+                shift += 7
+            value = data[index : index + size]
+            index += size
+        else:
+            raise RuntimeError(f"unsupported protobuf wire type {wire_type}")
+        yield field, value
+
+
+def first(entries, field, default=None):
+    return next((value for number, value in entries if number == field), default)
+
+
+def get_job(job_id: int):
+    controller_config = os.getenv("SPUR_CONTROLLER_ADDR", DEFAULT_CONTROLLER)
+    controllers = [endpoint.strip().rstrip("/") for endpoint in controller_config.split(",") if endpoint.strip()]
+    if not controllers:
+        raise RuntimeError("SPUR_CONTROLLER_ADDR contains no controller endpoints")
+
+    request = b"\x08" + encode_varint(job_id)
+    frame = b"\x00" + len(request).to_bytes(4, "big") + request
+    curl_args = [
+        "curl",
+        "--http2-prior-knowledge",
+        "-fsS",
+        "-H",
+        "Content-Type: application/grpc",
+        "-H",
+        "TE: trailers",
+        "--data-binary",
+        "@-",
+    ]
+    errors = []
+    for controller in controllers:
+        result = subprocess.run(
+            [*curl_args, f"{controller}/slurm.SlurmController/GetJob"],
+            input=frame,
+            capture_output=True,
+        )
+        if result.returncode == 0:
+            return result.stdout
+        detail = result.stderr.decode(errors="replace").strip()
+        errors.append(f"{controller}: {detail or f'curl exited {result.returncode}'}")
+    raise RuntimeError("all controller queries failed: " + "; ".join(errors))
+
+
+def main() -> None:
+    if len(sys.argv) != 2 or not sys.argv[1].isdigit():
+        raise SystemExit(f"usage: {sys.argv[0]} JOB_ID")
+
+    body = get_job(int(sys.argv[1]))
+    if len(body) < 5 or body[0] != 0:
+        raise RuntimeError("unexpected gRPC response")
+    message_size = int.from_bytes(body[1:5], "big")
+    job = list(protobuf_fields(body[5 : 5 + message_size]))
+    resources = list(protobuf_fields(first(job, 40, b"")))
+
+    gpu_ids = []
+    for _, allocation_map in (item for item in resources if item[0] == 3):
+        allocation_map = list(protobuf_fields(allocation_map))
+        resource = first(allocation_map, 1).decode()
+        if not resource.startswith("gpu"):
+            continue
+        allocations = list(protobuf_fields(first(allocation_map, 2)))
+        for _, device in (item for item in allocations if item[0] == 1):
+            gpu_ids.append(str(first(list(protobuf_fields(device)), 1, 0)))
+
+    print(",".join(gpu_ids))
+
+
+if __name__ == "__main__":
+    main()

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -161,6 +161,7 @@ sublicense
 sudo
 tm
 tmp
+unresolvable
 userspace
 vLLM
 vLLM's

--- a/Makefile
+++ b/Makefile
@@ -697,6 +697,9 @@ install-ci-scripts:            # Deploy .github/scripts/runners/*.sh to the runn
 #     gfx1201 -- see .slurm/run-build-distribute.sh).  RDNA parts have no
 #     NVMe-DMA hardware, so the gds arm is CDNA-only there.
 AIC_CLIFF_GFX ?=
+# GPUs reserved for a SPUR cliff submit. raise it only alongside a matching
+# tensor-parallel config.
+AIC_CLIFF_GPUS ?= 1
 ifeq ($(strip $(AIC_CLIFF_CONSTRAINT)),)
 ifneq ($(strip $(AIC_CLIFF_GFX)),)
 AIC_CLIFF_CONSTRAINT := $(shell echo '$(AIC_CLIFF_GFX)' | tr '[:lower:]' '[:upper:]')
@@ -706,7 +709,7 @@ endif
 endif
 ifeq ($(AIC_SPUR_CLUSTER),1)
 _CLIFF_SPUR_CTL  := SPUR_CONTROLLER_ADDR=$(AIC_SPUR_CONTROLLER)
-_CLIFF_SBATCH_ARGS := --partition=amd-spur --constraint= --gres= \
+_CLIFF_SBATCH_ARGS := --partition=amd-spur --constraint= --gpus=$(AIC_CLIFF_GPUS) \
     $(if $(AIC_CLIFF_NODE),--nodelist=$(AIC_CLIFF_NODE),)
 # SPUR sbatch does not support --parsable or --no-requeue; parse job id from "Submitted batch job N"
 _CLIFF_SUBMIT     = $(_CLIFF_SPUR_CTL) $(_CLIFF_STRIP) sbatch \

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -37,7 +37,11 @@
 #   NFS_DATA       — host path to NFS-over-RDMA mount (L2b; e.g. /mnt/lmcache-nfs)
 #
 # Optional:
-#   GPU                    — ROCR_VISIBLE_DEVICES for vllm and lmcache (default: 0)
+#   GPU                    — fallback GPU when no SPUR allocation is resolved (default: 0).
+#   AIC_ROCR_VISIBLE       — ROCR_VISIBLE_DEVICES for every service to isolate used GPUs
+#                            to the ones allocated to use by SPUR.
+#   AIC_HIP_VISIBLE        — HIP_VISIBLE_DEVICES + CUDA_VISIBLE_DEVICES.  RELATIVE
+#                            indices ( e.g., 0..n-1).
 #   GDS_MODE               — set to 1 to enable hipFile NVMe slab as L1 (requires GDS_SLAB_DATA)
 #   GDS_SLAB_DATA          — host path for the hipFile slab file (required when GDS_MODE=1)
 #   AIC_L2_BACKEND         — nixl (default AIS_MT + POSIX L2), local_disk (native
@@ -207,7 +211,10 @@ services:
       # Must share the SAME GPU as the vllm service: LMCacheMPConnector registers
       # vLLM's KV tensors via CUDA IPC, which fails ("invalid device pointer") if
       # lmcache lands on a different device.  Mirror vllm's ROCR_VISIBLE_DEVICES.
-      - ROCR_VISIBLE_DEVICES=${GPU:-0}
+      #
+      - ROCR_VISIBLE_DEVICES=${AIC_ROCR_VISIBLE:-${GPU:-0}}
+      - HIP_VISIBLE_DEVICES=${AIC_HIP_VISIBLE:-0}
+      - CUDA_VISIBLE_DEVICES=${AIC_HIP_VISIBLE:-0}
       - PYTHONHASHSEED=0
       - TZ=${TZ:-America/Edmonton}
     # The entrypoint script selects the L1/L2 topology from GDS_MODE +
@@ -374,7 +381,9 @@ services:
       - TORCH_HOME=/hf/torch
       - TORCHINDUCTOR_CACHE_DIR=/hf/torch_inductor
       - VLLM_TARGET_DEVICE=rocm
-      - ROCR_VISIBLE_DEVICES=${GPU:-0}
+      - ROCR_VISIBLE_DEVICES=${AIC_ROCR_VISIBLE:-${GPU:-0}}
+      - HIP_VISIBLE_DEVICES=${AIC_HIP_VISIBLE:-0}
+      - CUDA_VISIBLE_DEVICES=${AIC_HIP_VISIBLE:-0}
       - AMDGCN_USE_BUFFER_OPS=0
       - MIOPEN_FIND_MODE=FAST
       - MIOPEN_USER_DB_PATH=/app/miopen
@@ -510,6 +519,10 @@ services:
     container_name: aic-amdgpu-exporter
     networks: [aic]
     restart: unless-stopped
+    environment:
+      - ROCR_VISIBLE_DEVICES=${AIC_ROCR_VISIBLE:-${GPU:-0}}
+      - HIP_VISIBLE_DEVICES=${AIC_HIP_VISIBLE:-0}
+      - CUDA_VISIBLE_DEVICES=${AIC_HIP_VISIBLE:-0}
     devices:
       - /dev/kfd
       - /dev/dri

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -25,7 +25,10 @@
 | `AIC_TINY_MODEL` | `Qwen/Qwen2.5-0.5B-Instruct` | Model served by `make tiny-test` (end-to-end serve check) |
 | `HF_HOME` | `~/.cache/huggingface` (`/shared_nfs/huggingface` on SPUR) | Persistent Hugging Face cache used by normal, cliff, monitoring, and tiny-model paths |
 | `TENSOR_PARALLEL_SIZE` | `1` | vLLM tensor parallel degree |
-| `GPU` | `0` | ROCR_VISIBLE_DEVICES for the vllm container |
+| `GPU` | `0` | Fallback GPU used when no SPUR allocation is resolved (local `make up`, workstations). |
+| `AIC_ROCR_VISIBLE` | resolved from the SPUR allocation | `ROCR_VISIBLE_DEVICES` for every container with `/dev/kfd`. **Absolute** host GPU IDs (e.g. `3` or `2,5`). Falls back to `${GPU:-0}` off cluster; on `AIC_SPUR_CLUSTER=1` an unresolvable allocation fails the job rather than defaulting to GPU 0 |
+| `AIC_HIP_VISIBLE` | resolved from the SPUR allocation | `HIP_VISIBLE_DEVICES` and `CUDA_VISIBLE_DEVICES`. **Relative** indices `0..n-1` (e.g. `0` or `0,1`) — HIP filters the set ROCR already filtered, so absolute IDs would be out of range. Set together with `AIC_ROCR_VISIBLE` |
+| `AIC_CLIFF_GPUS` | `1` | GPUs reserved by a SPUR `make cliff-submit` (`--gpus=N`). Raise only alongside a matching `TENSOR_PARALLEL_SIZE` |
 | `AIC_NVME_AUTO` | `1` (cliff) | Auto-detect a dedicated local NVMe for the LMCache tiers: reuse a mounted `aic-lmcache` volume, else format+mount a raw non-root spare, else use a non-root mounted NVMe, else node-local `/tmp`. `0` forces `/tmp`; needs passwordless `sudo` to format/mount |
 | `AIC_NVME_MOUNT` | `/mnt/aic-lmcache` | Mountpoint used when auto-provisioning a spare NVMe (left mounted for reuse) |
 | `AIC_MONITORING` | `1` | Auto-start the Prometheus sidecar in cliff sbatch runs (`0` to skip) |

--- a/monitoring/docker-compose.monitoring.yml
+++ b/monitoring/docker-compose.monitoring.yml
@@ -99,6 +99,10 @@ services:
     profiles: ["exporters", "exporters-safe"]
     network_mode: host
     restart: unless-stopped
+    environment:
+      - ROCR_VISIBLE_DEVICES=${AIC_ROCR_VISIBLE:-${GPU:-0}}
+      - HIP_VISIBLE_DEVICES=${AIC_HIP_VISIBLE:-0}
+      - CUDA_VISIBLE_DEVICES=${AIC_HIP_VISIBLE:-0}
     devices:
       - /dev/kfd
       - /dev/dri
@@ -183,6 +187,10 @@ services:
     pid: "${AIC_HSA_SNOOP_PID_MODE:-container:aic-lmcache}"
     privileged: true
     restart: unless-stopped
+    environment:
+      - ROCR_VISIBLE_DEVICES=${AIC_ROCR_VISIBLE:-${GPU:-0}}
+      - HIP_VISIBLE_DEVICES=${AIC_HIP_VISIBLE:-0}
+      - CUDA_VISIBLE_DEVICES=${AIC_HIP_VISIBLE:-0}
     devices:
       - /dev/kfd
       - /dev/dri

--- a/monitoring/monitoring-lib.sh
+++ b/monitoring/monitoring-lib.sh
@@ -43,6 +43,44 @@
 # and run-build-distribute.sh each define their own prefixed log()).
 declare -F log >/dev/null 2>&1 || log() { printf '[monitoring] %s\n' "$*" >&2; }
 
+# --- GPU visibility resolution ------------------------------------------------
+# Resolve the SPUR GPU allocation for this job and export the values the compose
+# files and `docker run` call sites interpolate:
+#
+#   AIC_ROCR_VISIBLE  absolute host GPU IDs   -> ROCR_VISIBLE_DEVICES
+#   AIC_HIP_VISIBLE   relative indices 0..n-1 -> HIP_VISIBLE_DEVICES + CUDA_VISIBLE_DEVICES
+aic_resolve_gpu_visibility() {
+    local helper rocr n hip
+    helper="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.slurm" 2>/dev/null && pwd)/spur-gpu-allocation"
+
+    # Fail-closed only on SPUR; everywhere else (workstations, manual runs) fall
+    # back to today's behaviour so local development is unaffected.
+    _aic_gpu_fallback() {
+        if [[ "${AIC_SPUR_CLUSTER:-0}" == "1" ]]; then
+            printf 'aic_resolve_gpu_visibility: %s\n' "$1" >&2
+            return 1
+        fi
+        export AIC_ROCR_VISIBLE="${GPU:-0}" AIC_HIP_VISIBLE=0
+        return 0
+    }
+
+    [[ -n "${SLURM_JOB_ID:-}" ]] || { _aic_gpu_fallback "SLURM_JOB_ID unset; cannot resolve a GPU allocation"; return $?; }
+    [[ -x "${helper}" ]] || { _aic_gpu_fallback "helper not found or not executable: ${helper}"; return $?; }
+
+    rocr="$("${helper}" "${SLURM_JOB_ID}" 2>&1)" \
+        || { _aic_gpu_fallback "helper failed for job ${SLURM_JOB_ID}: ${rocr}"; return $?; }
+
+    [[ -n "${rocr}" ]] || { _aic_gpu_fallback "no GPUs allocated to job ${SLURM_JOB_ID} (is a GPU requested?)"; return $?; }
+    [[ "${rocr}" =~ ^[0-9]+(,[0-9]+)*$ ]] \
+        || { _aic_gpu_fallback "malformed allocation for job ${SLURM_JOB_ID}: ${rocr}"; return $?; }
+
+    n="$(awk -F, '{print NF}' <<<"${rocr}")"
+    hip="$(seq -s, 0 "$((n - 1))")"
+
+    export AIC_ROCR_VISIBLE="${rocr}" AIC_HIP_VISIBLE="${hip}"
+    log "GPU allocation for job ${SLURM_JOB_ID}: ROCR=${AIC_ROCR_VISIBLE} HIP=${AIC_HIP_VISIBLE}"
+}
+
 have_compose() { docker compose version >/dev/null 2>&1; }
 
 # Ensure the `docker compose` (v2) plugin is available.  Docker checks


### PR DESCRIPTION
## Motivation

We want to isolate the Docker containers that we run in CI to only use the GPUs that we allocated with SPUR. This stops CI from erroneously failing by using other people's reserved GPUs.

## Technical Details

I reuse a script made by @amd-ivaganev that detects the allocated GPUs given a SPUR job ID. 

I made sure to check whether the user is using SPUR (checking the AIC_SPUR_CLUSTER env var) before using this logic. If the user isn't running on SPUR, it just uses the normal GPU 0.

## Test Plan

Run CI (I also triggered a workflow manually to test them).

## Test Result

CI passes (manual workflow passed)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
