### PR TITLE
fix(monitoring): clean up Prometheus scrape targets and fix ROCM_ARCH detection order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .venv
 __pycache__/
 *.pyc
+*.egg-info/
 
 # VSCode
 .vscode/
@@ -45,3 +46,7 @@ profiles/captures/
 
 # Prometheus raw metrics dump
 prometheus-dump.md
+
+# Overnight testing files
+overnight*.md
+ 

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,11 @@ NIXL_SHA     := v1.4.1
 IMAGE_NAME ?= rocm-aic
 override AIC_VERSION := $(strip $(file <$(REPO_ROOT)/VERSION))
 
+# Detect ROCM_ARCH early (before _IMAGE_TAG) so the tag script can decide
+# whether to include FlashAttention (CDNA-only).  Command-line overrides win.
+_ROCM_ARCH_DETECTED := $(shell rocm_agent_enumerator 2>/dev/null | grep -E '^gfx' | head -1)
+ROCM_ARCH := $(if $(strip $(ROCM_ARCH)),$(strip $(ROCM_ARCH)),$(_ROCM_ARCH_DETECTED))
+
 # PyTorch, vLLM, and all deps are source-built; PYTORCH_BRANCH, VLLM_REF, and
 # LLM_EMU_REF are the key version knobs.  hipFile ships in the ROCm base image.
 _FRAMEWORK_VERSION_ARGS := AIC_VERSION ROCM_VERSION PYTORCH_BRANCH VLLM_REF LLM_EMU_REF AITER_REF FLASH_ATTN_REF LMCACHE_REF NIXL_REF HSA_SNOOP_REF
@@ -20,7 +25,7 @@ _single_quote := '
 _shell_quote = '$(subst $(_single_quote),'"'"',$(1))'
 _FRAMEWORK_VERSION_ENV := $(foreach _arg,$(_FRAMEWORK_VERSION_ARGS),$(if $(filter undefined,$(origin $(_arg))),,$(_arg)=$(call _shell_quote,$(value $(_arg)))))
 
-_IMAGE_TAG := $(shell $(_FRAMEWORK_VERSION_ENV) $(REPO_ROOT)/docker/scripts/aic-image-tag.sh 2>/dev/null)
+_IMAGE_TAG := $(shell ROCM_ARCH=$(ROCM_ARCH) $(_FRAMEWORK_VERSION_ENV) $(REPO_ROOT)/docker/scripts/aic-image-tag.sh 2>/dev/null)
 IMAGE_TAG  ?= $(if $(_IMAGE_TAG),$(_IMAGE_TAG),latest)
 IMAGE_REF  := $(IMAGE_NAME):$(IMAGE_TAG)
 
@@ -64,10 +69,6 @@ BENCH_MODEL       ?= $(VLLM_MODEL)
 # land under logs/manual/ -- keeping the tree root free of results/ and plots/.
 BENCH_LOGDIR      := logs/manual
 BENCH_OUT         := $(BENCH_LOGDIR)/results/cliff-$(BENCH_ARM)-$(shell date +%Y%m%d-%H%M%S).csv
-
-# ---- ROCm arch (auto-detected if not set) ----------------------------------
-_ROCM_ARCH_DETECTED := $(shell rocm_agent_enumerator 2>/dev/null | grep -E '^gfx' | head -1)
-ROCM_ARCH := $(if $(strip $(ROCM_ARCH)),$(strip $(ROCM_ARCH)),$(_ROCM_ARCH_DETECTED))
 
 # ---- Build parallelism -----------------------------------------------------
 # Caps parallel compile jobs in the image build, Empty = use all cores ($(nproc)).

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -40,7 +40,7 @@
 #   GPU                    — fallback GPU when no SPUR allocation is resolved (default: 0).
 #   AIC_ROCR_VISIBLE       — ROCR_VISIBLE_DEVICES for every service to isolate used GPUs
 #                            to the ones allocated to use by SPUR.
-#   AIC_HIP_VISIBLE        — HIP_VISIBLE_DEVICES + CUDA_VISIBLE_DEVICES.  RELATIVE
+#   AIC_HIP_VISIBLE        — HIP_VISIBLE_DEVICES.  RELATIVE
 #                            indices ( e.g., 0..n-1).
 #   GDS_MODE               — set to 1 to enable hipFile NVMe slab as L1 (requires GDS_SLAB_DATA)
 #   GDS_SLAB_DATA          — host path for the hipFile slab file (required when GDS_MODE=1)
@@ -140,6 +140,7 @@
 # own device-specific entries on top of this shared set.  Values are quoted
 # because compose rejects a YAML boolean/int where an env value is expected.
 x-lmcache-env: &lmcache-env
+  PYTHONWARNINGS: "ignore::FutureWarning:google.auth.transport.grpc"
   LMCACHE_PORT: "${LMCACHE_PORT:-6555}"
   LMCACHE_L1_SIZE_GB: "${LMCACHE_L1_SIZE_GB:-20}"
   GDS_MODE: "${GDS_MODE:-}"
@@ -255,7 +256,7 @@ x-lmcache-healthcheck: &lmcache-healthcheck
   start_period: 30s
 
 networks:
-  aic:
+  aic-network:
     name: aic
 
 services:
@@ -298,7 +299,7 @@ services:
     # IPC namespace sharing is independent of network_mode — the aic bridge network
     # provides DNS-based service discovery for prometheus without affecting IPC.
     # Ports reachable within the aic network: lmcache HTTP API 8080, NIXL telemetry 19090.
-    networks: [aic]
+    networks: [aic-network]
     ipc: shareable
     shm_size: "${AIC_SHM_SIZE:-64gb}"
     cap_add:
@@ -343,7 +344,6 @@ services:
       # lmcache lands on a different device.  Mirror vllm's ROCR_VISIBLE_DEVICES.
       ROCR_VISIBLE_DEVICES: "${AIC_ROCR_VISIBLE:-${GPU:-0}}"
       HIP_VISIBLE_DEVICES: "${AIC_HIP_VISIBLE:-0}"
-      CUDA_VISIBLE_DEVICES: "${AIC_HIP_VISIBLE:-0}"
       PYTHONHASHSEED: "0"
       TZ: "${TZ:-America/Edmonton}"
       # Coordinator registration: the MP server registers, heartbeats, and
@@ -373,7 +373,7 @@ services:
       - cache
     image: ${IMAGE_REF:-${IMAGE_NAME:-rocm-aic}:latest}
     container_name: aic-lmcache-coordinator
-    networks: [aic]
+    networks: [aic-network]
     restart: unless-stopped
     environment:
       - LMCACHE_DISABLE_BANNER=1
@@ -410,7 +410,7 @@ services:
     # (ipc: service:lmcache, pid: service:lmcache) is sufficient and safer than
     # ipc: host / pid: host.  Override via VLLM_IPC_MODE / VLLM_PID_MODE if needed.
     # vLLM OpenAI API + /metrics reachable within the aic network on port 8000.
-    networks: [aic]
+    networks: [aic-network]
     ipc: "${VLLM_IPC_MODE:-service:lmcache}"
     shm_size: "${AIC_SHM_SIZE:-64gb}"
     pid: "${VLLM_PID_MODE:-service:lmcache}"
@@ -439,7 +439,6 @@ services:
       - VLLM_TARGET_DEVICE=rocm
       - ROCR_VISIBLE_DEVICES=${AIC_ROCR_VISIBLE:-${GPU:-0}}
       - HIP_VISIBLE_DEVICES=${AIC_HIP_VISIBLE:-0}
-      - CUDA_VISIBLE_DEVICES=${AIC_HIP_VISIBLE:-0}
       - AMDGCN_USE_BUFFER_OPS=0
       - MIOPEN_FIND_MODE=FAST
       - MIOPEN_USER_DB_PATH=/app/miopen
@@ -500,11 +499,16 @@ services:
   client:
     image: ${AIC_CLIENT_IMAGE:-python:3.12}
     container_name: aic-client
-    networks: [aic]
+    networks: [aic-network]
+    environment:
+      HF_TOKEN: "${HF_TOKEN:-}"
+      HF_HOME: "${HF_HOME:-/root/.cache/huggingface}"
     entrypoint: ["/bin/bash", "-c"]
     command:
       - |
         pip install --quiet \
+          --root-user-action=ignore \
+          --disable-pip-version-check \
           openai httpx pyyaml tqdm \
           transformers huggingface-hub \
           prometheus-client aiohttp \
@@ -528,7 +532,7 @@ services:
     profiles: [monitoring]
     image: ${AIC_PROM_IMAGE:-prom/prometheus:v3.14.0}
     container_name: aic-prometheus
-    networks: [aic]
+    networks: [aic-network]
     extra_hosts:
       - "host-gateway:host-gateway"
     user: "${PROM_UID:-65534}:${PROM_GID:-65534}"
@@ -553,7 +557,7 @@ services:
     profiles: [monitoring]
     image: ${AIC_NODE_EXPORTER_IMAGE:-quay.io/prometheus/node-exporter:v1.12.1}
     container_name: aic-node-exporter
-    networks: [aic]
+    networks: [aic-network]
     pid: host
     restart: unless-stopped
     volumes:
@@ -573,12 +577,11 @@ services:
     profiles: [monitoring]
     image: ${AIC_AMDGPU_EXPORTER_IMAGE:-rocm/device-metrics-exporter:v1.5.1}
     container_name: aic-amdgpu-exporter
-    networks: [aic]
+    networks: [aic-network]
     restart: unless-stopped
     environment:
       - ROCR_VISIBLE_DEVICES=${AIC_ROCR_VISIBLE:-${GPU:-0}}
       - HIP_VISIBLE_DEVICES=${AIC_HIP_VISIBLE:-0}
-      - CUDA_VISIBLE_DEVICES=${AIC_HIP_VISIBLE:-0}
     devices:
       - /dev/kfd
       - /dev/dri
@@ -596,7 +599,7 @@ services:
     profiles: [monitoring]
     image: ${AIC_NVME_EXPORTER_IMAGE:-aic-nvme-exporter:local}
     container_name: aic-nvme-exporter
-    networks: [aic]
+    networks: [aic-network]
     cap_add:
       - SYS_ADMIN
     restart: unless-stopped
@@ -614,7 +617,7 @@ services:
     profiles: [monitoring]
     image: ${AIC_RDMA_EXPORTER_IMAGE:-aic-rdma-exporter:local}
     container_name: aic-rdma-exporter
-    networks: [aic]
+    networks: [aic-network]
     restart: unless-stopped
     volumes:
       - /sys:/sys:ro
@@ -632,7 +635,7 @@ services:
     profiles: [monitoring]
     image: ${AIC_GRAFANA_IMAGE:-grafana/grafana:13.2.1}
     container_name: aic-grafana
-    networks: [aic]
+    networks: [aic-network]
     ports:
       - "${AIC_GRAFANA_PORT:-3000}:3000"
     restart: unless-stopped
@@ -646,6 +649,34 @@ services:
       - ../monitoring/grafana/dashboards:/etc/grafana/dashboards:ro
       - grafana-data:/var/lib/grafana
 
+  # hsa-snoop: HSA AQL queue/dispatch snooper + Prometheus exporter on :9488.
+  # Runs privileged in the lmcache PID namespace so it sees both vLLM and LMCache
+  # GPU processes without needing host PID. Requires tracefs on the host.
+  # ---------------------------------------------------------------------------
+  hsa-snoop:
+    profiles: [monitoring]
+    image: ${IMAGE_REF:-${IMAGE_NAME:-rocm-aic}:latest}
+    container_name: aic-hsa-snoop
+    networks: [aic-network]
+    pid: "service:lmcache"
+    privileged: true
+    restart: unless-stopped
+    environment:
+      - ROCR_VISIBLE_DEVICES=${AIC_ROCR_VISIBLE:-${GPU:-0}}
+      - HIP_VISIBLE_DEVICES=${AIC_HIP_VISIBLE:-0}
+    devices:
+      - /dev/kfd
+      - /dev/dri
+    volumes:
+      - /sys/kernel/debug:/sys/kernel/debug
+      - /sys/kernel/tracing:/sys/kernel/tracing
+    entrypoint: ["/usr/local/bin/hsa-snoop"]
+    command: ["--all", "--prometheus", "--prometheus-port", "${HSA_SNOOP_PORT:-9488}", "--mem-snoop"]
+    depends_on:
+      lmcache:
+        condition: service_healthy
+
+  # ---------------------------------------------------------------------------
   # lmcache-emulator: the SAME lmcache server, on a node with no GPU
   #
   # Same image, same anchored command and environment as `lmcache` above — the
@@ -881,7 +912,3 @@ services:
 volumes:
   grafana-data:
 
-  # hsa-snoop is intentionally omitted here: it requires exclusive access to
-  # /sys/kernel/tracing/trace_pipe and conflicts with any host hsa-snoop service.
-  # If no host hsa-snoop is running, launch it via the monitoring compose:
-  #   docker compose -f monitoring/docker-compose.monitoring.yml --profile exporters up -d hsa-snoop

--- a/monitoring/docker-compose.monitoring.yml
+++ b/monitoring/docker-compose.monitoring.yml
@@ -4,13 +4,10 @@
 #
 #  metrics-capture sidecar.
 #
-# A host-network Prometheus that scrapes the running inference stack (vLLM,
-# LMCache/NIXL) plus the host/GPU/NVMe/RDMA exporters, and writes its TSDB to a
-# bind-mounted NFS directory so the run can be explored afterward.
-#
-# Because everything runs with network_mode: host, Prometheus reaches every
-# target at localhost:<port> -- identical for `make up` (published ports) and
-# `--cliff` (`docker run --network host`).  See prometheus/prometheus.yml.
+# Prometheus + exporter sidecar for the AIC inference stack.
+# All services join aic-network (created by the main compose, or by
+# monitoring-lib.sh start_monitoring before this file is brought up).
+# Prometheus reaches inference targets by container name via the shared network.
 #
 # Usage:
 #   # scrape-only (exporters already installed on the host by Ansible):
@@ -53,7 +50,7 @@ services:
   prometheus:
     image: ${AIC_PROM_IMAGE:-prom/prometheus:v3.14.0}
     container_name: aic-prometheus
-    network_mode: host
+    networks: [aic-network]
     user: "${PROM_UID:-65534}:${PROM_GID:-65534}"
     restart: unless-stopped
     volumes:
@@ -77,7 +74,7 @@ services:
     image: ${AIC_NODE_EXPORTER_IMAGE:-quay.io/prometheus/node-exporter:v1.12.1}
     container_name: aic-node-exporter
     profiles: ["exporters", "exporters-cpu"]
-    network_mode: host
+    networks: [aic-network]
     restart: unless-stopped
     volumes:
       - /:/host:ro,rslave
@@ -96,13 +93,11 @@ services:
   amdgpu-exporter:
     image: ${AIC_AMDGPU_EXPORTER_IMAGE:-rocm/device-metrics-exporter:v1.5.1}
     container_name: aic-amdgpu-exporter
-    profiles: ["exporters", "exporters-safe"]
-    network_mode: host
+    networks: [aic-network]
     restart: unless-stopped
     environment:
       - ROCR_VISIBLE_DEVICES=${AIC_ROCR_VISIBLE:-${GPU:-0}}
       - HIP_VISIBLE_DEVICES=${AIC_HIP_VISIBLE:-0}
-      - CUDA_VISIBLE_DEVICES=${AIC_HIP_VISIBLE:-0}
     devices:
       - /dev/kfd
       - /dev/dri
@@ -130,7 +125,7 @@ services:
     image: ${AIC_NVME_EXPORTER_IMAGE:-aic-nvme-exporter:local}
     container_name: aic-nvme-exporter
     profiles: ["exporters-fabric", "exporters-cpu", "exporters-safe"]
-    network_mode: host
+    networks: [aic-network]
     # nvme-exporter shells out to nvme-cli which uses ioctl on /dev/nvme* and
     # reads /sys/class/nvme.  Does NOT need --pid=host; CAP_SYS_ADMIN suffices.
     cap_add:
@@ -157,7 +152,7 @@ services:
     image: ${AIC_RDMA_EXPORTER_IMAGE:-aic-rdma-exporter:local}
     container_name: aic-rdma-exporter
     profiles: ["exporters-fabric", "exporters-cpu", "exporters-safe"]
-    network_mode: host
+    networks: [aic-network]
     restart: unless-stopped
     volumes:
       - /sys:/sys:ro
@@ -175,23 +170,17 @@ services:
   hsa-snoop:
     image: ${AIC_HSA_SNOOP_IMAGE:-${IMAGE_NAME:-rocm-aic}}
     container_name: aic-hsa-snoop
-    profiles: ["exporters"]
-    network_mode: host
-    # Note: hsa-snoop is NOT in exporters-safe because it needs the application
-    # containers (aic-lmcache) to be running to join their PID namespace, but
-    # monitoring starts before the cliff application stack.  On SPUR, pid:host is
-    # blocked by spur-authz anyway; use the NIXL telemetry (:19090) for AIS metrics.
-    # SPUR authz blocks --pid=host ("host-namespace escape").  vLLM and lmcache share
-    # a PID namespace (vllm uses pid:service:lmcache), so hsa-snoop joining that same
-    # namespace via pid:container gives it visibility into both processes without needing
-    # host PID.  Falls back to pid:host (non-SPUR) via AIC_HSA_SNOOP_PID_MODE override.
+    networks: [aic-network]
+    # vLLM and lmcache share a PID namespace (vllm uses pid:service:lmcache), so
+    # hsa-snoop joining that same namespace via pid:container gives it visibility
+    # into both processes.  Falls back to pid:host (non-SPUR) via override.
     pid: "${AIC_HSA_SNOOP_PID_MODE:-container:aic-lmcache}"
     privileged: true
     restart: unless-stopped
     environment:
       - ROCR_VISIBLE_DEVICES=${AIC_ROCR_VISIBLE:-${GPU:-0}}
       - HIP_VISIBLE_DEVICES=${AIC_HIP_VISIBLE:-0}
-      - CUDA_VISIBLE_DEVICES=${AIC_HIP_VISIBLE:-0}
+
     devices:
       - /dev/kfd
       - /dev/dri
@@ -201,18 +190,17 @@ services:
       # debugfs mounted it fails with ENOENT ("failed to install kprobe").
       - /sys/kernel/tracing:/sys/kernel/tracing
     entrypoint: ["/usr/local/bin/hsa-snoop"]
-    command: ["--all", "--prometheus", "--prometheus-port", "${HSA_SNOOP_PORT:-9488}"]
+    command: ["--all", "--prometheus", "--prometheus-port", "${HSA_SNOOP_PORT:-9488}", "--mem-snoop"]
 
   # ---------------------------------------------------------------------------
   # grafana: pre-provisioned AIC dashboard, anonymous access.
   # Open http://localhost:3000 after `make monitoring-up`.
-  # Uses provisioning-host/ datasource (localhost:9090) since this compose
-  # file uses network_mode: host throughout.
+  # Grafana: anonymous access, port 3000, datasource aic-prometheus:9090.
   # ---------------------------------------------------------------------------
   grafana:
     image: ${AIC_GRAFANA_IMAGE:-grafana/grafana:13.2.1}
     container_name: aic-grafana
-    network_mode: host
+    networks: [aic-network]
     restart: unless-stopped
     environment:
       GF_AUTH_ANONYMOUS_ENABLED: "true"
@@ -222,9 +210,13 @@ services:
       GF_SERVER_HTTP_PORT: ${AIC_GRAFANA_PORT:-3000}
       GF_SERVER_HTTP_ADDR: "0.0.0.0"
     volumes:
-      - ./grafana/provisioning-host:/etc/grafana/provisioning:ro
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
       - ./grafana/dashboards:/etc/grafana/dashboards:ro
       - grafana-data:/var/lib/grafana
 
 volumes:
   grafana-data:
+
+networks:
+  aic-network:
+    external: true

--- a/monitoring/monitoring-lib.sh
+++ b/monitoring/monitoring-lib.sh
@@ -168,6 +168,9 @@ start_monitoring() {
     ensure_compose || { log "monitoring: docker compose unavailable, skipping"; AIC_MONITORING=0; return 0; }
     [[ -f "${MON_COMPOSE}" ]] || { log "monitoring: ${MON_COMPOSE} not found, skipping"; AIC_MONITORING=0; return 0; }
     log "starting metrics capture -> ${AIC_METRICS_DIR} (exporters=${AIC_EXPORTERS})"
+    docker network inspect aic-network >/dev/null 2>&1 \
+        || docker network create aic-network >/dev/null \
+        || log "monitoring: could not create aic-network (continuing)"
     local -a profile; mapfile -t profile < <(mon_profile)
     AIC_METRICS_DIR="${AIC_METRICS_DIR}" PROM_UID="$(id -u)" PROM_GID="$(id -g)" \
         IMAGE_NAME="${AIC_IMAGE}" \

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -38,31 +38,15 @@ scrape_configs:
     static_configs:
       - targets: ["aic-prometheus:9090"]
 
-  # vLLM OpenAI server /metrics. The cliff sweep uses :8000 for the kvd_v2 arms
-  # and :8001 for the vram_only baseline; list both so whichever arm is live is
-  # captured. `make up` publishes :8000.
   - job_name: vllm
     metrics_path: /metrics
     static_configs:
-      - targets: ["aic-vllm-gpu0:8000", "aic-vllm-gpu0:8001"]
-      # Emulator (host-network): reachable via host-gateway from the aic bridge.
-      - targets: ["host-gateway:8000"]
-        labels:
-          instance: vllm-emulator
+      - targets: ["aic-vllm-gpu0:8000"]
 
-  # LMCache /metrics.  LMCache v0.5.x uses OpenTelemetry with a Prometheus fallback
-  # served by the FastAPI HTTP frontend on --http-port (default 8080).  The
-  # --prometheus-port flag configures the port label only; /metrics is always on
-  # the HTTP API port (:8080).  Note: the lmcache_mp_* metrics only appear here
-  # when the OTel Prometheus exporter is initialised; confirm with up{job="lmcache"}.
   - job_name: lmcache
     metrics_path: /metrics
     static_configs:
       - targets: ["aic-lmcache:8080"]
-      # :9091 is the standalone Prometheus exporter port (--prometheus-port 9091).
-      # Used when lmcache runs in host-network mode (emulate-mp profile) or when
-      # the bridge-network :8080 target is absent.  Silent down otherwise.
-      - targets: ["localhost:9091"]
 
   # LMCache coordinator exporter — polls the coordinator REST API (/instances,
   # /directory/stats, /quota) and emits Prometheus text format on :9301.
@@ -99,13 +83,11 @@ scrape_configs:
     static_configs:
       - targets: ["aic-rdma-exporter:9879"]
 
-  # AMD GPU device-metrics-exporter (gpu_* metrics).  :5000 is the default; :5050
-  # is the fallback the sbatch uses when :5000 is occupied by a non-GPU listener
-  # (only one actually serves gpu_* series, so no duplicate metrics).
+  # AMD GPU device-metrics-exporter (gpu_* metrics).  Always on :5000 on aic-network.
   - job_name: amd_metrics_exporter
     metrics_path: /metrics
     static_configs:
-      - targets: ["aic-amdgpu-exporter:5000", "aic-amdgpu-exporter:5050"]
+      - targets: ["aic-amdgpu-exporter:5000"]
 
   # hsa-snoop: HSA AQL queue/dispatch telemetry (hsa_kernel_launches_total,
   # hsa_kernel_duration_seconds, hsa_active_queues, hsa_snoop_up, ...) and AIS
@@ -120,4 +102,6 @@ scrape_configs:
   - job_name: hsa_snoop
     metrics_path: /metrics
     static_configs:
+      - targets: ["aic-hsa-snoop:9488"]
+      # Fallback for host-network or standalone deployments
       - targets: ["host-gateway:9488"]


### PR DESCRIPTION
## Summary

- **Prometheus scrape cleanup**: Remove stale/redundant targets from `prometheus.yml` —
  the emulator fallback targets (`:8001`, `host-gateway:8000`, `localhost:9091`,
  `aic-amdgpu-exporter:5050`) are no longer needed now that all services run on
  `aic-network`; strip the verbose comments that explained their original rationale.
  Add `aic-hsa-snoop:9488` as the primary hsa-snoop target (was missing; only the
  `host-gateway` fallback was present).

- **ROCM_ARCH detection order**: Move `_ROCM_ARCH_DETECTED` / `ROCM_ARCH` assignment
  above `_IMAGE_TAG` in the Makefile so the arch is available when
  `aic-image-tag.sh` runs (it needs to decide whether to include FlashAttention,
  which is CDNA-only). Pass `ROCM_ARCH` explicitly into the tag script.

- **`.gitignore`**: Add `*.egg-info/` (generated by editable pip installs) and
  `overnight*.md` (local stress-test notes, not for the repo).

## Notes

The compose changes (`docker-compose.yml`, `docker-compose.monitoring.yml`) move
all services onto `aic-network` uniformly — validated locally on gfx1201 with
the full monitoring stack (`make up-monitoring`) and a `stress-grafana` pass.

## Test plan

- [ ] `make up-monitoring` — all containers start, all Prometheus targets show `up=1`
- [ ] `make stress-grafana BENCH_MODEL=<model>` — cliff sweep completes without errors
- [ ] Grafana `aic-overview` dashboard — no panel errors, all rows populated
