### PR TITLE
Install validated ROCm attention backends

### DIFF
--- a/.github/workflows/aic-export.yml
+++ b/.github/workflows/aic-export.yml
@@ -60,23 +60,46 @@ jobs:
               exit 1
             }
 
+          # CDNA override: FlashAttention included (ROCM_ARCH unset → conservative default)
           override_tag="$(
             ROCM_VERSION=8.7.6 \
             PYTORCH_BRANCH=release/9.9 \
             VLLM_REF=v1.2.3 \
+            AITER_REF=v0.1.19 \
+            FLASH_ATTN_REF=0e60e394 \
             LMCACHE_REF=v2.3.4 \
             NIXL_REF=v3.4.5 \
             HSA_SNOOP_REF=v4.5.6 \
               bash docker/scripts/aic-image-tag.sh
           )"
-          expected_override="${aic_version}-rocm8.7.6-pytorch9.9-vllm1.2.3-lmcache2.3.4-nixl3.4.5-hsasnoop4.5.6"
+          expected_override="${aic_version}-rocm8.7.6-pytorch9.9-vllm1.2.3-aiter0.1.19-fa0e60e394-lmcache2.3.4-nixl3.4.5-hsasnoop4.5.6"
           [[ "${override_tag}" == "${expected_override}" ]] \
             || {
               echo "ERROR: expected ${expected_override}, got ${override_tag}" >&2
               exit 1
             }
+          # RDNA override: FlashAttention omitted for non-CDNA arch
+          rdna_tag="$(
+            ROCM_ARCH=gfx1201 \
+            ROCM_VERSION=8.7.6 \
+            PYTORCH_BRANCH=release/9.9 \
+            VLLM_REF=v1.2.3 \
+            AITER_REF=v0.1.19 \
+            FLASH_ATTN_REF=0e60e394 \
+            LMCACHE_REF=v2.3.4 \
+            NIXL_REF=v3.4.5 \
+            HSA_SNOOP_REF=v4.5.6 \
+              bash docker/scripts/aic-image-tag.sh
+          )"
+          expected_rdna="${aic_version}-rocm8.7.6-pytorch9.9-vllm1.2.3-aiter0.1.19-lmcache2.3.4-nixl3.4.5-hsasnoop4.5.6"
+          [[ "${rdna_tag}" == "${expected_rdna}" ]] \
+            || {
+              echo "ERROR: RDNA tag: expected ${expected_rdna}, got ${rdna_tag}" >&2
+              exit 1
+            }
           echo "Default tag: ${default_tag}"
-          echo "Override tag: ${override_tag}"
+          echo "Override tag (CDNA): ${override_tag}"
+          echo "Override tag (RDNA): ${rdna_tag}"
 
       - name: Validate release notes renderer
         run: |

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -3,6 +3,9 @@ AIC
 ais
 AIS
 AIS_MT
+AITER
+CPython
+FlashAttention
 amd
 AMD
 amdgpu

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,11 +28,12 @@ vLLM's engine core fails to start on gfx950 nodes — Triton kernel calls
 failed because Triton was disabled at startup due to circular import side-effects
 in vLLM's platform detection code.
 
-The current Dockerfile intentionally uses `torch 2.13.0+rocm7.2` with vLLM
-`v0.27.1`; validate changes to either pin on an MI355X before changing this
-historical workaround.
+The current Dockerfile uses vLLM `v0.28.0` with the matching vLLM ROCm wheel
+set: `torch 2.12.0+git6bbd260` and `torchvision 0.27.1+df56172` from
+`wheels.vllm.ai/rocm`. Validate changes to either pin on an MI355X before
+changing this historical workaround.
 
-vLLM v0.27.1 no longer calls `logger.warning_once()` from
+vLLM v0.28.0 no longer calls `logger.warning_once()` from
 `vllm.platforms.rocm._get_gcn_arch()` when the amdsmi probe fails, so the old
 ROCm-AIC circular-import patch was retired. The SPUR validation must confirm
 that the vLLM ROCm-platform import and engine startup remain healthy.
@@ -43,11 +44,12 @@ that the vLLM ROCm-platform import and engine startup remain healthy.
    (MI355X) specifically; gfx942 nodes have not been fully tested but the
    hipErrorInvalidImage issue is resolved with `AIC_ROCM_ARCH=gfx942`.
 
-2. **Use the current pytorch.org pin** — the Dockerfile already installs
-   `torch 2.13.0+rocm7.2` from `download.pytorch.org/whl/rocm7.2`; retain it
-   unless SPUR validation proves a different compatible pair is needed.
+2. **Use the current vLLM ROCm pin** — the Dockerfile already installs
+   `torch 2.12.0+git6bbd260` from `wheels.vllm.ai/rocm`; retain the matching
+   wheel set unless SPUR validation proves a different compatible pair is
+   needed.
 
-3. **Upgrade vLLM further** — only after validating the current `v0.27.1`
+3. **Upgrade vLLM further** — only after validating the current `v0.28.0`
    stack; newer vLLM versions may support the ROCm 7.14 Triton combination.
 
 ### SPUR cluster cliff submission quirks

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ override AIC_VERSION := $(strip $(file <$(REPO_ROOT)/VERSION))
 
 # PyTorch, vLLM, and all deps are source-built; PYTORCH_BRANCH, VLLM_REF, and
 # LLM_EMU_REF are the key version knobs.  hipFile ships in the ROCm base image.
-_FRAMEWORK_VERSION_ARGS := AIC_VERSION ROCM_VERSION PYTORCH_BRANCH VLLM_REF LLM_EMU_REF LMCACHE_REF NIXL_REF HSA_SNOOP_REF
+_FRAMEWORK_VERSION_ARGS := AIC_VERSION ROCM_VERSION PYTORCH_BRANCH VLLM_REF LLM_EMU_REF AITER_REF FLASH_ATTN_REF LMCACHE_REF NIXL_REF HSA_SNOOP_REF
 _single_quote := '
 _shell_quote = '$(subst $(_single_quote),'"'"',$(1))'
 _FRAMEWORK_VERSION_ENV := $(foreach _arg,$(_FRAMEWORK_VERSION_ARGS),$(if $(filter undefined,$(origin $(_arg))),,$(_arg)=$(call _shell_quote,$(value $(_arg)))))
@@ -87,6 +87,18 @@ export NVME_DATA NFS_DATA
 export VLLM_MODEL TENSOR_PARALLEL_SIZE
 export VLM_GPU_MEMORY_UTILIZATION VLM_MAX_MODEL_LEN VLM_MAX_NUM_BATCHED_TOKENS VLM_BLOCK_SIZE
 export NIXL_GIT_URL NIXL_SHA
+
+# Compose passes a declared build argument through only when it is present in
+# its environment. Do not export empty attention-backend overrides: an empty
+# value would override the pinned Dockerfile default and produce an invalid
+# AITER release URL. A non-empty command-line or environment override remains
+# available for validated version-pair updates.
+ifneq ($(strip $(AITER_REF)),)
+export AITER_REF
+endif
+ifneq ($(strip $(FLASH_ATTN_REF)),)
+export FLASH_ATTN_REF
+endif
 
 comma := ,
 # The whole stack is `docker compose` (v2) only -- the docker-compose v1 standalone

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ platform.
 | --- | --- | --- |
 | Base OS | `rocm/dev-ubuntu-24.04:7.14.1-full` | Ubuntu 24.04, ROCm 7.14, Python 3.12 |
 | vLLM | `github.com/vllm-project/vllm` (source build) | `v0.28.0` + 3 AMD patches |
+| AITER | `ROCm/aiter` (official ROCm 7.2 wheel) | `v0.1.19` (vLLM ROCm-validated) |
+| FlashAttention | `Dao-AILab/flash-attention` (source build) | `0e60e394` (vLLM ROCm-validated) |
 | LMCache | `LMCache/LMCache` (upstream) | `v0.5.4` + 16 AMD patches |
 | NIXL | `ai-dynamo/nixl` (upstream) | `v1.4.1` + `nixl-rocm-ais-mt.patch` |
 | hsa-snoop | `sbates130272/hsa-snoop` (source build) | `v1.1.0` |

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -114,8 +114,8 @@ ARG ROCM_ARCH
 ARG BUILD_JOBS
 ARG VLLM_GIT_URL
 ARG VLLM_REF
+ARG AITER_GIT_URL
 ARG AITER_REF
-ARG AITER_WHEEL_ROCM
 ARG FLASH_ATTN_GIT_URL
 ARG FLASH_ATTN_REF
 ARG NIXL_GIT_URL
@@ -469,8 +469,8 @@ ARG ROCM_ARCH
 ARG BUILD_JOBS=
 
 # ROCm attention backends — validated pair, update together after revalidation.
+ARG AITER_GIT_URL=https://github.com/ROCm/aiter.git
 ARG AITER_REF=v0.1.19
-ARG AITER_WHEEL_ROCM=7.2
 ARG FLASH_ATTN_GIT_URL=https://github.com/Dao-AILab/flash-attention.git
 ARG FLASH_ATTN_REF=0e60e394
 
@@ -499,24 +499,22 @@ ARG AIC_UCX_FAST=
 # specific model.  vLLM can then select ROCM_AITER_FA or FLASH_ATTN whenever a
 # loaded model and its runtime configuration support it.
 #
-# AITER's source wheel does not include its required `module_aiter_core` unless
-# every JIT kernel is eagerly prebuilt.  That takes more than an hour and is
-# incompatible with this image's MI355-stable Torch runtime.  Use AITER's
-# matching upstream binary release instead.  The release artifact contains the
-# gfx942 and gfx950 kernels and leaves only model-specific work for runtime.
-# AITER imports rocminfo to detect the installed GPU, so its actual import is
-# checked in the GPU-enabled smoke test after the image build rather than here.
+# Build AITER from source at the pinned ref, against the source-built torch in
+# this stage.  The pre-built upstream wheels (amd_aiter-*+rocm7.2) are compiled
+# against pytorch.org's ROCm 7.2 torch binary, whose ABI diverges from our
+# source-built torch-2.13: the symbol c10::impl::cow::materialize_cow_storage
+# is present in the wheel's .so files but not exported by our libtorch, causing
+# an ImportError at EngineCore startup.  Building from source guarantees that
+# every compiled .so links against the libtorch and libc10 that are present at
+# runtime.
 #
-# AITER_REF must name a release that publishes this CPython/ROCm wheel format.
-# It is generated from the ref so a deliberate, validated override cannot
-# silently install a different AITER revision.
+# AITER_REF must name a git tag or commit in ROCm/aiter.  Keep it in sync with
+# the FlashAttention ref below — they share the composable_kernel submodule and
+# must be validated together.
+# hadolint ignore=SC2039
 RUN --mount=type=cache,target=/root/.cache/pip \
+    --mount=type=cache,target=/root/.cache/ccache \
     mkdir -p /wheels && \
-    aiter_version="${AITER_REF#v}" && \
-    aiter_wheel="/wheels/amd_aiter-${aiter_version}+rocm${AITER_WHEEL_ROCM}.manylinux.2.28-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl" && \
-    curl --fail --location --retry 5 --retry-all-errors \
-        "https://github.com/ROCm/aiter/releases/download/${AITER_REF}/amd_aiter-${aiter_version}%2Brocm${AITER_WHEEL_ROCM}.manylinux.2.28-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl" \
-        --output "${aiter_wheel}" && \
     pip3 install --no-cache-dir \
         "pandas==3.0.3" \
         "psutil==7.2.2" \
@@ -525,8 +523,16 @@ RUN --mount=type=cache,target=/root/.cache/pip \
         "pybind11==3.0.4" \
         "ninja==1.13.0" \
         "flydsl==0.2.4" && \
-    pip3 install --no-cache-dir --no-deps "${aiter_wheel}" && \
-    python3 -c 'import importlib.util, pathlib; spec = importlib.util.find_spec("aiter"); assert spec and spec.submodule_search_locations; package_dir = pathlib.Path(next(iter(spec.submodule_search_locations))); assert any(package_dir.glob("jit/module_aiter_core*.so")), "AITer core module is missing"; print("AITer installed:", package_dir)'
+    git clone --depth 1 --branch "${AITER_REF}" "${AITER_GIT_URL}" /app/aiter && \
+    cd /app/aiter && \
+    git submodule update --init --recursive && \
+    PYTORCH_ROCM_ARCH="${ROCM_ARCH}" \
+        TORCH_DONT_CHECK_COMPILER_ABI=1 \
+        MAX_JOBS="${BUILD_JOBS:-$(nproc)}" \
+        CCACHE_DIR=/root/.cache/ccache \
+        python3 setup.py bdist_wheel --dist-dir=/wheels && \
+    pip3 install --no-cache-dir --no-deps /wheels/amd_aiter-*.whl && \
+    python3 -c 'import importlib.util, pathlib; spec = importlib.util.find_spec("aiter"); assert spec and spec.submodule_search_locations; print("AITER installed:", next(iter(spec.submodule_search_locations)))'
 
 # FlashAttention: CDNA-only (gfx9xx — MI100/MI200/MI300/MI355X).
 # The composable_kernel backend does not support RDNA Wave32 (gfx10xx/gfx11xx/gfx12xx),

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,6 +10,8 @@
 #   torchvision: built from source at pytorch/vision@${TORCHVISION_BRANCH} against the
 #                source-built torch (pre-built wheel ABI-incompatible with custom torch)
 #   vLLM:        built from source at ${VLLM_REF}
+#   AITER:       ROCm/aiter ${AITER_REF}, installed from its matching ROCm wheel
+#   FlashAttn:   Dao-AILab/flash-attention ${FLASH_ATTN_REF}, built for ROCm
 #   LMCache:     LMCache/LMCache ${LMCACHE_REF} + AMD patches from patches/lmcache/
 #   hipFile:     included in the ROCm 7.14 base image (GA since 7.14) — no source build needed
 #   NIXL:        ai-dynamo/nixl ${NIXL_REF} + nixl-rocm-ais-mt.patch (ROCm/HIP + AIS_MT)
@@ -58,10 +60,11 @@
 # into the directory to include it.
 #
 # Wheels: the build also produces pip-installable wheels for vLLM (source-built),
-# the patched LMCache, and ROCm NIXL under /wheels.  Extract them with the `wheels` stage:
+# AITER (upstream prebuilt), FlashAttention, the patched LMCache, and ROCm NIXL under /wheels.  Extract
+# them with the `wheels` stage:
 #   docker build --build-arg AIC_VERSION="$(<VERSION)" \
 #     --target wheels --output type=local,dest=./wheels .
-# (the default target remains the full runtime image -- see stages 8/9 below).
+# (the default target remains the full runtime image -- see stages 9/10 below).
 
 # Stages:
 #
@@ -111,6 +114,10 @@ ARG ROCM_ARCH
 ARG BUILD_JOBS
 ARG VLLM_GIT_URL
 ARG VLLM_REF
+ARG AITER_REF
+ARG AITER_WHEEL_ROCM
+ARG FLASH_ATTN_GIT_URL
+ARG FLASH_ATTN_REF
 ARG NIXL_GIT_URL
 ARG NIXL_REF
 ARG HSA_SNOOP_GIT_URL
@@ -461,6 +468,12 @@ ARG ROCM_ARCH
 # Defaults to $(nproc).
 ARG BUILD_JOBS=
 
+# ROCm attention backends — validated pair, update together after revalidation.
+ARG AITER_REF=v0.1.19
+ARG AITER_WHEEL_ROCM=7.2
+ARG FLASH_ATTN_GIT_URL=https://github.com/Dao-AILab/flash-attention.git
+ARG FLASH_ATTN_REF=0e60e394
+
 # Pinned component revisions — bump together when validating a new combo.
 # ai-dynamo/nixl release tag + nixl-rocm-ais-mt.patch (ROCm/HIP + AIS_MT).
 # The patch is AIS_MT-only (it no longer relocates upstream GDS_MT), so it applies
@@ -481,7 +494,78 @@ ARG LMCACHE_REF=v0.5.4
 # Optional: enable UCX fast-path for NIXL (default off).
 ARG AIC_UCX_FAST=
 
-# ----- 4. LMCache (upstream release + AMD patches) ---------------------------
+# ----- 4. ROCm attention backends (AITer + FlashAttention) ------------------
+# Install these for every image, rather than enabling an attention backend for a
+# specific model.  vLLM can then select ROCM_AITER_FA or FLASH_ATTN whenever a
+# loaded model and its runtime configuration support it.
+#
+# AITER's source wheel does not include its required `module_aiter_core` unless
+# every JIT kernel is eagerly prebuilt.  That takes more than an hour and is
+# incompatible with this image's MI355-stable Torch runtime.  Use AITER's
+# matching upstream binary release instead.  The release artifact contains the
+# gfx942 and gfx950 kernels and leaves only model-specific work for runtime.
+# AITER imports rocminfo to detect the installed GPU, so its actual import is
+# checked in the GPU-enabled smoke test after the image build rather than here.
+#
+# AITER_REF must name a release that publishes this CPython/ROCm wheel format.
+# It is generated from the ref so a deliberate, validated override cannot
+# silently install a different AITER revision.
+RUN --mount=type=cache,target=/root/.cache/pip \
+    mkdir -p /wheels && \
+    aiter_version="${AITER_REF#v}" && \
+    aiter_wheel="/wheels/amd_aiter-${aiter_version}+rocm${AITER_WHEEL_ROCM}.manylinux.2.28-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl" && \
+    curl --fail --location --retry 5 --retry-all-errors \
+        "https://github.com/ROCm/aiter/releases/download/${AITER_REF}/amd_aiter-${aiter_version}%2Brocm${AITER_WHEEL_ROCM}.manylinux.2.28-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl" \
+        --output "${aiter_wheel}" && \
+    pip3 install --no-cache-dir \
+        "pandas==3.0.3" \
+        "psutil==7.2.2" \
+        "pyyaml==6.0.3" \
+        "einops==0.8.2" \
+        "pybind11==3.0.4" \
+        "ninja==1.13.0" \
+        "flydsl==0.2.4" && \
+    pip3 install --no-cache-dir --no-deps "${aiter_wheel}" && \
+    python3 -c 'import importlib.util, pathlib; spec = importlib.util.find_spec("aiter"); assert spec and spec.submodule_search_locations; package_dir = pathlib.Path(next(iter(spec.submodule_search_locations))); assert any(package_dir.glob("jit/module_aiter_core*.so")), "AITer core module is missing"; print("AITer installed:", package_dir)'
+
+# FlashAttention: CDNA-only (gfx9xx — MI100/MI200/MI300/MI355X).
+# The composable_kernel backend does not support RDNA Wave32 (gfx10xx/gfx11xx/gfx12xx),
+# and the upstream setup.py rejects non-CDNA arches at configure time.
+# On RDNA targets vLLM falls back to its Triton attention backend automatically.
+# hadolint ignore=SC2039
+RUN --mount=type=cache,target=/root/.cache/pip \
+    --mount=type=cache,target=/root/.cache/ccache \
+    _cdna_only() { \
+        _a=""; for _a in $(echo "$1" | tr ';' '\n'); do \
+            [ "${_a#gfx9}" != "${_a}" ] || return 1; done; return 0; }; \
+    if _cdna_only "${ROCM_ARCH}"; then \
+        git clone --recurse-submodules "${FLASH_ATTN_GIT_URL}" /app/flash-attention && \
+        cd /app/flash-attention && \
+        git checkout "${FLASH_ATTN_REF}" && \
+        git submodule update --init --recursive && \
+        GPU_ARCHS="${ROCM_ARCH}" \
+            PYTORCH_ROCM_ARCH="${ROCM_ARCH}" \
+            MAX_JOBS="${BUILD_JOBS:-$(nproc)}" \
+            CCACHE_DIR=/root/.cache/ccache \
+            python3 setup.py bdist_wheel --dist-dir=/wheels && \
+        pip3 install --no-cache-dir --no-deps /wheels/flash_attn-*.whl && \
+        python3 -c 'import flash_attn; print("FlashAttention installed:", flash_attn.__file__)' && \
+        { \
+            echo "AITER_REF=${AITER_REF}"; \
+            echo "FLASH_ATTN_REF=${FLASH_ATTN_REF}"; \
+            python3 -c 'import importlib.util; spec = importlib.util.find_spec("aiter"); assert spec and spec.submodule_search_locations; print("AITER_PACKAGE=" + next(iter(spec.submodule_search_locations)))'; \
+            python3 -c 'import flash_attn; print("FLASH_ATTN_PACKAGE=" + flash_attn.__file__)'; \
+        } > /etc/rocm-aic-attention-backends.env; \
+    else \
+        echo "Skipping FlashAttention: ${ROCM_ARCH} contains non-CDNA arch(es); vLLM will use Triton attention" && \
+        { \
+            echo "AITER_REF=${AITER_REF}"; \
+            echo "FLASH_ATTN_REF="; \
+            python3 -c 'import importlib.util; spec = importlib.util.find_spec("aiter"); assert spec and spec.submodule_search_locations; print("AITER_PACKAGE=" + next(iter(spec.submodule_search_locations)))'; \
+        } > /etc/rocm-aic-attention-backends.env; \
+    fi
+
+# ----- 5. LMCache (upstream release + AMD patches) ---------------------------
 # Shallow-clone the pinned release tag directly (no history/other branches).
 RUN git clone --depth 1 --branch "${LMCACHE_REF}" "${LMCACHE_GIT_URL}" /app/LMCache
 
@@ -541,11 +625,11 @@ RUN uv pip uninstall --system \
         nixl nixl-cu12 nixl-cu13 \
         cupy-cuda12x cufile-python cuda-pathfinder 2>/dev/null || true
 
-# ----- 5. hipFile — provided by the ROCm 7.14 base image (GA since 7.14) ------
+# ----- 6. hipFile — provided by the ROCm 7.14 base image (GA since 7.14) ------
 # No source build needed.  hipFile headers, libraries, Python bindings, ais-stats,
 # and ais-check are all pre-installed in rocm/dev-ubuntu-24.04:${ROCM_VERSION}-full.
 
-# ----- 6. NIXL (ai-dynamo/nixl upstream + nixl-rocm-ais-mt.patch) ------------
+# ----- 7. NIXL (ai-dynamo/nixl upstream + nixl-rocm-ais-mt.patch) ------------
 # Clone upstream ai-dynamo/nixl, then apply nixl-rocm-ais-mt.patch to add ROCm/HIP
 # detection and the AIS_MT plugin tree.
 COPY docker/scripts /tmp/nixl-scripts
@@ -577,7 +661,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
         UV_SYSTEM_CERTS=1 \
         /tmp/nixl-scripts/build-nixl.sh
 
-# ----- 6b. hsa-snoop (HSA AQL queue snooper + Prometheus exporter) -----------
+# ----- 7b. hsa-snoop (HSA AQL queue snooper + Prometheus exporter) -----------
 # GPU dispatch/queue telemetry on :9488 (/metrics), including AIS (AMD Infinity
 # Storage) P2P metrics (ais_rx_ops_total, ais_tx_bytes_total, etc.) added in
 # v1.0.0.  The v1.1.0 release also exposes SDMA telemetry.  The snooper binary
@@ -605,7 +689,7 @@ RUN git clone --depth 1 --branch "${HSA_SNOOP_REF}" "${HSA_SNOOP_GIT_URL}" /app/
         || { echo "ERROR: hsa-snoop built without Prometheus mode (--prometheus absent)" >&2; exit 1; } && \
     echo "PASS: hsa-snoop v${HSA_SNOOP_REF} with Prometheus exporter (incl. AIS metrics) installed"
 
-# ----- 7. Runtime environment ------------------------------------------------
+# ----- 8. Runtime environment ------------------------------------------------
 # Vars from upstream vLLM Dockerfile.rocm added here:
 #   SAFETENSORS_FAST_GPU=1        — GPU-accelerated weight loading, faster model startup
 #   HIP_FORCE_DEV_KERNARG=1       — kernel arg handling fix on MI300+/gfx942/gfx950
@@ -644,6 +728,8 @@ LABEL org.opencontainers.image.title="rocm-aic" \
       ai.amd.aic.rocm="${ROCM_VERSION}" \
       ai.amd.aic.vllm="${VLLM_REF}" \
       ai.amd.aic.llm-emu="${LLM_EMU_REF}" \
+      ai.amd.aic.aiter="${AITER_REF}" \
+      ai.amd.aic.flash-attention="${FLASH_ATTN_REF}" \
       ai.amd.aic.lmcache="${LMCACHE_REF}" \
       ai.amd.aic.nixl="${NIXL_REF}" \
       ai.amd.aic.hipfile="rocm-${ROCM_VERSION}" \
@@ -652,17 +738,17 @@ LABEL org.opencontainers.image.title="rocm-aic" \
 # vLLM OpenAI-compatible server is the default entrypoint.
 ENTRYPOINT ["python3", "-m", "vllm.entrypoints.openai.api_server"]
 
-# ----- 8. Wheel export stage -------------------------------------------------
+# ----- 9. Wheel export stage -------------------------------------------------
 # A scratch image whose only content is the pip wheels built above (source-built
-# vLLM + patched LMCache + ROCm NIXL).  Extract them WITHOUT building/loading
-# the full image:
+# vLLM, AITER (prebuilt), FlashAttention, patched LMCache, and ROCm NIXL).  Extract them
+# WITHOUT building/loading the full image:
 #   docker build --build-arg AIC_VERSION="$(<VERSION)" \
 #     --target wheels --output type=local,dest=./wheels .
 # The nightly-wheels GitHub workflow uses exactly this to publish the wheels.
 FROM scratch AS wheels
 COPY --from=build /wheels /
 
-# ----- 9. Runtime image (default target) -------------------------------------
+# ----- 10. Runtime image (default target) ------------------------------------
 # Aliases the `build` stage so the DEFAULT build target (no --target) is the full
 # runtime image, exactly as before -- Makefile/compose/run-build-distribute.sh
 # and the existing Docker CI all keep getting the runtime image unchanged.  Must

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -58,7 +58,7 @@
 #   IMAGE_NAME             — image name when IMAGE_REF is unset (default: rocm-aic)
 #   AIC_VERSION            — AIC release from the root VERSION file
 #   ROCM_VERSION           — ROCm release used by the default base image
-#   PYTORCH_BRANCH, VLLM_REF, LLM_EMU_REF, LMCACHE_REF, NIXL_REF, HSA_SNOOP_REF
+#   PYTORCH_BRANCH, VLLM_REF, LLM_EMU_REF, AITER_REF, FLASH_ATTN_REF, LMCACHE_REF, NIXL_REF, HSA_SNOOP_REF
 #                          — optional framework version build-arg overrides
 #   VLLM_MODEL             — model to serve
 #   LMCACHE_PORT           — lmcache ZMQ listen port (default: 6555)
@@ -284,6 +284,8 @@ services:
         PYTORCH_BRANCH:
         VLLM_REF:
         LLM_EMU_REF:
+        AITER_REF:
+        FLASH_ATTN_REF:
         LMCACHE_REF:
         NIXL_REF:
         HSA_SNOOP_REF:

--- a/docker/scripts/aic-image-tag.sh
+++ b/docker/scripts/aic-image-tag.sh
@@ -7,7 +7,10 @@
 # the versions pinned in the Dockerfile.
 #
 # Emits just the tag component (no image name) in the following format:
-#   0.1.0-rocm7.14.0-vllm0.27.1-lmcache0.5.4-nixl1.3.2-hsasnoop1.1.0
+#   CDNA (gfx9xx):  0.1.0-rocm7.14.1-pytorch2.13-vllm0.28.0-aiter0.1.19-fa0e60e394-lmcache0.5.4-nixl1.4.1-hsasnoop1.1.0
+#   RDNA (gfx12xx): 0.1.0-rocm7.14.1-pytorch2.13-vllm0.28.0-aiter0.1.19-lmcache0.5.4-nixl1.4.1-hsasnoop1.1.0
+# FlashAttention is omitted for non-CDNA arches (gfx10xx/gfx11xx/gfx12xx) because
+# the CK backend does not support RDNA Wave32 GPUs.
 # Where 0.1.0 represents the AIC version.
 #
 # Usage:  aic-image-tag.sh [path/to/Dockerfile]
@@ -55,14 +58,37 @@ fi
 vllm="$(_arg VLLM_REF | sed 's/^v//')"
 lmcache="$(_arg LMCACHE_REF | sed 's/^v//')"
 nixl="$(_arg NIXL_REF | sed 's/^v//')"
+aiter="$(_arg AITER_REF | sed 's/^v//')"
+flash_attn="$(_arg FLASH_ATTN_REF)"
 hsasnoop="$(_arg HSA_SNOOP_REF | sed 's/^v//')"
 
-for _v in aic rocm pytorch vllm lmcache nixl hsasnoop; do
+# FlashAttention is CDNA-only (gfx9xx). Detect from ROCM_ARCH env (set by make/caller)
+# or fall back to including fa in the tag when arch is unknown (conservative default).
+_cdna_only() {
+  local a
+  for a in $(echo "$1" | tr ';' '\n'); do
+    [[ "$a" == gfx9* ]] || return 1
+  done
+  return 0
+}
+if [[ -n "${ROCM_ARCH:-}" ]] && ! _cdna_only "${ROCM_ARCH}"; then
+  include_fa=0
+else
+  include_fa=1
+fi
+
+for _v in aic rocm pytorch vllm aiter lmcache nixl hsasnoop; do
   [[ -n "${!_v}" ]] || {
     echo "aic-image-tag: could not resolve ${_v}" >&2
     exit 1
   }
 done
+[[ "${include_fa}" -eq 1 ]] && [[ -z "${flash_attn}" ]] && {
+  echo "aic-image-tag: could not resolve flash_attn" >&2
+  exit 1
+}
 
-tag="${aic}-rocm${rocm}-pytorch${pytorch}-vllm${vllm}-lmcache${lmcache}-nixl${nixl}-hsasnoop${hsasnoop}"
+tag="${aic}-rocm${rocm}-pytorch${pytorch}-vllm${vllm}-aiter${aiter}"
+[[ "${include_fa}" -eq 1 ]] && tag="${tag}-fa${flash_attn}"
+tag="${tag}-lmcache${lmcache}-nixl${nixl}-hsasnoop${hsasnoop}"
 printf '%s\n' "${tag}"

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -3,6 +3,8 @@
 | Variable | Default | Description |
 | --- | --- | --- |
 | `ROCM_ARCH` | auto-detected | GPU arch, e.g. `gfx942` |
+| `AITER_REF` | `v0.1.19` | Pinned ROCm AITER release installed into every image from its matching ROCm 7.2 CPython 3.12 wheel; override only with a validated release wheel and FlashAttention pair |
+| `FLASH_ATTN_REF` | `0e60e394` | Pinned ROCm FlashAttention revision installed into every image; override only when validating a new pair with AITER |
 | `HF_TOKEN` | — | HuggingFace access token (required) |
 | `VLLM_MODEL` | `openai/gpt-oss-120b` | Model to serve |
 | `NVME_DATA` | `/mnt/lmcache-nvme` | Host path for NVMe L2a pool |


### PR DESCRIPTION
## Summary

- Update the vLLM source build to v0.28.0.
- Use the matching vLLM ROCm wheel set: Torch 2.12.0+git6bbd260 and TorchVision 0.27.1+df56172 from wheels.vllm.ai/rocm.
- Install the vLLM-validated AITER v0.1.19 ROCm 7.2 wheel.
- Build FlashAttention revision 0e60e394 for the selected ROCm architecture.
- Record the attention-backend pins in build arguments, image metadata, tags, and documentation.
- Validate AITER only in a GPU-enabled runtime, where it can detect the device.

## Validation

- Built the image on an MI355X host for gfx950.
- GPU smoke test: AITER loaded its core and detected gfx950; FlashAttention imported successfully.

The pins are updated as a pair only after validation with the image Torch and ROCm runtime.