### PR TITLE
fix(slurm): use SPUR GPU requests and preserve visibility

### DIFF
--- a/.slurm/run-build-distribute.sh
+++ b/.slurm/run-build-distribute.sh
@@ -123,8 +123,9 @@
 #                        (default: <site>&GFX942&NVME -- MI300X + local NVMe).
 #                        Used only when AIC_TEST_NODE is unset.
 #   AIC_TEST_NODE        pin an exact test node via --nodelist  (default: unset)
-#   AIC_TEST_GRES        Slurm GPU resource request for smoke/tiny tests
+#   AIC_TEST_GRES        Standard-Slurm GPU GRES request for smoke/tiny tests
 #                        (default: gpu:1)
+#   AIC_TEST_GPUS        SPUR GPU request for smoke/tiny tests (default: 1)
 #   AIC_TEST_TIME        test job time limit               (default: 00:20:00)
 #   AIC_TEST_CPUS        --cpus-per-task for the test job  (default: 8)
 #   AIC_TEST_MEM         --mem for the test job            (default: 32G)
@@ -219,6 +220,7 @@ AIC_TEST_TIME="${AIC_TEST_TIME:-00:45:00}"
 AIC_TEST_CPUS="${AIC_TEST_CPUS:-8}"
 AIC_TEST_MEM="${AIC_TEST_MEM:-32G}"
 AIC_TEST_GRES="${AIC_TEST_GRES:-gpu:1}"
+AIC_TEST_GPUS="${AIC_TEST_GPUS:-1}"
 
 # --- tiny-test: end-to-end serve check with a tiny model ---------------------
 # Brings up the compose MP stack (standalone lmcache + vLLM LMCacheMPConnector)
@@ -1123,12 +1125,17 @@ exit \${img_rc}
 REMOTE
 )"
 
-    # Always reserve a GPU.  Omitting GRES on SPUR lets Slurm co-locate this job
-    # with an existing GPU workload, even though the test launches ROCm code.
-    local -a _gres_arg=(--gres="${AIC_TEST_GRES}")
+    # Always reserve a GPU. SPUR requires --gpus; standard Slurm deployments
+    # retain the configurable GRES request.
+    local -a _gpu_request
+    if [[ "${AIC_SPUR_CLUSTER}" == "1" ]]; then
+        _gpu_request=(--gpus="${AIC_TEST_GPUS}")
+    else
+        _gpu_request=(--gres="${AIC_TEST_GRES}")
+    fi
     _sbatch_run aic-test smoke-test "${remote_script}" \
         "${_sel[@]}" \
-        "${_gres_arg[@]}" \
+        "${_gpu_request[@]}" \
         --nodes=1 --ntasks=1 \
         --cpus-per-task="${AIC_TEST_CPUS}" --mem="${AIC_TEST_MEM}" \
         --time="${AIC_TEST_TIME}"
@@ -1287,11 +1294,16 @@ exit 1
 REMOTE
 )"
 
-    # Always reserve a GPU; see cmd_test for why SPUR must not omit GRES.
-    local -a _gres_arg=(--gres="${AIC_TEST_GRES}")
+    # Always reserve a GPU; see cmd_test for the SPUR-specific request form.
+    local -a _gpu_request
+    if [[ "${AIC_SPUR_CLUSTER}" == "1" ]]; then
+        _gpu_request=(--gpus="${AIC_TEST_GPUS}")
+    else
+        _gpu_request=(--gres="${AIC_TEST_GRES}")
+    fi
     _sbatch_run aic-tiny-test tiny-test "${remote_script}" \
         "${_sel[@]}" \
-        "${_gres_arg[@]}" \
+        "${_gpu_request[@]}" \
         --nodes=1 --ntasks=1 \
         --cpus-per-task="${AIC_TINY_CPUS}" --mem="${AIC_TINY_MEM}" \
         --time="${AIC_TINY_TIME}"

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -25,10 +25,11 @@
 | `AIC_TINY_MODEL` | `Qwen/Qwen2.5-0.5B-Instruct` | Model served by `make tiny-test` (end-to-end serve check) |
 | `HF_HOME` | `~/.cache/huggingface` (`/shared_nfs/huggingface` on SPUR) | Persistent Hugging Face cache used by normal, cliff, monitoring, and tiny-model paths |
 | `TENSOR_PARALLEL_SIZE` | `1` | vLLM tensor parallel degree |
-| `GPU` | `0` | Fallback GPU used when no SPUR allocation is resolved (local `make up`, workstations). |
-| `AIC_ROCR_VISIBLE` | resolved from the SPUR allocation | `ROCR_VISIBLE_DEVICES` for every container with `/dev/kfd`. **Absolute** host GPU IDs (e.g. `3` or `2,5`). Falls back to `${GPU:-0}` off cluster; on `AIC_SPUR_CLUSTER=1` an unresolvable allocation fails the job rather than defaulting to GPU 0 |
-| `AIC_HIP_VISIBLE` | resolved from the SPUR allocation | `HIP_VISIBLE_DEVICES` and `CUDA_VISIBLE_DEVICES`. **Relative** indices `0..n-1` (e.g. `0` or `0,1`) — HIP filters the set ROCR already filtered, so absolute IDs would be out of range. Set together with `AIC_ROCR_VISIBLE` |
+| `GPU` | `0` | Local fallback GPU when no scheduler visibility variable is set. |
+| `AIC_ROCR_VISIBLE` | resolved GPU set | `ROCR_VISIBLE_DEVICES` for every container with `/dev/kfd`. **Absolute** host GPU IDs (e.g. `3` or `2,5`). On standard Slurm, preserves `ROCR_VISIBLE_DEVICES`, then `HIP_VISIBLE_DEVICES`, then `CUDA_VISIBLE_DEVICES`; on SPUR it comes from the controller allocation and an unresolvable allocation fails the job. |
+| `AIC_HIP_VISIBLE` | relative to `AIC_ROCR_VISIBLE` | `HIP_VISIBLE_DEVICES` and `CUDA_VISIBLE_DEVICES`. **Relative** indices `0..n-1` (e.g. `0` or `0,1`) — HIP filters the set ROCR already filtered. Set together with `AIC_ROCR_VISIBLE`. |
 | `AIC_CLIFF_GPUS` | `1` | GPUs reserved by a SPUR `make cliff-submit` (`--gpus=N`). Raise only alongside a matching `TENSOR_PARALLEL_SIZE` |
+| `AIC_TEST_GPUS` | `1` | GPUs reserved by SPUR `smoke-test` and `tiny-test` jobs (`--gpus=N`). Standard Slurm continues to use `AIC_TEST_GRES`. |
 | `AIC_NVME_AUTO` | `1` (cliff) | Auto-detect a dedicated local NVMe for the LMCache tiers: reuse a mounted `aic-lmcache` volume, else format+mount a raw non-root spare, else use a non-root mounted NVMe, else node-local `/tmp`. `0` forces `/tmp`; needs passwordless `sudo` to format/mount |
 | `AIC_NVME_MOUNT` | `/mnt/aic-lmcache` | Mountpoint used when auto-provisioning a spare NVMe (left mounted for reuse) |
 | `AIC_MONITORING` | `1` | Auto-start the Prometheus sidecar in cliff sbatch runs (`0` to skip) |

--- a/monitoring/monitoring-lib.sh
+++ b/monitoring/monitoring-lib.sh
@@ -44,40 +44,56 @@
 declare -F log >/dev/null 2>&1 || log() { printf '[monitoring] %s\n' "$*" >&2; }
 
 # --- GPU visibility resolution ------------------------------------------------
-# Resolve the SPUR GPU allocation for this job and export the values the compose
-# files and `docker run` call sites interpolate:
+# Resolve GPU visibility for this job and export the values the compose files and
+# `docker run` call sites interpolate:
 #
 #   AIC_ROCR_VISIBLE  absolute host GPU IDs   -> ROCR_VISIBLE_DEVICES
 #   AIC_HIP_VISIBLE   relative indices 0..n-1 -> HIP_VISIBLE_DEVICES + CUDA_VISIBLE_DEVICES
 aic_resolve_gpu_visibility() {
     local helper rocr n hip
-    helper="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.slurm" 2>/dev/null && pwd)/spur-gpu-allocation"
 
-    # Fail-closed only on SPUR; everywhere else (workstations, manual runs) fall
-    # back to today's behaviour so local development is unaffected.
-    _aic_gpu_fallback() {
-        if [[ "${AIC_SPUR_CLUSTER:-0}" == "1" ]]; then
-            printf 'aic_resolve_gpu_visibility: %s\n' "$1" >&2
+    _aic_set_gpu_visibility() {
+        local device_ids="$1"
+        [[ "${device_ids}" =~ ^[^,[:space:]]+(,[^,[:space:]]+)*$ ]] || {
+            printf 'aic_resolve_gpu_visibility: malformed GPU visibility: %s\n' "${device_ids}" >&2
             return 1
-        fi
-        export AIC_ROCR_VISIBLE="${GPU:-0}" AIC_HIP_VISIBLE=0
-        return 0
+        }
+        n="$(awk -F, '{print NF}' <<<"${device_ids}")"
+        hip="$(seq -s, 0 "$((n - 1))")"
+        export AIC_ROCR_VISIBLE="${device_ids}" AIC_HIP_VISIBLE="${hip}"
     }
 
-    [[ -n "${SLURM_JOB_ID:-}" ]] || { _aic_gpu_fallback "SLURM_JOB_ID unset; cannot resolve a GPU allocation"; return $?; }
-    [[ -x "${helper}" ]] || { _aic_gpu_fallback "helper not found or not executable: ${helper}"; return $?; }
+    # Only SPUR needs a controller query.  Standard Slurm has already selected
+    # the GPU and exposes that choice via its normal visibility environment.
+    # Do not replace it with GPU 0 or contact SPUR from another cluster.
+    if [[ "${AIC_SPUR_CLUSTER:-0}" != "1" ]]; then
+        rocr="${ROCR_VISIBLE_DEVICES:-${HIP_VISIBLE_DEVICES:-${CUDA_VISIBLE_DEVICES:-${GPU:-0}}}}"
+        _aic_set_gpu_visibility "${rocr}" || return 1
+        log "GPU visibility: ROCR=${AIC_ROCR_VISIBLE} HIP=${AIC_HIP_VISIBLE}"
+        return 0
+    fi
+
+    helper="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.slurm" 2>/dev/null && pwd)/spur-gpu-allocation"
+    [[ -n "${SLURM_JOB_ID:-}" ]] || {
+        printf 'aic_resolve_gpu_visibility: SLURM_JOB_ID unset; cannot resolve a SPUR GPU allocation\n' >&2
+        return 1
+    }
+    [[ -x "${helper}" ]] || {
+        printf 'aic_resolve_gpu_visibility: helper not found or not executable: %s\n' "${helper}" >&2
+        return 1
+    }
 
     rocr="$("${helper}" "${SLURM_JOB_ID}" 2>&1)" \
-        || { _aic_gpu_fallback "helper failed for job ${SLURM_JOB_ID}: ${rocr}"; return $?; }
+        || { printf 'aic_resolve_gpu_visibility: helper failed for job %s: %s\n' "${SLURM_JOB_ID}" "${rocr}" >&2; return 1; }
 
-    [[ -n "${rocr}" ]] || { _aic_gpu_fallback "no GPUs allocated to job ${SLURM_JOB_ID} (is a GPU requested?)"; return $?; }
+    [[ -n "${rocr}" ]] || {
+        printf 'aic_resolve_gpu_visibility: no GPUs allocated to job %s (is a GPU requested?)\n' "${SLURM_JOB_ID}" >&2
+        return 1
+    }
     [[ "${rocr}" =~ ^[0-9]+(,[0-9]+)*$ ]] \
-        || { _aic_gpu_fallback "malformed allocation for job ${SLURM_JOB_ID}: ${rocr}"; return $?; }
+        || { printf 'aic_resolve_gpu_visibility: malformed allocation for job %s: %s\n' "${SLURM_JOB_ID}" "${rocr}" >&2; return 1; }
 
-    n="$(awk -F, '{print NF}' <<<"${rocr}")"
-    hip="$(seq -s, 0 "$((n - 1))")"
-
-    export AIC_ROCR_VISIBLE="${rocr}" AIC_HIP_VISIBLE="${hip}"
+    _aic_set_gpu_visibility "${rocr}" || return 1
     log "GPU allocation for job ${SLURM_JOB_ID}: ROCR=${AIC_ROCR_VISIBLE} HIP=${AIC_HIP_VISIBLE}"
 }
 


### PR DESCRIPTION
## Summary

- Submit SPUR smoke and tiny-test jobs with `--gpus`, while retaining configurable GRES requests on standard Slurm.
- Preserve scheduler-provided device visibility outside SPUR and restrict controller allocation lookups to SPUR jobs.
- Document `AIC_TEST_GPUS` and the resolved visibility behavior.

## Validation

- Tested standard ROCR, HIP fallback, local GPU fallback, and SPUR missing-job failure paths.
- Ran shell syntax checks, Python compilation, and `git diff --check`.