### PR TITLE
fix(docker): give the pip-wheels build context an empty default stage

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -54,6 +54,16 @@
 ARG ROCM_VERSION=7.14.0
 # ROCm 7.14 publishes the hipFile-bearing variant as `-full` (not `-complete`).
 ARG ROCM_BASE_IMAGE=rocm/dev-ubuntu-24.04:${ROCM_VERSION}-full
+
+# Empty default for the `pip-wheels` build context.  The torch install step
+# mounts that context (--mount=from=pip-wheels) to reuse a host wheel cache and
+# already falls back to the index when the wheel is absent, but BuildKit
+# resolves the name against a named context first and a stage second; with
+# neither it tries to pull docker.io/library/pip-wheels and the build fails
+# before the fallback can run.  A caller that passes
+# --build-context pip-wheels=<dir> overrides this stage exactly as before.
+FROM scratch AS pip-wheels
+
 # ROCM_BASE_IMAGE has a tagged default but remains overridable by callers.
 # hadolint ignore=DL3006
 FROM ${ROCM_BASE_IMAGE} AS build


### PR DESCRIPTION
## Motivation

`AIC Nightly Wheels` has failed every night since 2026-08-12, so the `nightly` release is stuck at 2026-08-11:

    pip-wheels: failed to resolve source metadata for docker.io/library/pip-wheels:latest

## Technical Details

The torch step mounts a named build context, `pip-wheels`, and already falls back to the index when the wheel is absent. With no `--build-context` and no stage of that name, BuildKit tries to pull an image called `pip-wheels` instead. #132 added the flag to the Slurm path; a plain `docker build` still fails.

Add an empty `FROM scratch AS pip-wheels` stage. A passed `--build-context` overrides it as before; otherwise the mount is empty and the index fallback runs.

## Test Plan

Minimal Dockerfile with the same mount, three cases. hadolint 2.12.0 and `docker build --check`.

## Test Result

No context: empty mount, fallback taken. With context: files visible. Without the stage: the nightly error verbatim. Lint clean. No full image build here (no AMD hardware).

Scope note: this removes the error the nightly currently dies on and fixes any plain `docker build` without a wheel cache. Whether the nightly then completes is a separate question: the last success (Aug 11, 41 min) used prebuilt vLLM wheels, while the current Dockerfile builds vLLM from source for nine GPU targets on a GitHub-hosted runner with a 6-hour limit.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

