### PR TITLE
fix(ci): scope SPUR build cache to a per-user NFS directory

### DIFF
--- a/.github/scripts/runners/spur-dist-build.sh
+++ b/.github/scripts/runners/spur-dist-build.sh
@@ -43,7 +43,10 @@ SHORT="${SHA:0:7}"
 WORKDIR="$HOME/Projects/rocm-aic.${SHORT}.${AIC_CI_RUN_KEY}"
 CI_STORAGE_ROOT="${AIC_CI_STORAGE_ROOT:-$HOME/Projects/rocm-aic-ci}"
 TARBALL_DIR="${CI_STORAGE_ROOT}/images/aic-ci-${SHORT}"
-CACHE_DIR="${CI_STORAGE_ROOT}/buildcache"
+# Build cache lives on shared NFS under the running user, never in $HOME (small
+# and quota'd on SPUR) and never in a path shared across users (not writable by
+# all of them).  Matches the AIC_SPUR_CLUSTER=1 default in the Makefile.
+CACHE_DIR="${AIC_SHARED_NFS%/}/${USER:-$(id -un)}/buildcache"
 CONTROL_PREFIX="${CI_STORAGE_ROOT}/control/${SHORT}.${AIC_CI_RUN_KEY}.${AIC_CI_STAGE}"
 PID_FILE="${CONTROL_PREFIX}.pid"
 JOB_FILE="${CONTROL_PREFIX}.job"

--- a/Makefile
+++ b/Makefile
@@ -157,8 +157,10 @@ ifeq ($(AIC_SPUR_CLUSTER),1)
 export AIC_SPUR_CLUSTER
 export AIC_SPUR_CONTROLLER  ?= $(SPUR_CONTROLLER_ADDR)
 export AIC_IMAGE_DIR        ?= $(AIC_SHARED_NFS)/rocm-aic/images
-# Cache export is best-effort, so SPUR runners can share one BuildKit cache.
-export AIC_CACHE_DIR        ?= $(AIC_SHARED_NFS)/rocm-aic/images/buildcache
+# Per-user BuildKit cache on the shared NFS volume: $HOME is small and quota'd
+# on SPUR, and a cache shared across users is not writable by all of them.
+# Cache export is best-effort, so a user's concurrent builds still share it.
+export AIC_CACHE_DIR        ?= $(AIC_SHARED_NFS)/$(USER)/buildcache
 # SPUR nodes have 8x NVMe drives combined into a single LVM at /mnt/m2m_nobackup.
 # Use override (not ?=) so these win over the top-level ?= defaults set earlier.
 # HF_HOME points to the cluster-wide model cache since /scratch does not exist


### PR DESCRIPTION
## Motivation

- SPUR prefers large files to be in nfs rather than /home (see email regarding /home capacity)
- buildcache must be user-specific, because concurrent readers/writers of buildcache are not permitted

## Technical Details

N/A

## Test Plan

Run CI.

## Test Result

CI passes.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
