### PR TITLE
fix(ci): add Slurm client path

### DIFF
--- a/.github/scripts/runners/spur-ci-common.sh
+++ b/.github/scripts/runners/spur-ci-common.sh
@@ -29,6 +29,7 @@ aic_ci_session_init() {
 
 aic_ci_ssh_bash() {
     ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=4 "${AIC_SPUR_HOST}" env \
+        PATH="/usr/local/bin:\${PATH}" \
         AIC_CI_RUN_KEY="${AIC_CI_RUN_KEY}" \
         AIC_CI_STAGE="${AIC_CI_STAGE}" \
         "$@" \
@@ -50,6 +51,7 @@ _aic_ci_session_exit() {
             AIC_SPUR_CONTROLLER="${AIC_SPUR_CONTROLLER}" \
             bash <<'REMOTE_CANCEL' || true
 set -u
+export PATH="/usr/local/bin:${PATH}"
 
 CI_STORAGE_ROOT="${AIC_CI_STORAGE_ROOT:-$HOME/Projects/rocm-aic-ci}"
 CONTROL_PREFIX="${CI_STORAGE_ROOT}/control/${AIC_CI_SHORT_SHA}.${AIC_CI_RUN_KEY}.${AIC_CI_STAGE}"

--- a/.github/scripts/runners/spur-cliff.sh
+++ b/.github/scripts/runners/spur-cliff.sh
@@ -37,6 +37,7 @@ ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=4 "${AIC_SPUR_HOST}" env \
     SPUR_CONTROLLER_ADDR="${AIC_SPUR_CONTROLLER}" \
     bash << 'REMOTE'
 set -euo pipefail
+export PATH="/usr/local/bin:${PATH}"
 
 SHORT="${SHA:0:7}"
 WORKDIR="$HOME/Projects/rocm-aic.${SHORT}"

--- a/.github/scripts/workflows/spur-cliff-harvest.sh
+++ b/.github/scripts/workflows/spur-cliff-harvest.sh
@@ -46,6 +46,7 @@ ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=4 "${AIC_SPUR_HOST}" env \
     SPUR_CONTROLLER_ADDR="${AIC_SPUR_CONTROLLER}" \
     bash << 'REMOTE'
 set -euo pipefail
+export PATH="/usr/local/bin:${PATH}"
 
 SHORT="${SHA:0:7}"
 WORKDIR="$HOME/Projects/rocm-aic.${SHORT}"

--- a/.github/scripts/workflows/spur-monitoring-cpu-smoke.sh
+++ b/.github/scripts/workflows/spur-monitoring-cpu-smoke.sh
@@ -39,6 +39,7 @@ ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=4 "${AIC_SPUR_HOST}" env \
     AIC_SMOKE_USE_REGISTRY="${AIC_SMOKE_USE_REGISTRY}" \
     bash << 'REMOTE'
 set -euo pipefail
+export PATH="/usr/local/bin:${PATH}"
 
 SHORT="${SHA:0:7}"
 WORKDIR="$HOME/Projects/rocm-aic.${SHORT}"

--- a/.github/workflows/aic-amd-dist-build-fast.yml
+++ b/.github/workflows/aic-amd-dist-build-fast.yml
@@ -33,6 +33,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          export PATH="/usr/local/bin:${PATH}"
           [[ "${JOB_ID}" =~ ^[0-9]+$ ]] || {
             echo "ERROR: Slurm job ID must be numeric" >&2
             exit 2
@@ -42,6 +43,7 @@ jobs:
             AIC_SPUR_CONTROLLER="${AIC_SPUR_CONTROLLER}" \
             bash <<'REMOTE'
           set -euo pipefail
+          export PATH="/usr/local/bin:${PATH}"
           scancel --controller="${AIC_SPUR_CONTROLLER}" "${JOB_ID}"
           for _ in 1 2 3 4 5 6 7 8 9 10; do
               if ! squeue --controller="${AIC_SPUR_CONTROLLER}" -h 2>/dev/null |

--- a/.slurm/ext-hit-test.sbatch
+++ b/.slurm/ext-hit-test.sbatch
@@ -6,6 +6,7 @@
 #SBATCH --job-name=aic-ext-hit-test
 
 set -euo pipefail
+export PATH="/usr/local/bin:${PATH}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO="${SLURM_SUBMIT_DIR:-$(cd "${SCRIPT_DIR}/.." && pwd)}"

--- a/.slurm/run-build-distribute.sh
+++ b/.slurm/run-build-distribute.sh
@@ -155,6 +155,7 @@
 #                                                            else gzip)
 #
 set -euo pipefail
+export PATH="/usr/local/bin:${PATH}"
 
 # --- Resolve paths (script lives at aic-release/.slurm/) ------------------
 # The tree is self-contained: the Docker build context IS aic-release/.

--- a/.slurm/run-cliff.sbatch
+++ b/.slurm/run-cliff.sbatch
@@ -72,6 +72,7 @@
 # A provisioned mount is left mounted for reuse by later jobs on the same node.
 #
 set -uo pipefail
+export PATH="/usr/local/bin:${PATH}"
 
 # --- Config (all overridable via environment) --------------------------------
 # Under sbatch, Slurm copies this script to the node's spool dir and runs it from

--- a/monitoring/monitoring-lib.sh
+++ b/monitoring/monitoring-lib.sh
@@ -32,6 +32,8 @@
 #   Optional: AIC_PROM_IMAGE/PORT/RETENTION, AIC_{NODE,AMDGPU,NVME,RDMA}_EXPORTER_IMAGE,
 #             AIC_{NVME,RDMA}_EXPORTER_ARGS, {NVME,RDMA}_EXPORTER_PORT, HSA_SNOOP_PORT.
 
+export PATH="/usr/local/bin:${PATH}"
+
 # --- Caller-provided vars: defaults so the lib is self-contained + SC2154-clean.
 : "${AIC_IMAGE:=rocm-aic:latest}"
 : "${AIC_MONITORING:=1}"


### PR DESCRIPTION
## Summary
- add `/usr/local/bin` to Slurm-facing CI and scheduler shells
- ensure remote SPUR cleanup and submitted jobs can resolve Slurm clients

## Validation
- `bash -n` on updated shell scripts
- workflow YAML parsed
- `git diff --check`